### PR TITLE
Issue43 - implement list command with --tenant and --tenant_slug (also prettier format the code)

### DIFF
--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -1,12 +1,11 @@
-const { ElvClient } = require("elv-client-js")
-const Utils = require("elv-client-js/src/Utils.js")
-const { Config } = require("./Config.js")
+const { ElvClient } = require("elv-client-js");
+const Utils = require("elv-client-js/src/Utils.js");
+const { Config } = require("./Config.js");
 
 const Ethers = require("ethers");
-const fs = require('fs');
-const path = require('path');
-const BigNumber = require('big-number');
-
+const fs = require("fs");
+const path = require("path");
+const BigNumber = require("big-number");
 
 /**
  * EluvioLive is an application platform built on top of the Eluvio Content Fabric.
@@ -16,7 +15,6 @@ const BigNumber = require('big-number');
  * This SDK provides tools for working with EluvioLive APIs and services.
  */
 class EluvioLive {
-
   /**
    * Instantiate the EluvioLive SDK
    *
@@ -26,28 +24,23 @@ class EluvioLive {
    * @param {string} tenantObjectId - The ID of the tenant specific EluvioLive object (optional)
    * @return {EluvioLive} - New EluvioLive object connected to the specified content fabric and blockchain
    */
-  constructor({
-		configUrl,
-		mainObjectId,
-		tenantObjectId
-  }) {
-
+  constructor({ configUrl, mainObjectId, tenantObjectId }) {
     this.configUrl = configUrl || ElvClient.main;
-		this.mainObjectId = mainObjectId;
+    this.mainObjectId = mainObjectId;
 
     this.debug = false;
   }
 
   async Init() {
-		this.client = await ElvClient.FromConfigurationUrl({
-				configUrl: this.configUrl
-			});
-		let wallet = this.client.GenerateWallet();
-		let signer = wallet.AddAccount({
-			privateKey: process.env.PRIVATE_KEY
-		});
-		this.client.SetSigner({signer});
-		this.client.ToggleLogging(false);
+    this.client = await ElvClient.FromConfigurationUrl({
+      configUrl: this.configUrl,
+    });
+    let wallet = this.client.GenerateWallet();
+    let signer = wallet.AddAccount({
+      privateKey: process.env.PRIVATE_KEY,
+    });
+    this.client.SetSigner({ signer });
+    this.client.ToggleLogging(false);
   }
 
   /**
@@ -64,84 +57,106 @@ class EluvioLive {
    * @cauth {string} mintHelper - Warn if any NFTs don't have this as minter
    * @return {Promise<Object>} - An object containing tenant info, including 'warnings'
    */
-  async TenantShow({tenantId, libraryId, objectId, eventId, marketplaceId, cauth, mintHelper}) {
+  async TenantShow({
+    tenantId,
+    libraryId,
+    objectId,
+    eventId,
+    marketplaceId,
+    cauth,
+    mintHelper,
+  }) {
+    const abiNft = fs.readFileSync(
+      path.resolve(__dirname, "../contracts/v3/ElvTradable.abi")
+    );
+    const abiTenant = fs.readFileSync(
+      path.resolve(__dirname, "../contracts/v3/BaseTenantSpace.abi")
+    );
 
-	const abiNft = fs.readFileSync(path.resolve(__dirname, "../contracts/v3/ElvTradable.abi"));
-	const abiTenant = fs.readFileSync(path.resolve(__dirname, "../contracts/v3/BaseTenantSpace.abi"));
+    var tenantInfo = {};
 
-	var tenantInfo = {};
+    var m = await this.client.ContentObjectMetadata({
+      libraryId,
+      objectId,
+      metadataSubtree: "/public/asset_metadata",
+      resolveLinks: true,
+      resolveIncludeSource: true,
+      resolveIgnoreErrors: true,
+      linkDepthLimit: 5,
+    });
 
-	var m = await this.client.ContentObjectMetadata({
-	  libraryId,
-	  objectId,
-	  metadataSubtree: "/public/asset_metadata",
-	  resolveLinks: true,
-	  resolveIncludeSource: true,
-	  resolveIgnoreErrors: true,
-	  linkDepthLimit: 5
-	});
+    tenantInfo.marketplaces = {};
+    var warns = [];
 
-	tenantInfo.marketplaces = {};
-	var warns = [];
+    for (var key in m.marketplaces) {
+      tenantInfo.marketplaces[key] = {};
+      tenantInfo.marketplaces[key].items = {};
+      for (var i in m.marketplaces[key].info.items) {
+        const item = m.marketplaces[key].info.items[i];
 
-	for (var key in m.marketplaces) {
-	  tenantInfo.marketplaces[key] = {};
-	  tenantInfo.marketplaces[key].items = {};
-	  for (var i in m.marketplaces[key].info.items) {
+        const sku = item.sku;
 
-		const item = m.marketplaces[key].info.items[i];
+        if (item.nft_template == "") {
+          warns.push("No NFT Template sku: " + sku);
+          continue;
+        }
 
-		const sku = item.sku;
+        tenantInfo.marketplaces[key].items[sku] = {};
+        tenantInfo.marketplaces[key].items[sku].name = item.name;
+        tenantInfo.marketplaces[key].items[sku].description = item.description;
+        tenantInfo.marketplaces[key].items[sku].mint_cauth =
+          item.nft_template.mint.cauth_id;
+        tenantInfo.marketplaces[key].items[sku].nft_addr =
+          item.nft_template.nft.address;
+        tenantInfo.marketplaces[key].items[sku].templateTotalSupply =
+          item.nft_template.nft.total_supply;
+        tenantInfo.marketplaces[key].items[sku].nft_template =
+          item.nft_template["."].source;
 
-		if (item.nft_template == "") {
-		  warns.push("No NFT Template sku: " + sku);
-		  continue;
-		}
+        if (cauth && cauth != item.nft_template.mint.cauth_id) {
+          warns.push("Wrong cauth_id sku: " + sku);
+        }
 
-		tenantInfo.marketplaces[key].items[sku] = {};
-		tenantInfo.marketplaces[key].items[sku].name = item.name;
-		tenantInfo.marketplaces[key].items[sku].description = item.description;
-		tenantInfo.marketplaces[key].items[sku].mint_cauth = item.nft_template.mint.cauth_id;
-		tenantInfo.marketplaces[key].items[sku].nft_addr = item.nft_template.nft.address;
-		tenantInfo.marketplaces[key].items[sku].templateTotalSupply = item.nft_template.nft.total_supply;
-		tenantInfo.marketplaces[key].items[sku].nft_template = item.nft_template["."].source;
+        if (item.nft_template.nft.address === "") {
+          warns.push("No NFT address sku: " + sku);
+        } else {
+          // Check NFT contract parameters
+          const nftInfo = await this.NftShow({
+            addr: item.nft_template.nft.address,
+            mintHelper,
+          });
+          tenantInfo.marketplaces[key].items[sku].nftCap = nftInfo.cap;
+          tenantInfo.marketplaces[key].items[sku].nftMinted = nftInfo.minted;
+          tenantInfo.marketplaces[key].items[sku].nftTotalSupply =
+            nftInfo.totalSupply;
+          tenantInfo.marketplaces[key].items[sku].nftName = nftInfo.name;
+          tenantInfo.marketplaces[key].items[sku].proxy = nftInfo.owner;
+          tenantInfo.marketplaces[key].items[sku].proxy = nftInfo.proxy;
+          tenantInfo.marketplaces[key].items[sku].firstTokenUri =
+            nftInfo.firstTokenUri;
+          tenantInfo.marketplaces[key].items[sku].defHoldSecs =
+            nftInfo.defHoldSecs;
 
-		if (cauth && cauth != item.nft_template.mint.cauth_id) {
-		  warns.push("Wrong cauth_id sku: " + sku);
-		}
+          if (nftInfo.cap != item.nft_template.nft.total_supply) {
+            warns.push("NFT cap mismatch sku: " + sku);
+          }
+          if (
+            nftInfo.proxyInfo != null &&
+            nftInfo.owner != nftInfo.proxyInfo.owner
+          ) {
+            warns.push("NFT owner not proxy owner: " + sku);
+          }
+          if (nftInfo.warns.length > 0) {
+            warns.push(...nftInfo.warns);
+          }
+        }
+      }
+    }
 
-		if (item.nft_template.nft.address === "") {
-		  warns.push("No NFT address sku: " + sku);
-		} else {
-		  // Check NFT contract parameters
-		  const nftInfo = await this.NftShow({addr: item.nft_template.nft.address, mintHelper});
-		  tenantInfo.marketplaces[key].items[sku].nftCap = nftInfo.cap;
-		  tenantInfo.marketplaces[key].items[sku].nftMinted = nftInfo.minted;
-		  tenantInfo.marketplaces[key].items[sku].nftTotalSupply = nftInfo.totalSupply;
-		  tenantInfo.marketplaces[key].items[sku].nftName = nftInfo.name;
-		  tenantInfo.marketplaces[key].items[sku].proxy = nftInfo.owner;
-		  tenantInfo.marketplaces[key].items[sku].proxy = nftInfo.proxy;
-		  tenantInfo.marketplaces[key].items[sku].firstTokenUri = nftInfo.firstTokenUri;
-		  tenantInfo.marketplaces[key].items[sku].defHoldSecs = nftInfo.defHoldSecs;
+    tenantInfo.sites = {};
+    tenantInfo.warns = warns;
 
-		  if (nftInfo.cap != item.nft_template.nft.total_supply) {
-			warns.push("NFT cap mismatch sku: " + sku);
-		  }
-		  if (nftInfo.proxyInfo != null && (nftInfo.owner != nftInfo.proxyInfo.owner)) {
-			warns.push("NFT owner not proxy owner: " + sku);
-		  }
-		  if (nftInfo.warns.length > 0) {
-			warns.push(...nftInfo.warns);
-		  }
-		}
-	  }
-	}
-
-	tenantInfo.sites = {};
-	tenantInfo.warns = warns;
-
-	return tenantInfo;
-
+    return tenantInfo;
   }
 
   /**
@@ -152,57 +167,56 @@ class EluvioLive {
    * @param {string} ownerAddr - A user address to check the balance of
    * @return {Promise<Object>} - Number of tokens owned
    */
-  async FabricTenantBalanceOf({objectId, ownerAddr}) {
-		var nftInfo = {};
+  async FabricTenantBalanceOf({ objectId, ownerAddr }) {
+    var nftInfo = {};
 
-		const libraryId = await this.client.ContentObjectLibraryId({
-			objectId
-		});
+    const libraryId = await this.client.ContentObjectLibraryId({
+      objectId,
+    });
 
-		var m = await this.client.ContentObjectMetadata({
-			libraryId,
-			objectId,
-			metadataSubtree: "/public/asset_metadata",
-			resolveLinks: true,
-			resolveIncludeSource: true,
-			resolveIgnoreErrors: true,
-			linkDepthLimit: 5
-		});
+    var m = await this.client.ContentObjectMetadata({
+      libraryId,
+      objectId,
+      metadataSubtree: "/public/asset_metadata",
+      resolveLinks: true,
+      resolveIncludeSource: true,
+      resolveIgnoreErrors: true,
+      linkDepthLimit: 5,
+    });
 
-		nftInfo.marketplaces = {};
-		var warns = [];
+    nftInfo.marketplaces = {};
+    var warns = [];
 
-		for (var key in m.marketplaces) {
-			nftInfo.marketplaces[key] = {};
-			nftInfo.marketplaces[key].nfts = {};
-			for (var i in m.marketplaces[key].info.items) {
+    for (var key in m.marketplaces) {
+      nftInfo.marketplaces[key] = {};
+      nftInfo.marketplaces[key].nfts = {};
+      for (var i in m.marketplaces[key].info.items) {
+        const item = m.marketplaces[key].info.items[i];
 
-			const item = m.marketplaces[key].info.items[i];
+        const sku = item.sku;
 
-			const sku = item.sku;
+        if (item.nft_template == "") {
+          warns.push("No NFT Template sku: " + sku);
+          continue;
+        }
 
-			if (item.nft_template == "") {
-				warns.push("No NFT Template sku: " + sku);
-				continue;
-			}
+        const nftAddr = item.nft_template.nft.address;
+        const info = await this.NftBalanceOf({ addr: nftAddr, ownerAddr });
 
-			const nftAddr = item.nft_template.nft.address;
-			const info = await this.NftBalanceOf({addr:nftAddr, ownerAddr});
+        if (info.length == 0) {
+          continue;
+        }
+        var nft = await this.NftShow({ addr: nftAddr });
+        nft.tokens = info;
 
-			if(info.length == 0){
-				continue;
-			}
-			var nft = await this.NftShow({addr: nftAddr});
-			nft.tokens = info
-			
-			nftInfo.marketplaces[key].nfts[nftAddr] = nft
-			}
-		}
+        nftInfo.marketplaces[key].nfts[nftAddr] = nft;
+      }
+    }
 
-		nftInfo.warns = warns;
+    nftInfo.warns = warns;
 
-		return nftInfo;
-	}
+    return nftInfo;
+  }
 
   /**
    * Get a list of the NFTs of this tenant owned by 'ownerAddr'
@@ -210,55 +224,57 @@ class EluvioLive {
    * @namedParams
    * @param {string} tenantId - The ID of the tenant (iten***)
    * @param {string} ownerAddr - A user address to check the balance of
-	 * @param {integer} maxNumber - Max number of NFTs returned
+   * @param {integer} maxNumber - Max number of NFTs returned
    * @return {Promise<Object>} - Number of tokens owned
    */
-	 async TenantBalanceOf({tenantId, ownerAddr, maxNumber=Number.MAX_SAFE_INTEGER}) {
-		if(maxNumber < 1){
-			maxNumber = Number.MAX_SAFE_INTEGER
-		}
-		const abiTenant = fs.readFileSync(path.resolve(__dirname, "../contracts/v3/BaseTenantSpace.abi"));
-		const tenantAddr = Utils.HashToAddress(tenantId);
-		var arg = 'tenant_nfts';
+  async TenantBalanceOf({
+    tenantId,
+    ownerAddr,
+    maxNumber = Number.MAX_SAFE_INTEGER,
+  }) {
+    if (maxNumber < 1) {
+      maxNumber = Number.MAX_SAFE_INTEGER;
+    }
+    const abiTenant = fs.readFileSync(
+      path.resolve(__dirname, "../contracts/v3/BaseTenantSpace.abi")
+    );
+    const tenantAddr = Utils.HashToAddress(tenantId);
+    var arg = "tenant_nfts";
 
-		var nftInfo = {};
-		nftInfo.nfts = {};
+    var nftInfo = {};
+    nftInfo.nfts = {};
 
-		var num = 0;
-		for(var i = 0; i < Number.MAX_SAFE_INTEGER && num < maxNumber; i++){
-			var ordinal = BigNumber(i).toString(16);
-			try {
-				var nftAddr = await this.client.CallContractMethod({
-					contractAddress: tenantAddr,
-					abi: JSON.parse(abiTenant),
-					methodName: "groupsMapping",
-					methodArgs: [
-						arg,
-						ordinal
-					],
-					formatArguments: true
-				});
+    var num = 0;
+    for (var i = 0; i < Number.MAX_SAFE_INTEGER && num < maxNumber; i++) {
+      var ordinal = BigNumber(i).toString(16);
+      try {
+        var nftAddr = await this.client.CallContractMethod({
+          contractAddress: tenantAddr,
+          abi: JSON.parse(abiTenant),
+          methodName: "groupsMapping",
+          methodArgs: [arg, ordinal],
+          formatArguments: true,
+        });
 
-				const info = await this.NftBalanceOf({addr:nftAddr, ownerAddr});
+        const info = await this.NftBalanceOf({ addr: nftAddr, ownerAddr });
 
-				if(info.length == 0){
-					continue;
-				}
-				
-				var nft = await this.NftShow({addr: nftAddr});
-				nft.tokens = info;
+        if (info.length == 0) {
+          continue;
+        }
 
-				nftInfo.nfts[nftAddr] = nft;
-				num++;
-			}catch(e){
-				//We don't know the length so just stop on error and return
-				break;
-			}
-		}
+        var nft = await this.NftShow({ addr: nftAddr });
+        nft.tokens = info;
 
-		return nftInfo;
-	}
+        nftInfo.nfts[nftAddr] = nft;
+        num++;
+      } catch (e) {
+        //We don't know the length so just stop on error and return
+        break;
+      }
+    }
 
+    return nftInfo;
+  }
 
   /**
    * Add an NFT contract to the tenant's 'tenant_nfts' group
@@ -267,21 +283,19 @@ class EluvioLive {
    * @param {string} tenantId - The ID of the tenant (iten***)
    * @param {string} nftAddr = The address of the NFT contract (hex format)
    */
-  async TenantAddNft({tenantId, nftAddr}) {
+  async TenantAddNft({ tenantId, nftAddr }) {
+    const abi = fs.readFileSync(
+      path.resolve(__dirname, "../contracts/v3/BaseTenantSpace.abi")
+    );
 
-    const abi = fs.readFileSync(path.resolve(__dirname, "../contracts/v3/BaseTenantSpace.abi"));
-
-		const addr = Utils.HashToAddress(tenantId);
+    const addr = Utils.HashToAddress(tenantId);
 
     var res = await this.client.CallContractMethodAndWait({
       contractAddress: addr,
       abi: JSON.parse(abi),
       methodName: "addGroup",
-      methodArgs: [
-        "tenant_nfts",
-				nftAddr
-      ],
-      formatArguments: true
+      methodArgs: ["tenant_nfts", nftAddr],
+      formatArguments: true,
     });
   }
 
@@ -293,54 +307,57 @@ class EluvioLive {
    * @param {string} objectId - The ID of the site object
    * @return {Promise<Object>} - An object containing site info, including 'warnings'
    */
-  async SiteShow({libraryId, objectId}) {
+  async SiteShow({ libraryId, objectId }) {
+    var siteInfo = {};
 
-	var siteInfo = {};
+    var m = await this.client.ContentObjectMetadata({
+      libraryId,
+      objectId,
+      metadataSubtree: "/public/asset_metadata",
+      select: "",
+      resolveLinks: true,
+      resolveIncludeSource: true,
+      resolveIgnoreError: true,
+      linkDepthLimit: 5,
+    });
 
-	var m = await this.client.ContentObjectMetadata({
-	  libraryId,
-	  objectId,
-	  metadataSubtree: "/public/asset_metadata",
-	  select: "",
-	  resolveLinks: true,
-	  resolveIncludeSource: true,
-	  resolveIgnoreError: true,
-	  linkDepthLimit: 5
-	});
+    siteInfo.drops = {};
+    for (var key in m.info.drops) {
+      const drop = m.info.drops[key];
+      const uuid = drop.uuid;
 
-	siteInfo.drops = {};
-	for (var key in m.info.drops) {
-	  const drop = m.info.drops[key];
-	  const uuid = drop.uuid;
+      siteInfo.drops[uuid] = {};
 
-	  siteInfo.drops[uuid] = {};
+      siteInfo.drops[uuid].event_header = drop.event_header;
 
-	  siteInfo.drops[uuid].event_header = drop.event_header;
+      siteInfo.drops[uuid].start_date = drop.start_date;
+      siteInfo.drops[uuid].end_date = drop.end_date;
 
-	  siteInfo.drops[uuid].start_date = drop.start_date;
-	  siteInfo.drops[uuid].end_date = drop.end_date;
+      siteInfo.drops[uuid].stages = {};
+      siteInfo.drops[uuid].stages["preroll"] = {};
+      siteInfo.drops[uuid].stages["preroll"].start_date =
+        drop.event_state_preroll.start_date;
 
-	  siteInfo.drops[uuid].stages = {};
-	  siteInfo.drops[uuid].stages["preroll"] = {};
-	  siteInfo.drops[uuid].stages["preroll"].start_date = drop.event_state_preroll.start_date;
+      siteInfo.drops[uuid].stages["main"] = {};
+      siteInfo.drops[uuid].stages["main"].start_date =
+        drop.event_state_main.start_date;
 
-	  siteInfo.drops[uuid].stages["main"] = {};
-	  siteInfo.drops[uuid].stages["main"].start_date = drop.event_state_main.start_date;
+      siteInfo.drops[uuid].stages["vote_end"] = {};
+      siteInfo.drops[uuid].stages["vote_end"].start_date =
+        drop.event_state_post_vote.start_date;
 
-	  siteInfo.drops[uuid].stages["vote_end"] = {};
-	  siteInfo.drops[uuid].stages["vote_end"].start_date = drop.event_state_post_vote.start_date;
+      siteInfo.drops[uuid].stages["mint_start"] = {};
+      siteInfo.drops[uuid].stages["mint_start"].start_date =
+        drop.event_state_mint_start.start_date;
 
-	  siteInfo.drops[uuid].stages["mint_start"] = {};
-	  siteInfo.drops[uuid].stages["mint_start"].start_date = drop.event_state_mint_start.start_date;
+      siteInfo.drops[uuid].nfts = {};
+      for (var i in drop.nfts) {
+        const nft = drop.nfts[i];
+        siteInfo.drops[uuid].nfts[nft.sku] = nft.label;
+      }
+    }
 
-	  siteInfo.drops[uuid].nfts = {};
-	  for (var i in drop.nfts) {
-		const nft = drop.nfts[i];
-		siteInfo.drops[uuid].nfts[nft.sku] = nft.label;
-	  }
-	}
-
-	return siteInfo;
+    return siteInfo;
   }
 
   /**
@@ -358,107 +375,116 @@ class EluvioLive {
    * @param {string} update - Tenant-level EluvioLive object ID, to update
    * @return {Promise<Object>} - An object containing new drop info
    */
-  async SiteSetDrop({libraryId, objectId, uuid, start, end, endVote, startMint, newUuid, update}) {
+  async SiteSetDrop({
+    libraryId,
+    objectId,
+    uuid,
+    start,
+    end,
+    endVote,
+    startMint,
+    newUuid,
+    update,
+  }) {
+    const defaultStageDurationMin = 2;
 
-	const defaultStageDurationMin = 2;
+    // If stages are not specified use 2min for each
+    const startMsec = Date.parse(start);
+    if (!endVote || endVote == "") {
+      endVote = new Date(startMsec + defaultStageDurationMin * 60 * 1000);
+    }
+    if (!startMint || startMint == "") {
+      startMint = new Date(startMsec + 2 * defaultStageDurationMin * 60 * 1000);
+    }
+    if (!end || end == "") {
+      end = new Date(startMsec + 3 * defaultStageDurationMin * 60 * 1000);
+    }
 
-	// If stages are not specified use 2min for each
-	const startMsec = Date.parse(start);
-	if (!endVote || endVote == "") {
-	  endVote = new Date(startMsec + defaultStageDurationMin*60*1000);
-	}
-	if (!startMint || startMint == "") {
-	  startMint = new Date(startMsec + 2*defaultStageDurationMin*60*1000);
-	}
-	if (!end || end == "") {
-	  end = new Date(startMsec + 3*defaultStageDurationMin*60*1000);
-	}
+    var dropInfo = {};
 
-	var dropInfo = {};
+    var m = await this.client.ContentObjectMetadata({
+      libraryId,
+      objectId,
+      metadataSubtree: "/public/asset_metadata",
+      resolveLinks: false,
+    });
 
-	var m = await this.client.ContentObjectMetadata({
-	  libraryId,
-	  objectId,
-	  metadataSubtree: "/public/asset_metadata",
-	  resolveLinks: false
-	});
+    var found = false;
+    for (var key in m.info.drops) {
+      const drop = m.info.drops[key];
+      const dropUuid = drop.uuid;
 
-	var found = false;
-	for (var key in m.info.drops) {
-	  const drop = m.info.drops[key];
-	  const dropUuid = drop.uuid;
+      if (dropUuid.slice(0, 22) == uuid) {
+        console.log("Found drop uuid: ", uuid);
+        console.log(drop);
+        found = true;
 
-	  if (dropUuid.slice(0, 22) == uuid) {
-		console.log("Found drop uuid: ", uuid);
-		console.log(drop);
-		found = true;
+        drop.start_date = start;
+        drop.end_date = end;
+        drop.event_state_preroll.start_date = "";
+        drop.event_state_main.start_date = start;
+        drop.event_state_post_vote.start_date = endVote;
+        drop.event_state_mint_start.start_date = startMint;
+        drop.event_state_event_end.start_date = end;
 
-		drop.start_date = start;
-		drop.end_date = end;
-		drop.event_state_preroll.start_date = "";
-		drop.event_state_main.start_date = start;
-		drop.event_state_post_vote.start_date = endVote;
-		drop.event_state_mint_start.start_date = startMint;
-		drop.event_state_event_end.start_date = end;
+        dropInfo.start = start;
+        dropInfo.end = end;
+        dropInfo.endVote = endVote;
+        dropInfo.startMint = startMint;
 
-		dropInfo.start = start;
-		dropInfo.end = end;
-		dropInfo.endVote = endVote;
-		dropInfo.startMint = startMint;
+        if (newUuid) {
+          drop.uuid = uuid.slice(0, 22) + startMsec / 1000;
+        }
+        dropInfo.uuid = drop.uuid;
 
-		if (newUuid) {
-		  drop.uuid = uuid.slice(0, 22) + (startMsec / 1000);
-		}
-		dropInfo.uuid = drop.uuid;
+        // Set new metadata
+        m.info.drops[key] = drop;
 
-		// Set new metadata
-		m.info.drops[key] = drop;
+        const dryRun = false;
+        if (!dryRun) {
+          var e = await this.client.EditContentObject({
+            libraryId,
+            objectId,
+          });
 
-		const dryRun = false;
-		if (!dryRun) {
-		  var e = await this.client.EditContentObject({
-			libraryId,
-			objectId
-		  });
+          await this.client.ReplaceMetadata({
+            libraryId,
+            objectId,
+            writeToken: e.write_token,
+            metadataSubtree: "/public/asset_metadata",
+            metadata: m,
+          });
 
-		  await this.client.ReplaceMetadata({
-			libraryId,
-			objectId,
-			writeToken: e.write_token,
-			metadataSubtree: "/public/asset_metadata",
-			metadata: m
-		  });
+          var f = await this.client.FinalizeContentObject({
+            libraryId,
+            objectId,
+            writeToken: e.write_token,
+            commitMessage: "Set drop start " + uuid + " " + start,
+          });
 
-		  var f = await this.client.FinalizeContentObject({
-			libraryId,
-			objectId,
-			writeToken: e.write_token,
-			commitMessage: "Set drop start " + uuid + " " + start
-		  });
+          dropInfo.hash = f.hash;
+          console.log("Finalized: ", f);
 
-		  dropInfo.hash = f.hash;
-		  console.log("Finalized: ", f);
+          if (update != null && update != "") {
+            await this.client.UpdateContentObjectGraph({
+              libraryId,
+              objectId: update,
+            });
+            console.log("Update ", update);
+          }
+        } else {
+          console.log("New drop:", drop);
+          console.log("New metadata:", m);
+        }
+        break;
+      }
+    }
 
-		  if (update != null && update != "") {
-			await this.client.UpdateContentObjectGraph({
-			  libraryId,
-			  objectId: update
-			});
-			console.log("Update ", update);
-		  }
-		} else {
-		  console.log("New drop:", drop);
-		  console.log("New metadata:", m);
-		}
-		break;
-	  }
-	}
+    if (!found) {
+      console.log("Drop not found - uuid: ", uuid);
+    }
 
-	if (!found) {
-	  console.log("Drop not found - uuid: ", uuid);
-	}
-
-	return dropInfo;
+    return dropInfo;
   }
 
   /**
@@ -481,55 +507,64 @@ class EluvioLive {
    * @return {Promise<Object>} - New contract address
    */
   async CreateNftContract({
-	tenantId,
-	mintHelperAddr,
-	minterAddr,
-	collectionName,
-	collectionSymbol,
-	contractUri,
-	proxyAddress,
-	totalSupply, /* PENDING: should be 'cap' */
-	hold
+    tenantId,
+    mintHelperAddr,
+    minterAddr,
+    collectionName,
+    collectionSymbol,
+    contractUri,
+    proxyAddress,
+    totalSupply /* PENDING: should be 'cap' */,
+    hold,
   }) {
+    const abistr = fs.readFileSync(
+      path.resolve(__dirname, "../contracts/v3/ElvTradableLocal.abi")
+    );
+    const bytecode = fs.readFileSync(
+      path.resolve(__dirname, "../contracts/v3/ElvTradableLocal.bin")
+    );
 
-	const abistr = fs.readFileSync(path.resolve(__dirname, "../contracts/v3/ElvTradableLocal.abi"));
-	const bytecode = fs.readFileSync(path.resolve(__dirname, "../contracts/v3/ElvTradableLocal.bin"));
+    if (proxyAddress == null || proxyAddress == "") {
+      proxyAddress = await this.CreateNftTransferProxy({});
+    }
+    console.log("TransferProxy addr:", proxyAddress);
 
-	if (proxyAddress == null || proxyAddress == "") {
-	  proxyAddress = await this.CreateNftTransferProxy({});
-	}
-	console.log("TransferProxy addr:", proxyAddress);
+    if (hold == null || hold == 0) {
+      hold = 604800;
+    }
 
-	if (hold == null || hold == 0) {
-	  hold = 604800;
-	}
+    var c = await this.client.DeployContract({
+      abi: JSON.parse(abistr),
+      bytecode: bytecode.toString("utf8").replace("\n", ""),
+      constructorArgs: [
+        collectionName,
+        collectionSymbol,
+        contractUri || "",
+        proxyAddress,
+        0,
+        totalSupply /* this is the 'cap' */,
+        hold,
+      ],
+    });
 
-	var c = await this.client.DeployContract({
-	  abi: JSON.parse(abistr),
-	  bytecode: bytecode.toString('utf8').replace('\n', ''),
-	  constructorArgs: [
-		collectionName,
-		collectionSymbol,
-		contractUri || "",
-		proxyAddress,
-		0,
-		totalSupply, /* this is the 'cap' */
-		hold
-	  ]
-	});
+    console.log("NFT contract address:", c.contractAddress);
 
-	console.log("NFT contract address:", c.contractAddress);
+    await this.NftAddMinter({
+      addr: c.contractAddress,
+      minterAddr: mintHelperAddr,
+    });
+    console.log("- mint helper added", mintHelperAddr);
 
-	await this.NftAddMinter({addr: c.contractAddress, minterAddr:mintHelperAddr});
-	console.log("- mint helper added", mintHelperAddr);
+    await this.NftAddMinter({
+      addr: c.contractAddress,
+      minterAddr: minterAddr,
+    });
+    console.log("- minter added", minterAddr);
 
-	await this.NftAddMinter({addr: c.contractAddress, minterAddr: minterAddr});
-	console.log("- minter added", minterAddr);
+    await this.TenantAddNft({ tenantId, nftAddr: c.contractAddress });
+    console.log("- tenant_nfts added", tenantId);
 
-	await this.TenantAddNft({tenantId, nftAddr: c.contractAddress});
-	console.log("- tenant_nfts added", tenantId);
-
-	return c.contractAddress;
+    return c.contractAddress;
   }
 
   /**
@@ -541,24 +576,23 @@ class EluvioLive {
    * @param {string} proxyAddress - The address of the proxy contract (optional)
    * @return {Promise<Object>} - New contract address
    */
-  async NftSetTransferProxy({addr, proxyAddr}) {
+  async NftSetTransferProxy({ addr, proxyAddr }) {
+    if (proxyAddr == null || proxyAddr.length() == 0) {
+      proxyAddr = await this.CreateNftTransferProxy({});
+    }
 
-	if (proxyAddr == null || proxyAddr.length() == 0) {
-	  proxyAddr = await this.CreateNftTransferProxy({});
-	}
-
-    const abi = fs.readFileSync(path.resolve(__dirname, "../contracts/v3/ElvTradableLocal.abi"));
+    const abi = fs.readFileSync(
+      path.resolve(__dirname, "../contracts/v3/ElvTradableLocal.abi")
+    );
     var res = await this.client.CallContractMethod({
       contractAddress: addr,
       abi: JSON.parse(abi),
       methodName: "setProxyRegistryAddress",
-      methodArgs: [
-		proxyAddr
-      ],
-      formatArguments: true
+      methodArgs: [proxyAddr],
+      formatArguments: true,
     });
 
-	return proxyAddr;
+    return proxyAddr;
   }
 
   /**
@@ -568,18 +602,20 @@ class EluvioLive {
    * @return {Promise<Object>} - New contract address
    */
   async CreateNftTransferProxy({}) {
+    const abistr = fs.readFileSync(
+      path.resolve(__dirname, "../contracts/v3/TransferProxyRegistry.abi")
+    );
+    const bytecode = fs.readFileSync(
+      path.resolve(__dirname, "../contracts/v3/TransferProxyRegistry.bin")
+    );
 
-	const abistr = fs.readFileSync(path.resolve(__dirname, "../contracts/v3/TransferProxyRegistry.abi"));
-	const bytecode = fs.readFileSync(path.resolve(__dirname, "../contracts/v3/TransferProxyRegistry.bin"));
+    var c = await this.client.DeployContract({
+      abi: JSON.parse(abistr),
+      bytecode: bytecode.toString("utf8").replace("\n", ""),
+      constructorArgs: [],
+    });
 
-	var c = await this.client.DeployContract({
-	  abi: JSON.parse(abistr),
-	  bytecode: bytecode.toString('utf8').replace('\n', ''),
-	  constructorArgs: [
-	  ]
-	});
-
-	return c.contractAddress;
+    return c.contractAddress;
   }
 
   /**
@@ -589,27 +625,27 @@ class EluvioLive {
    * @param {string} addr - The NFT Transfer Proxy contract address
    * @return {Promise<Object>} - New contract address
    */
-  async ShowNftTransferProxy({addr}) {
+  async ShowNftTransferProxy({ addr }) {
+    const abistr = fs.readFileSync(
+      path.resolve(__dirname, "../contracts/v3/TransferProxyRegistry.abi")
+    );
 
-	const abistr = fs.readFileSync(path.resolve(__dirname, "../contracts/v3/TransferProxyRegistry.abi"));
-
-	var info = {};
+    var info = {};
 
     info.owner = await this.client.CallContractMethod({
       contractAddress: addr,
       abi: JSON.parse(abistr),
       methodName: "owner",
-      formatArguments: true
+      formatArguments: true,
     });
 
-	return info;
+    return info;
   }
-
 
   /**
    *  WIP
    */
-/*
+  /*
   async ContractCallMintHelper(client) {
 
     const abi = fs.readFileSync(path.resolve(__dirname, "../contracts/v3/ElvTokenHelper.abi"));
@@ -639,55 +675,50 @@ class EluvioLive {
    * @param {string} ownerAddr - A user address to check the balance of
    * @return {Promise<Object>} - Number of tokens owned
    */
-  async NftBalanceOf({addr, ownerAddr}) {
-
-	var balance = [];
-    const abi = fs.readFileSync(path.resolve(__dirname, "../contracts/v3/ElvTradableLocal.abi"));
+  async NftBalanceOf({ addr, ownerAddr }) {
+    var balance = [];
+    const abi = fs.readFileSync(
+      path.resolve(__dirname, "../contracts/v3/ElvTradableLocal.abi")
+    );
     var res = await this.client.CallContractMethod({
       contractAddress: addr,
       abi: JSON.parse(abi),
       methodName: "balanceOf",
-      methodArgs: [
-		ownerAddr
-      ],
-      formatArguments: true
+      methodArgs: [ownerAddr],
+      formatArguments: true,
     });
 
-	// List all tokens
-	for (var i = 0; i < res; i ++) {
-	  var tokenId = await this.client.CallContractMethod({
-		contractAddress: addr,
-		abi: JSON.parse(abi),
-		methodName: "tokenOfOwnerByIndex",
-		methodArgs: [
-		  ownerAddr,
-		  i
-		],
-		formatArguments: true
+    // List all tokens
+    for (var i = 0; i < res; i++) {
+      var tokenId = await this.client.CallContractMethod({
+        contractAddress: addr,
+        abi: JSON.parse(abi),
+        methodName: "tokenOfOwnerByIndex",
+        methodArgs: [ownerAddr, i],
+        formatArguments: true,
       });
 
-	  var holdSecs = -1;
-	  var holdEnd = -1;
-	  try {
-		holdSecs = await this.client.CallContractMethod({
-		  contractAddress: addr,
-		  abi: JSON.parse(abi),
-		  methodName: "_allTokensHolds",
-		  methodArgs: [tokenId],
-		  formatArguments: true
-		});
-		holdEnd = new Date(holdSecs * 1000);
+      var holdSecs = -1;
+      var holdEnd = -1;
+      try {
+        holdSecs = await this.client.CallContractMethod({
+          contractAddress: addr,
+          abi: JSON.parse(abi),
+          methodName: "_allTokensHolds",
+          methodArgs: [tokenId],
+          formatArguments: true,
+        });
+        holdEnd = new Date(holdSecs * 1000);
+      } catch (e) {}
 
-	  } catch(e) {
-	  }
+      balance[i] = {
+        tokenId: tokenId.toString(),
+        hold: holdSecs.toString(),
+        holdEnd: holdEnd,
+      };
+    }
 
-	  balance[i] = {tokenId: tokenId.toString(), 
-				hold: holdSecs.toString(), 
-				holdEnd: holdEnd
-			};
-	}
-
-	return balance;
+    return balance;
   }
 
   /**
@@ -698,60 +729,60 @@ class EluvioLive {
    * @param {integer} tokenId - The token ID
    * @return {Promise<Object>} - An object containing token info, including 'warnings'
    */
-  async NftShowToken({addr, tokenId}) {
+  async NftShowToken({ addr, tokenId }) {
+    const abi = fs.readFileSync(
+      path.resolve(__dirname, "../contracts/v3/ElvTradableLocal.abi")
+    );
 
-	const abi = fs.readFileSync(path.resolve(__dirname, "../contracts/v3/ElvTradableLocal.abi"));
+    var tokenInfo = {};
+    tokenInfo.warns = [];
+    tokenInfo.tokenId = tokenId.toString();
 
-	var tokenInfo = {};
-	tokenInfo.warns = [];
-	tokenInfo.tokenId = tokenId.toString();
+    tokenInfo.owner = await this.client.CallContractMethod({
+      contractAddress: addr,
+      abi: JSON.parse(abi),
+      methodName: "ownerOf",
+      methodArgs: [tokenId],
+      formatArguments: true,
+    });
 
-	tokenInfo.owner = await this.client.CallContractMethod({
-	  contractAddress: addr,
-	  abi: JSON.parse(abi),
-	  methodName: "ownerOf",
-	  methodArgs: [tokenId],
-	  formatArguments: true
-	});
+    try {
+      const ordinal = await this.client.CallContractMethod({
+        contractAddress: addr,
+        abi: JSON.parse(abi),
+        methodName: "ordinalOfToken",
+        methodArgs: [tokenId],
+        formatArguments: true,
+      });
+      tokenInfo.ordinal = ordinal.toString();
+    } catch (e) {
+      tokenInfo.ordinal = -1;
+      tokenInfo.warns.push("Failed to get ordinal: " + addr);
+    }
 
-	try {
-	  const ordinal = await this.client.CallContractMethod({
-		contractAddress: addr,
-		abi: JSON.parse(abi),
-		methodName: "ordinalOfToken",
-		methodArgs: [tokenId],
-		formatArguments: true
-	  });
-	tokenInfo.ordinal = ordinal.toString();
-	} catch (e) {
-	  tokenInfo.ordinal = -1;
-	  tokenInfo.warns.push("Failed to get ordinal: " + addr);
-	}
+    tokenInfo.tokenURI = await this.client.CallContractMethod({
+      contractAddress: addr,
+      abi: JSON.parse(abi),
+      methodName: "tokenURI",
+      methodArgs: [tokenId],
+      formatArguments: true,
+    });
 
-	tokenInfo.tokenURI = await this.client.CallContractMethod({
-	  contractAddress: addr,
-	  abi: JSON.parse(abi),
-	  methodName: "tokenURI",
-	  methodArgs: [tokenId],
-	  formatArguments: true
-	});
+    try {
+      const holdSecs = await this.client.CallContractMethod({
+        contractAddress: addr,
+        abi: JSON.parse(abi),
+        methodName: "_allTokensHolds",
+        methodArgs: [tokenId],
+        formatArguments: true,
+      });
+      tokenInfo.holdSecs = holdSecs.toString();
+      tokenInfo.holdEnd = new Date(tokenInfo.holdSecs * 1000);
+    } catch (e) {
+      tokenInfo.warns.push("Failed to get token hold: " + addr);
+    }
 
-	try {
-	  const holdSecs = await this.client.CallContractMethod({
-		contractAddress: addr,
-		abi: JSON.parse(abi),
-		methodName: "_allTokensHolds",
-		methodArgs: [tokenId],
-		formatArguments: true
-	  });
-	  tokenInfo.holdSecs = holdSecs.toString();
-	  tokenInfo.holdEnd = new Date(tokenInfo.holdSecs * 1000);
-
-	} catch(e) {
-	  tokenInfo.warns.push("Failed to get token hold: " + addr);
-	}
-
-	return tokenInfo;
+    return tokenInfo;
   }
 
   /**
@@ -762,145 +793,150 @@ class EluvioLive {
    * @param {string} mintHelper - Warn if this is not a minter for the NFT contract
    * @return {Promise<Object>} - An object containing NFT info, including 'warnings'
    */
-  async NftShow({addr, mintHelper, showOwners}) {
-
-	const abi = fs.readFileSync(path.resolve(__dirname, "../contracts/v3/ElvTradableLocal.abi"));
-	var nftInfo = {};
-	var warns = [];
+  async NftShow({ addr, mintHelper, showOwners }) {
+    const abi = fs.readFileSync(
+      path.resolve(__dirname, "../contracts/v3/ElvTradableLocal.abi")
+    );
+    var nftInfo = {};
+    var warns = [];
 
     nftInfo.name = await this.client.CallContractMethod({
       contractAddress: addr,
       abi: JSON.parse(abi),
       methodName: "name",
-      formatArguments: true
+      formatArguments: true,
     });
     nftInfo.owner = await this.client.CallContractMethod({
       contractAddress: addr,
       abi: JSON.parse(abi),
       methodName: "owner",
-      formatArguments: true
+      formatArguments: true,
     });
     nftInfo.symbol = await this.client.CallContractMethod({
       contractAddress: addr,
       abi: JSON.parse(abi),
       methodName: "symbol",
-      formatArguments: true
+      formatArguments: true,
     });
     const totalSupply = await this.client.CallContractMethod({
       contractAddress: addr,
       abi: JSON.parse(abi),
       methodName: "totalSupply",
-      formatArguments: true
+      formatArguments: true,
     });
-	nftInfo.totalSupply = Number(totalSupply);
+    nftInfo.totalSupply = Number(totalSupply);
 
     try {
       const minted = await this.client.CallContractMethod({
-		contractAddress: addr,
-		abi: JSON.parse(abi),
-		methodName: "minted",
-		formatArguments: true
+        contractAddress: addr,
+        abi: JSON.parse(abi),
+        methodName: "minted",
+        formatArguments: true,
       });
       nftInfo.minted = Number(minted);
-    } catch(e) {
-	  nftInfo.minted = -1; // Older contract
+    } catch (e) {
+      nftInfo.minted = -1; // Older contract
     }
     const cap = await this.client.CallContractMethod({
-	  contractAddress: addr,
-	  abi: JSON.parse(abi),
-	  methodName: "cap",
-	  formatArguments: true
+      contractAddress: addr,
+      abi: JSON.parse(abi),
+      methodName: "cap",
+      formatArguments: true,
     });
-	nftInfo.cap = Number(cap);
+    nftInfo.cap = Number(cap);
 
-	const proxy = await this.client.CallContractMethod({
-	  contractAddress: addr,
-	  abi: JSON.parse(abi),
-	  methodName: "proxyRegistryAddress",
-	  formatArguments: true
+    const proxy = await this.client.CallContractMethod({
+      contractAddress: addr,
+      abi: JSON.parse(abi),
+      methodName: "proxyRegistryAddress",
+      formatArguments: true,
     });
-	nftInfo.proxy = proxy;
+    nftInfo.proxy = proxy;
 
-	if (proxy == "0x0000000000000000000000000000000000000000") {
-	  warns.push("No proxy: " + addr);
-	} else {
-	  nftInfo.proxyInfo = await this.ShowNftTransferProxy({addr: proxy});
-	}
+    if (proxy == "0x0000000000000000000000000000000000000000") {
+      warns.push("No proxy: " + addr);
+    } else {
+      nftInfo.proxyInfo = await this.ShowNftTransferProxy({ addr: proxy });
+    }
 
-	if (mintHelper) {
-	  const isMinter = await this.client.CallContractMethod({
-		contractAddress: addr,
-		abi: JSON.parse(abi),
-		methodName: "isMinter",
-		methodArgs: [mintHelper],
-		formatArguments: true
-	  });
-	  if (!isMinter) {
-		warns.push("Minter not set up addr: " + addr);
-	  }
-	}
+    if (mintHelper) {
+      const isMinter = await this.client.CallContractMethod({
+        contractAddress: addr,
+        abi: JSON.parse(abi),
+        methodName: "isMinter",
+        methodArgs: [mintHelper],
+        formatArguments: true,
+      });
+      if (!isMinter) {
+        warns.push("Minter not set up addr: " + addr);
+      }
+    }
 
-	try {
-	  const defHoldSecs = await this.client.CallContractMethod({
-		contractAddress: addr,
-		abi: JSON.parse(abi),
-		methodName: "defHoldSecs",
-		formatArguments: true
-	  });
-	  nftInfo.defHoldSecs = defHoldSecs.toString();
-	} catch(e) {
-	  nftInfo.defHoldSecs = "not supported";
-	  warns.push("Bad local tradable hold: " + addr);
-	}
+    try {
+      const defHoldSecs = await this.client.CallContractMethod({
+        contractAddress: addr,
+        abi: JSON.parse(abi),
+        methodName: "defHoldSecs",
+        formatArguments: true,
+      });
+      nftInfo.defHoldSecs = defHoldSecs.toString();
+    } catch (e) {
+      nftInfo.defHoldSecs = "not supported";
+      warns.push("Bad local tradable hold: " + addr);
+    }
 
-	nftInfo.tokens = [];
+    nftInfo.tokens = [];
 
-	var maxWarnsTokenUri = 1;
+    var maxWarnsTokenUri = 1;
 
-	if (showOwners && showOwners > 0) {
-	  var maxShowOwners = showOwners;
+    if (showOwners && showOwners > 0) {
+      var maxShowOwners = showOwners;
 
-	  for (var i = 0; i < maxShowOwners && i < nftInfo.totalSupply; i ++) {
+      for (var i = 0; i < maxShowOwners && i < nftInfo.totalSupply; i++) {
+        nftInfo.tokens[i] = {};
 
-		nftInfo.tokens[i] = {};
+        var tokenId;
+        try {
+          tokenId = await this.client.CallContractMethod({
+            contractAddress: addr,
+            abi: JSON.parse(abi),
+            methodName: "tokenByIndex",
+            methodArgs: [i],
+            formatArguments: true,
+          });
+          nftInfo.tokens[i].tokenId = tokenId.toString();
+        } catch (e) {
+          warns.push("Failed to get token ID (index: " + i + "): " + addr);
+          continue;
+        }
 
-		var tokenId;
-		try {
-		  tokenId = await this.client.CallContractMethod({
-			contractAddress: addr,
-			abi: JSON.parse(abi),
-			methodName: "tokenByIndex",
-			methodArgs: [i],
-			formatArguments: true
-		  });
-		  nftInfo.tokens[i].tokenId = tokenId.toString();
-		} catch(e) {
-		  warns.push("Failed to get token ID (index: " + i + "): " + addr);
-		  continue;
-		}
+        var tokenInfo = await this.NftShowToken({ addr, tokenId });
 
-		var tokenInfo = await this.NftShowToken({addr, tokenId});
+        if (tokenInfo.warns.length > 0) {
+          warns.push(...tokenInfo.warns);
+        }
 
-		if (tokenInfo.warns.length > 0) {
-		  warns.push(...tokenInfo.warns);
-		}
+        nftInfo.tokens[i] = tokenInfo;
 
-		nftInfo.tokens[i] = tokenInfo;
+        if (i == 0) {
+          nftInfo.firstTokenUri = nftInfo.tokens[i].tokenURI;
+        }
+        if (
+          maxWarnsTokenUri-- > 0 &&
+          (!nftInfo.tokens[i].tokenURI.startsWith(
+            Config.consts[Config.net].tokenUriStart
+          ) ||
+            !nftInfo.tokens[i].tokenURI.endsWith(
+              Config.consts[Config.net].tokenUriEnd
+            ))
+        ) {
+          warns.push("Bad tokenURI: " + addr);
+        }
+      }
+    }
 
-		if (i == 0) {
-		  nftInfo.firstTokenUri = nftInfo.tokens[i].tokenURI;
-		}
-		if ((maxWarnsTokenUri --) > 0 &&
-			(!nftInfo.tokens[i].tokenURI.startsWith(Config.consts[Config.net].tokenUriStart) ||
-			 !nftInfo.tokens[i].tokenURI.endsWith(Config.consts[Config.net].tokenUriEnd))) {
-		  warns.push("Bad tokenURI: " + addr);
-		}
-
-	  }
-	}
-
-	nftInfo.warns = warns;
-	return nftInfo;
+    nftInfo.warns = warns;
+    return nftInfo;
   }
 
   /**
@@ -910,19 +946,18 @@ class EluvioLive {
    * @param {string} addr - The NFT contract address
    * @param {string} mintAddr - The address of the minter (key or helper contract)
    */
-  async NftAddMinter({addr, minterAddr}) {
-
-	console.log("Add minter", addr, minterAddr);
-    const abi = fs.readFileSync(path.resolve(__dirname, "../contracts/v3/ElvTradable.abi"));
+  async NftAddMinter({ addr, minterAddr }) {
+    console.log("Add minter", addr, minterAddr);
+    const abi = fs.readFileSync(
+      path.resolve(__dirname, "../contracts/v3/ElvTradable.abi")
+    );
 
     var res = await this.client.CallContractMethodAndWait({
       contractAddress: addr,
       abi: JSON.parse(abi),
       methodName: "addMinter",
-      methodArgs: [
-        minterAddr
-      ],
-      formatArguments: true
+      methodArgs: [minterAddr],
+      formatArguments: true,
     });
   }
 
@@ -944,70 +979,69 @@ class EluvioLive {
    * @return {Promise<Object>} - An object containing info about the new NFT
    */
   async NftTemplateAddNftContract({
-	libraryId,
-	objectId,
-	nftAddr,
-	tenantId,
-	mintHelperAddr,
-	minterAddr,
-	collectionName,
-	collectionSymbol,
-	hold,
-	contractUri,
-	proxyAddress,
-  	totalSupply
+    libraryId,
+    objectId,
+    nftAddr,
+    tenantId,
+    mintHelperAddr,
+    minterAddr,
+    collectionName,
+    collectionSymbol,
+    hold,
+    contractUri,
+    proxyAddress,
+    totalSupply,
   }) {
+    console.log("Create NFT contract");
 
-	console.log("Create NFT contract");
+    if (nftAddr == null) {
+      nftAddr = await this.CreateNftContract({
+        tenantId,
+        mintHelperAddr,
+        minterAddr,
+        totalSupply,
+        collectionName,
+        collectionSymbol,
+        hold,
+        contractUri,
+        proxyAddress,
+      });
+    }
 
-	if (nftAddr == null) {
-	  nftAddr = await this.CreateNftContract({
-		tenantId,
-		mintHelperAddr,
-		minterAddr,
-		totalSupply,
-		collectionName,
-		collectionSymbol,
-		hold,
-		contractUri,
-		proxyAddress
-	  });
-	};
+    // Update object metadata
+    console.log("Update object metadata");
+    var m = await this.client.ContentObjectMetadata({
+      libraryId,
+      objectId,
+      resolveLinks: false,
+    });
 
-	// Update object metadata
-	console.log("Update object metadata");
-	var m = await this.client.ContentObjectMetadata({
-	  libraryId,
-	  objectId,
-	  resolveLinks: false
-	});
+    m.permissioned.mint_private.address = nftAddr;
+    m.public.asset_metadata.nft.address = nftAddr;
+    m.public.asset_metadata.nft.total_supply = totalSupply;
 
-	m.permissioned.mint_private.address = nftAddr;
-	m.public.asset_metadata.nft.address = nftAddr;
-	m.public.asset_metadata.nft.total_supply = totalSupply;
+    var e = await this.client.EditContentObject({
+      libraryId,
+      objectId,
+    });
 
-	var e = await this.client.EditContentObject({
-	  libraryId,
-	  objectId
-	});
+    await this.client.ReplaceMetadata({
+      libraryId,
+      objectId,
+      writeToken: e.write_token,
+      metadata: m,
+    });
 
-	await this.client.ReplaceMetadata({
-	  libraryId,
-	  objectId,
-	  writeToken: e.write_token,
-	  metadata: m
-	});
+    var f = await this.client.FinalizeContentObject({
+      libraryId,
+      objectId,
+      writeToken: e.write_token,
+      commitMessage: "Set NFT contract address " + nftAddr,
+    });
 
-	var f = await this.client.FinalizeContentObject({
-	  libraryId,
-	  objectId,
-	  writeToken: e.write_token,
-	  commitMessage: "Set NFT contract address " + nftAddr
-	});
+    console.log("Finalized", f);
 
-	console.log("Finalized", f);
-
-	return nftAddr;
+    return nftAddr;
   }
 
   /**
@@ -1019,57 +1053,53 @@ class EluvioLive {
    * @param {Object} assetMetadata - The NFT Template asset metadata
    * @return {Promise<Object>} - The public/nft JSON
    */
-  async NftMake({
-	assetMetadata,
-	hash
-  }) {
+  async NftMake({ assetMetadata, hash }) {
+    const m = assetMetadata;
+    var pnft = {};
 
-	const m = assetMetadata;
-	var pnft = {};
-
-	/* Add this to description */
-	const addtlInfo = `
+    /* Add this to description */
+    const addtlInfo = `
 
 Lookup NFT: https://wallet.contentfabric.io/lookup/`;
 
-	pnft.name = m.nft.name;
-	pnft.display_name = m.nft.display_name;
-	pnft.description = m.nft.description; // + addtlInfo;
-	pnft.edition_name = m.nft.edition_name;
-	pnft.rich_text = m.nft.rich_text;
+    pnft.name = m.nft.name;
+    pnft.display_name = m.nft.display_name;
+    pnft.description = m.nft.description; // + addtlInfo;
+    pnft.edition_name = m.nft.edition_name;
+    pnft.rich_text = m.nft.rich_text;
 
-	pnft.address = m.nft.address;
-	pnft.total_supply = m.nft.total_supply;
-	pnft.template_id = m.nft.template_id;
+    pnft.address = m.nft.address;
+    pnft.total_supply = m.nft.total_supply;
+    pnft.template_id = m.nft.template_id;
 
-	pnft.copyright = m.nft.copyright;
-	pnft.created_at = m.nft.created_at;
-	pnft.creator = m.nft.creator;
+    pnft.copyright = m.nft.copyright;
+    pnft.created_at = m.nft.created_at;
+    pnft.creator = m.nft.creator;
 
-	pnft.embed_url = m.nft.embed_url;
-	pnft.external_url = m.nft.external_url;
-	pnft.youtube_url = m.nft.marketplace_attributes.opensea.youtube_url;
-	pnft.image = m.nft.image;
-	pnft.playable = m.nft.playable;
+    pnft.embed_url = m.nft.embed_url;
+    pnft.external_url = m.nft.external_url;
+    pnft.youtube_url = m.nft.marketplace_attributes.opensea.youtube_url;
+    pnft.image = m.nft.image;
+    pnft.playable = m.nft.playable;
 
-	// pnft.addtl_info = addtlInfo;
+    // pnft.addtl_info = addtlInfo;
 
-	pnft.attributes = [
+    pnft.attributes = [
       {
-		trait_type: "Creator",
-		value: "Eluvio NFT Central"
+        trait_type: "Creator",
+        value: "Eluvio NFT Central",
       },
       {
-		trait_type: "Total Minted Supply",
-		value: m.nft.total_supply.toString()
+        trait_type: "Total Minted Supply",
+        value: m.nft.total_supply.toString(),
       },
       {
-		trait_type: "Content Fabric Hash",
-		value: hash
-      }
-	];
+        trait_type: "Content Fabric Hash",
+        value: hash,
+      },
+    ];
 
-	return pnft;
+    return pnft;
   }
 
   /**
@@ -1079,72 +1109,74 @@ Lookup NFT: https://wallet.contentfabric.io/lookup/`;
    * @param {string} hash - The NFT Template hash or id
    * @return {Promise<Object>} - The public/nft JSON
    */
-  async NftBuild({
-	libraryId,
-	objectId
-  }) {
+  async NftBuild({ libraryId, objectId }) {
+    var hash = await this.client.LatestVersionHash({
+      objectId,
+    });
 
-	var hash = await this.client.LatestVersionHash({
-	  objectId
-	});
+    var m = await this.client.ContentObjectMetadata({
+      libraryId,
+      objectId,
+      metadataSubtree: "public/asset_metadata",
+      resolveLinks: false,
+    });
 
-	var m = await this.client.ContentObjectMetadata({
-	  libraryId,
-	  objectId,
-	  metadataSubtree: "public/asset_metadata",
-	  resolveLinks: false
-	});
+    var pnft = await this.NftMake({ assetMetadata: m, hash });
+    console.log(pnft);
 
-	var pnft = await this.NftMake({assetMetadata: m, hash});
-	console.log(pnft);
+    var e = await this.client.EditContentObject({
+      libraryId,
+      objectId,
+    });
 
-	var e = await this.client.EditContentObject({
-	  libraryId,
-	  objectId
-	});
+    await this.client.ReplaceMetadata({
+      libraryId,
+      objectId,
+      writeToken: e.write_token,
+      metadataSubtree: "public/nft",
+      metadata: pnft,
+    });
 
-	await this.client.ReplaceMetadata({
-	  libraryId,
-	  objectId,
-	  writeToken: e.write_token,
-	  metadataSubtree: "public/nft",
-	  metadata: pnft
-	});
+    var f = await this.client.FinalizeContentObject({
+      libraryId,
+      objectId,
+      writeToken: e.write_token,
+      commitMessage: "Set NFT public/nft",
+    });
 
-	var f = await this.client.FinalizeContentObject({
-	  libraryId,
-	  objectId,
-	  writeToken: e.write_token,
-	  commitMessage: "Set NFT public/nft"
-	});
+    const nftPath = "/meta/public/nft";
+    const tokenUri =
+      Config.networks[Config.net] +
+      "/s/" +
+      Config.net +
+      "/q/" +
+      f.hash +
+      nftPath;
 
-	const nftPath = "/meta/public/nft";
-	const tokenUri = Config.networks[Config.net] + "/s/" + Config.net + "/q/" + f.hash + nftPath;
+    console.log("Token URI: ", tokenUri);
 
-	console.log("Token URI: ", tokenUri);
+    // Set the token URI - edit the object one more time
+    var e = await this.client.EditContentObject({
+      libraryId,
+      objectId,
+    });
 
-	// Set the token URI - edit the object one more time
-	var e = await this.client.EditContentObject({
-	  libraryId,
-	  objectId
-	});
+    await this.client.ReplaceMetadata({
+      libraryId,
+      objectId,
+      writeToken: e.write_token,
+      metadataSubtree: "public/asset_metadata/nft/token_uri",
+      metadata: tokenUri,
+    });
 
-	await this.client.ReplaceMetadata({
-	  libraryId,
-	  objectId,
-	  writeToken: e.write_token,
-	  metadataSubtree: "public/asset_metadata/nft/token_uri",
-	  metadata: tokenUri
-	});
+    var f2 = await this.client.FinalizeContentObject({
+      libraryId,
+      objectId,
+      writeToken: e.write_token,
+      commitMessage: "Set NFT token URI",
+    });
 
-	var f2 = await this.client.FinalizeContentObject({
-	  libraryId,
-	  objectId,
-	  writeToken: e.write_token,
-	  commitMessage: "Set NFT token URI"
-	});
-
-	return f2;
+    return f2;
   }
 
   /**
@@ -1155,16 +1187,11 @@ Lookup NFT: https://wallet.contentfabric.io/lookup/`;
    * @param {integer} tokenId - External NFT token ID
    * @return {Promise<Object>} - NFT info JSON
    */
-  async NftLookup({
-	addr,
-	tokenId
-  }) {
+  async NftLookup({ addr, tokenId }) {
+    console.log("tokenId", tokenId);
 
-	console.log("tokenId", tokenId);
-
-	var x = new BigNumber(tokenId, 10);
-	console.log(x.toString(16));
-
+    var x = new BigNumber(tokenId, 10);
+    console.log(x.toString(16));
   }
 
   /**
@@ -1177,167 +1204,167 @@ Lookup NFT: https://wallet.contentfabric.io/lookup/`;
    * @param {integer} tokenId - The token ID
    * @return {Promise<Object>} - ?
    */
-  async NftProxyTransferFrom({addr, tokenId, fromAddr, toAddr}) {
-
-	console.log("NFT Transfer", "from: ", fromAddr);
-    const abi = fs.readFileSync(path.resolve(__dirname, "../contracts/v3/ElvTradableLocal.abi"));
-	const pxabi = fs.readFileSync(path.resolve(__dirname, "../contracts/v3/TransferProxyRegistry.abi"));
+  async NftProxyTransferFrom({ addr, tokenId, fromAddr, toAddr }) {
+    console.log("NFT Transfer", "from: ", fromAddr);
+    const abi = fs.readFileSync(
+      path.resolve(__dirname, "../contracts/v3/ElvTradableLocal.abi")
+    );
+    const pxabi = fs.readFileSync(
+      path.resolve(__dirname, "../contracts/v3/TransferProxyRegistry.abi")
+    );
 
     var ownerOf = await this.client.CallContractMethod({
       contractAddress: addr,
       abi: JSON.parse(abi),
       methodName: "ownerOf",
       methodArgs: [tokenId],
-      formatArguments: true
+      formatArguments: true,
     });
 
-	if (ownerOf.toLowerCase() != fromAddr.toLowerCase()) {
-	  console.log("Not owner", "(owner: " + ownerOf + ")");
-	  return;
-	}
+    if (ownerOf.toLowerCase() != fromAddr.toLowerCase()) {
+      console.log("Not owner", "(owner: " + ownerOf + ")");
+      return;
+    }
 
-	const proxy = await this.client.CallContractMethod({
-	  contractAddress: addr,
-	  abi: JSON.parse(abi),
-	  methodName: "proxyRegistryAddress",
-	  formatArguments: true
+    const proxy = await this.client.CallContractMethod({
+      contractAddress: addr,
+      abi: JSON.parse(abi),
+      methodName: "proxyRegistryAddress",
+      formatArguments: true,
     });
 
-	if (proxy == "0x0000000000000000000000000000000000000000") {
-	  console.log("NFT has no proxy");
-	  return;
-	}
-	console.log("Proxy: ", proxy);
+    if (proxy == "0x0000000000000000000000000000000000000000") {
+      console.log("NFT has no proxy");
+      return;
+    }
+    console.log("Proxy: ", proxy);
 
-	var proxyInfo = await this.ShowNftTransferProxy({addr: proxy});
-	if (proxyInfo.owner != this.client.signer.address) {
-	  console.log("Bad key - not proxy owner (should be: " + proxyInfo.owner + ")");
-	  return;
-	}
+    var proxyInfo = await this.ShowNftTransferProxy({ addr: proxy });
+    if (proxyInfo.owner != this.client.signer.address) {
+      console.log(
+        "Bad key - not proxy owner (should be: " + proxyInfo.owner + ")"
+      );
+      return;
+    }
 
-	console.log("Executing proxyTransferFrom");
-	var res = await this.client.CallContractMethod({
+    console.log("Executing proxyTransferFrom");
+    var res = await this.client.CallContractMethod({
       contractAddress: proxy,
       abi: JSON.parse(pxabi),
       methodName: "proxyTransferFrom",
-      methodArgs: [
-		addr,
-		fromAddr,
-		toAddr,
-		tokenId
-      ],
-      formatArguments: true
+      methodArgs: [addr, fromAddr, toAddr, tokenId],
+      formatArguments: true,
     });
 
-	res.wait(1);
-	return res;
+    res.wait(1);
+    return res;
   }
 
-  async Sign({message}) {
-		const signature = await this.client.authClient.Sign(Ethers.utils.keccak256(Ethers.utils.toUtf8Bytes(message)));
-		const multiSig = this.client.utils.FormatSignature(signature);
-		return {signature, multiSig}
+  async Sign({ message }) {
+    const signature = await this.client.authClient.Sign(
+      Ethers.utils.keccak256(Ethers.utils.toUtf8Bytes(message))
+    );
+    const multiSig = this.client.utils.FormatSignature(signature);
+    return { signature, multiSig };
   }
 
-  async MakeAuthServiceRequest({method, path, body}){
+  async MakeAuthServiceRequest({ method, path, body }) {
+    const { signature, multiSig } = await this.Sign({
+      message: JSON.stringify(body),
+    });
 
-		const {signature, multiSig} = await this.Sign({message:JSON.stringify(body)});
+    let res = await this.client.authClient.MakeAuthServiceRequest({
+      method,
+      path,
+      body,
+      headers: {
+        Authorization: `Bearer ${multiSig}`,
+      },
+    });
 
-		let res = await this.client.authClient.MakeAuthServiceRequest({
-			method,
-			path,
-			body,
-			headers: {
-			"Authorization": `Bearer ${multiSig}`
-			}
-		});
-
-		return res;
+    return res;
   }
 
-  async TenantMint({tenant, marketplace, sku, addr}) {
-		let now = Date.now();
+  async TenantMint({ tenant, marketplace, sku, addr }) {
+    let now = Date.now();
 
-		let body = {
-			"trans_id":"",
-			"tickets":null,
-			"products":[
-			{
-				"prod_name": "",
-				"sku": sku,
-				"quant": 1
-			}
-			],
-			"ident":"minter@tenant.com",
-			"email":"minter@tenant.com",
-			"cust_name":"minter@tenant.com",
-			"ts": now,
-			"extra":{
-			"elv_addr": addr
-			}
-		};
+    let body = {
+      trans_id: "",
+      tickets: null,
+      products: [
+        {
+          prod_name: "",
+          sku: sku,
+          quant: 1,
+        },
+      ],
+      ident: "minter@tenant.com",
+      email: "minter@tenant.com",
+      cust_name: "minter@tenant.com",
+      ts: now,
+      extra: {
+        elv_addr: addr,
+      },
+    };
 
-		let res = await this.MakeAuthServiceRequest({
-			method: "POST",
-			path: "/as/tnt/trans/base/" + tenant + "/" + marketplace,
-			body
-		});
-		return res;
+    let res = await this.MakeAuthServiceRequest({
+      method: "POST",
+      path: "/as/tnt/trans/base/" + tenant + "/" + marketplace,
+      body,
+    });
+    return res;
   }
 
-	async list({tenantId, tenantSlug}){
-		var results = {};
+  async list({ tenantId, tenantSlug }) {
+    var results = {};
 
-		var objectId = this.mainObjectId;
+    var objectId = this.mainObjectId;
 
-		const libraryId = await this.client.ContentObjectLibraryId({
-			objectId
-		});
+    const libraryId = await this.client.ContentObjectLibraryId({
+      objectId,
+    });
 
-		var warns = [];
-		var meta = {};
-		var metadataSubtree = "/public/asset_metadata/tenants";
+    var warns = [];
+    var meta = {};
+    var metadataSubtree = "/public/asset_metadata/tenants";
 
-		meta = await this.client.ContentObjectMetadata({
-			libraryId,
-			objectId,
-			metadataSubtree,
-			resolveLinks: true,
-			resolveIncludeSource: true,
-			resolveIgnoreErrors: true,
-			linkDepthLimit: 5
-		});
+    meta = await this.client.ContentObjectMetadata({
+      libraryId,
+      objectId,
+      metadataSubtree,
+      resolveLinks: true,
+      resolveIncludeSource: true,
+      resolveIgnoreErrors: true,
+      linkDepthLimit: 5,
+    });
 
+    if (tenantSlug) {
+      results = meta[tenantSlug];
+    } else if (tenantId) {
+      let tenants = meta || {};
 
-		if(tenantSlug){
-			results=meta[tenantSlug];
-		}else if(tenantId){
-				let tenants = meta || {};
-	
-				for (const index in tenants) {
-					try {
-						let tenantObj = tenants[index];
-						let key = Object.keys(tenantObj.marketplaces)[0];
-						let marketplace = tenantObj.marketplaces[key];
-						var testTenantId = marketplace.info.tenant_id;
-						if(testTenantId === tenantId){
-							results = tenantObj;
-							break;
-						}
-					}catch(e){
-						warns.push(`Error reading tenant: ${index} ${e}`);
-					}
-				}
-		}else{
-			results = meta;
-		}
+      for (const index in tenants) {
+        try {
+          let tenantObj = tenants[index];
+          let key = Object.keys(tenantObj.marketplaces)[0];
+          let marketplace = tenantObj.marketplaces[key];
+          var testTenantId = marketplace.info.tenant_id;
+          if (testTenantId === tenantId) {
+            results = tenantObj;
+            break;
+          }
+        } catch (e) {
+          warns.push(`Error reading tenant: ${index} ${e}`);
+        }
+      }
+    } else {
+      results = meta;
+    }
 
-		results.warns = warns;
+    results.warns = warns;
 
-		return results;
-	}
-
+    return results;
+  }
 }
-
 
 exports.EluvioLive = EluvioLive;

--- a/src/Shuffler.js
+++ b/src/Shuffler.js
@@ -1,93 +1,93 @@
-const seedrandom = require("seedrandom")
+const seedrandom = require("seedrandom");
 
-const fs = require("fs")
-const readline = require('readline')
+const fs = require("fs");
+const readline = require("readline");
 
 class Shuffler {
-    /**
-     * Shuffle an array using the Durstenfeld algorithm
-     * @param a - An array of strings
-     * @param sort - First sort alphabetically if true, so the input order does not matter
-     * @param seed - The order will always be the same for the given string; nil for a random seed
-     * @param check_dupes - Abort if duplicate is found
-     * @returns {*} - The same array object, after shuffling
-     */
-    static shuffle(a, sort, seed, check_dupes) {
-        if (check_dupes && !sort) throw "duplicate check requires sorting"
+  /**
+   * Shuffle an array using the Durstenfeld algorithm
+   * @param a - An array of strings
+   * @param sort - First sort alphabetically if true, so the input order does not matter
+   * @param seed - The order will always be the same for the given string; nil for a random seed
+   * @param check_dupes - Abort if duplicate is found
+   * @returns {*} - The same array object, after shuffling
+   */
+  static shuffle(a, sort, seed, check_dupes) {
+    if (check_dupes && !sort) throw "duplicate check requires sorting";
 
-        if (sort) a.sort()
+    if (sort) a.sort();
 
-        let last = ""
-        for (let i in a) {
-            if (a[i] === "") throw "empty string not allowed"
-            if (check_dupes && last === a[i]) throw "duplicate lines found: " + last
-            last = a[i]
-        }
-
-        let rng = seedrandom(seed);
-        for (let i = a.length - 1; i > 0; i--) {
-            let j = Math.floor(rng() * (i + 1))
-            let temp = a[i]
-            a[i] = a[j]
-            a[j] = temp
-        }
-        return a
+    let last = "";
+    for (let i in a) {
+      if (a[i] === "") throw "empty string not allowed";
+      if (check_dupes && last === a[i]) throw "duplicate lines found: " + last;
+      last = a[i];
     }
 
-    /**
-     * Read a file into an array of line strings
-     * @param f - The file path
-     * @returns {Promise<*[]>} - An array of lines
-     */
-    static async readFileToArray(f) {
-        const a = []
-        const rl = readline.createInterface({
-            input: fs.createReadStream(f),
-            crlfDelay: Infinity
-        })
-        for await (const line of rl) {
-            if (line.length > 0) a.push(line)
-        }
-        return a
+    let rng = seedrandom(seed);
+    for (let i = a.length - 1; i > 0; i--) {
+      let j = Math.floor(rng() * (i + 1));
+      let temp = a[i];
+      a[i] = a[j];
+      a[j] = temp;
     }
+    return a;
+  }
 
-    /**
-     * Write an array of strings to a file, one element per line
-     * @param f - The file path
-     * @param a - An array of strings
-     */
-    static writeArrayToFile(f, a) {
-        let fd
-        try {
-            fd = fs.openSync(f, "ax")
-            for (let line of a) {
-                fs.appendFileSync(fd, line)
-                fs.appendFileSync(fd, "\n")
-            }
-        } finally {
-            if (fd !== undefined) fs.closeSync(fd)
-        }
+  /**
+   * Read a file into an array of line strings
+   * @param f - The file path
+   * @returns {Promise<*[]>} - An array of lines
+   */
+  static async readFileToArray(f) {
+    const a = [];
+    const rl = readline.createInterface({
+      input: fs.createReadStream(f),
+      crlfDelay: Infinity,
+    });
+    for await (const line of rl) {
+      if (line.length > 0) a.push(line);
     }
+    return a;
+  }
 
-    static shuffledPath(f) {
-        return f + ".shuffled"
+  /**
+   * Write an array of strings to a file, one element per line
+   * @param f - The file path
+   * @param a - An array of strings
+   */
+  static writeArrayToFile(f, a) {
+    let fd;
+    try {
+      fd = fs.openSync(f, "ax");
+      for (let line of a) {
+        fs.appendFileSync(fd, line);
+        fs.appendFileSync(fd, "\n");
+      }
+    } finally {
+      if (fd !== undefined) fs.closeSync(fd);
     }
+  }
 
-    /**
-     * Shuffle the lines in a file, print the result, and write it back out
-     * to the result of shuffledPath()
-     * @param f - The file path
-     * @param sort - see shuffle()
-     * @param seed - see shuffle()
-     * @param check_dupes see shuffle()
-     * @returns {Promise<*[]>} - The shuffled lines in an array
-     */
-    static async shuffleFile(f, sort, seed, check_dupes) {
-        let a = await Shuffler.readFileToArray(f)
-        Shuffler.shuffle(a, sort, seed, check_dupes)
-        Shuffler.writeArrayToFile(Shuffler.shuffledPath(f), a)
-        return a
-    }
+  static shuffledPath(f) {
+    return f + ".shuffled";
+  }
+
+  /**
+   * Shuffle the lines in a file, print the result, and write it back out
+   * to the result of shuffledPath()
+   * @param f - The file path
+   * @param sort - see shuffle()
+   * @param seed - see shuffle()
+   * @param check_dupes see shuffle()
+   * @returns {Promise<*[]>} - The shuffled lines in an array
+   */
+  static async shuffleFile(f, sort, seed, check_dupes) {
+    let a = await Shuffler.readFileToArray(f);
+    Shuffler.shuffle(a, sort, seed, check_dupes);
+    Shuffler.writeArrayToFile(Shuffler.shuffledPath(f), a);
+    return a;
+  }
 }
 
-exports.Shuffler = Shuffler
+exports.Shuffler = Shuffler;

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -1,691 +1,722 @@
-const { ElvClient } = require("elv-client-js")
-const { EluvioLive } = require("../src/EluvioLive.js")
-const { Config } = require("../src/Config.js")
-const {Shuffler} = require("../src/Shuffler")
+const { ElvClient } = require("elv-client-js");
+const { EluvioLive } = require("../src/EluvioLive.js");
+const { Config } = require("../src/Config.js");
+const { Shuffler } = require("../src/Shuffler");
 
-const yargs = require('yargs/yargs')
-const { hideBin } = require('yargs/helpers')
-const yaml = require('js-yaml');
+const yargs = require("yargs/yargs");
+const { hideBin } = require("yargs/helpers");
+const yaml = require("js-yaml");
 
-const fs = require("fs")
-const path = require("path")
+const fs = require("fs");
+const path = require("path");
 
 var elvlv;
 
 const Init = async () => {
-
   console.log("Network: " + Config.net);
 
   elvlv = new EluvioLive({
-	configUrl: Config.networks[Config.net],
-	mainObjectId: Config.mainObjects[Config.net]
+    configUrl: Config.networks[Config.net],
+    mainObjectId: Config.mainObjects[Config.net],
   });
   await elvlv.Init();
+};
 
-}
-
-const CmfNftTemplateAddNftContract = async ({argv}) => {
-
-  console.log("NFT Template - set contract",
-			  argv.library, argv.object, argv.tenant, argv.minthelper, argv.minter, argv.cap, argv.name, argv.symbol,
-			  argv.nftAddress)
+const CmfNftTemplateAddNftContract = async ({ argv }) => {
+  console.log(
+    "NFT Template - set contract",
+    argv.library,
+    argv.object,
+    argv.tenant,
+    argv.minthelper,
+    argv.minter,
+    argv.cap,
+    argv.name,
+    argv.symbol,
+    argv.nftAddress
+  );
   await Init();
 
   var c = await elvlv.NftTemplateAddNftContract({
-	libraryId: argv.library,
-	objectId: argv.object,
-	//nftAddr,
-	tenantId: argv.tenant,
-	mintHelperAddr: argv.minthelper, //"0x59e79eFE007F5208857a646Db5cBddA82261Ca81",
-	minterAddr: argv.minter,
-	totalSupply: argv.cap,
-	collectionName: argv.name,
-	collectionSymbol: argv.symbol,
-	hold: argv.hold,
-	contractUri: "",
-	proxyAddress: ""
-  })
+    libraryId: argv.library,
+    objectId: argv.object,
+    //nftAddr,
+    tenantId: argv.tenant,
+    mintHelperAddr: argv.minthelper, //"0x59e79eFE007F5208857a646Db5cBddA82261Ca81",
+    minterAddr: argv.minter,
+    totalSupply: argv.cap,
+    collectionName: argv.name,
+    collectionSymbol: argv.symbol,
+    hold: argv.hold,
+    contractUri: "",
+    proxyAddress: "",
+  });
+};
 
-}
-
-const CmfNftAddMintHelper = async ({argv}) => {
-
-  console.log("NFT - add mint helper",
-			  argv.addr, argv.minter)
+const CmfNftAddMintHelper = async ({ argv }) => {
+  console.log("NFT - add mint helper", argv.addr, argv.minter);
   await Init();
 
   var c = await elvlv.NftAddMinter({
-	addr: argv.addr,
-	minterAddr: argv.minter
-  })
+    addr: argv.addr,
+    minterAddr: argv.minter,
+  });
+};
 
-}
-
-const CmfNftSetProxy = async ({argv}) => {
-
-  console.log("NFT - set proxy",
-			  argv.addr, argv.proxy_addr)
+const CmfNftSetProxy = async ({ argv }) => {
+  console.log("NFT - set proxy", argv.addr, argv.proxy_addr);
   await Init();
 
   var p = await elvlv.NftSetTransferProxy({
-	addr: argv.addr,
-	proxyAddr: argv.proxy_addr
-  })
+    addr: argv.addr,
+    proxyAddr: argv.proxy_addr,
+  });
   console.log("Proxy: ", p);
+};
 
-}
-
-const CmdNftBalanceOf = async ({argv}) => {
-
+const CmdNftBalanceOf = async ({ argv }) => {
   console.log("NFT - call", argv.addr, argv.owner);
 
   await Init();
 
   var res = await elvlv.NftBalanceOf({
-	addr: argv.addr,
-	ownerAddr: argv.owner
-  })
+    addr: argv.addr,
+    ownerAddr: argv.owner,
+  });
 
   console.log(yaml.dump(res));
-}
+};
 
-const CmdNftShow = async ({argv}) => {
-
+const CmdNftShow = async ({ argv }) => {
   console.log("NFT - show", argv.addr, argv.show_owners);
 
   await Init();
 
   var res = await elvlv.NftShow({
-	addr: argv.addr,
-	mintHelper: argv.check_minter,
-	showOwners: argv.show_owners
-  })
+    addr: argv.addr,
+    mintHelper: argv.check_minter,
+    showOwners: argv.show_owners,
+  });
 
   console.log(yaml.dump(res));
-}
+};
 
-const CmdNftBuild = async ({argv}) => {
-
+const CmdNftBuild = async ({ argv }) => {
   console.log("NFT - build public/nft", argv.object);
 
   await Init();
 
   var res = await elvlv.NftBuild({
-	libraryId: argv.library,
-	objectId: argv.object
-  })
+    libraryId: argv.library,
+    objectId: argv.object,
+  });
 
   console.log(yaml.dump(res));
-}
+};
 
-const CmdNftLookup = async ({argv}) => {
-
+const CmdNftLookup = async ({ argv }) => {
   console.log("NFT - lookup", argv.addr, argv.token_id);
 
   await Init();
 
   var res = await elvlv.NftLookup({
-	addr: argv.addr,
-	tokenId: argv.token_id
-  })
+    addr: argv.addr,
+    tokenId: argv.token_id,
+  });
 
   console.log(yaml.dump(res));
-}
+};
 
-const CmdNftProxyTransfer = async ({argv}) => {
-
-  console.log("NFT - transer as proxy owner", argv.addr, argv.from_addr, argv.to_addr);
+const CmdNftProxyTransfer = async ({ argv }) => {
+  console.log(
+    "NFT - transer as proxy owner",
+    argv.addr,
+    argv.from_addr,
+    argv.to_addr
+  );
 
   await Init();
 
   var res = await elvlv.NftProxyTransferFrom({
-	addr: argv.addr,
-	tokenId: argv.token_id,
-	fromAddr: argv.from_addr,
-	toAddr: argv.to_addr
-  })
+    addr: argv.addr,
+    tokenId: argv.token_id,
+    fromAddr: argv.from_addr,
+    toAddr: argv.to_addr,
+  });
 
   console.log(yaml.dump(res));
-}
+};
 
-const CmdTenantShow = async ({argv}) => {
-
+const CmdTenantShow = async ({ argv }) => {
   console.log("Tenant - show", argv.tenant);
 
   await Init();
 
   var res = await elvlv.TenantShow({
-	tenantId: argv.tenant,
-	libraryId: argv.library,
-	objectId: argv.object,
-	marketplaceId: argv.marketplace,
-	eventId: argv.event,
-	cauth: argv.check_cauth,
-	mintHelper: argv.check_minter
-  })
+    tenantId: argv.tenant,
+    libraryId: argv.library,
+    objectId: argv.object,
+    marketplaceId: argv.marketplace,
+    eventId: argv.event,
+    cauth: argv.check_cauth,
+    mintHelper: argv.check_minter,
+  });
 
   console.log(yaml.dump(res));
-}
+};
 
-const CmdSiteShow = async ({argv}) => {
-
+const CmdSiteShow = async ({ argv }) => {
   console.log("Site - show", argv.object);
 
   await Init();
 
   var res = await elvlv.SiteShow({
-	libraryId: argv.library,
-	objectId: argv.object,
-  })
+    libraryId: argv.library,
+    objectId: argv.object,
+  });
 
   console.log(yaml.dump(res));
-}
+};
 
-const CmdSiteSetDrop = async ({argv}) => {
-
+const CmdSiteSetDrop = async ({ argv }) => {
   console.log("Site - set drop", argv.object, argv.uuid, "update", argv.update);
 
   await Init();
 
   var res = await elvlv.SiteSetDrop({
-	libraryId: argv.library,
-	objectId: argv.object,
-	uuid: argv.uuid,
-	start: argv.start_date,
-	end: argv.end_date,
-	endVote: argv.end_vote,
-	startMint: argv.start_mint,
-	newUuid: argv.new_uuid,
-	update: argv.update
-  })
+    libraryId: argv.library,
+    objectId: argv.object,
+    uuid: argv.uuid,
+    start: argv.start_date,
+    end: argv.end_date,
+    endVote: argv.end_vote,
+    startMint: argv.start_mint,
+    newUuid: argv.new_uuid,
+    update: argv.update,
+  });
 
   console.log(yaml.dump(res));
-}
+};
 
-const CmdTenantBalanceOf = async ({argv}) => {
-
+const CmdTenantBalanceOf = async ({ argv }) => {
   console.log("Tenant - balance of", argv.tenant, argv.owner, argv.max_results);
 
   await Init();
 
   var res = await elvlv.TenantBalanceOf({
-		tenantId: argv.tenant,
-		ownerAddr: argv.owner,
-		maxNumber: argv.max_results
-  })
+    tenantId: argv.tenant,
+    ownerAddr: argv.owner,
+    maxNumber: argv.max_results,
+  });
 
   console.log(yaml.dump(res));
-}
+};
 
-const CmdFabricTenantBalanceOf = async ({argv}) => {
+const CmdFabricTenantBalanceOf = async ({ argv }) => {
+  console.log("Fabric Tenant - balance of", argv.object, argv.owner);
 
-	console.log("Fabric Tenant - balance of", argv.object, argv.owner);
-  
-	await Init();
-  
-	var res = await elvlv.FabricTenantBalanceOf({
-	  objectId: argv.object,
-	  ownerAddr: argv.owner
-	})
-  
-	console.log(yaml.dump(res));
-}
+  await Init();
 
-const CmdShuffle = async ({argv}) => {
-	try {
-		let files = [argv.file]
-		let isDir = fs.lstatSync(argv.file).isDirectory()
-		if (isDir) {
-			files = fs.readdirSync(argv.file)
-			files.forEach((f, i) => {
-				files[i] = path.join(argv.file, f)
-			})
-		}
+  var res = await elvlv.FabricTenantBalanceOf({
+    objectId: argv.object,
+    ownerAddr: argv.owner,
+  });
 
-		for (let f of files) {
-			console.log("\n" + Shuffler.shuffledPath(f) + ":")
+  console.log(yaml.dump(res));
+};
 
-			let a = await Shuffler.shuffleFile(
-				f, true, argv.seed, argv.check_dupes)
-
-			if (argv.print_js) {
-				console.log(a)
-			} else {
-				a.forEach((line) => {
-					console.log(line)
-				})
-			}
-		}
-		console.log("")
-	} catch (e) {
-		console.error("ERROR:", e)
-	}
-}
-
-const TenantMint = async ({argv}) => {
-
-  console.log("Tenant mint", argv.tenant, argv.marketplace, argv.sku, argv.addr);
+const CmdShuffle = async ({ argv }) => {
   try {
-	await Init();
+    let files = [argv.file];
+    let isDir = fs.lstatSync(argv.file).isDirectory();
+    if (isDir) {
+      files = fs.readdirSync(argv.file);
+      files.forEach((f, i) => {
+        files[i] = path.join(argv.file, f);
+      });
+    }
 
-	let res = await elvlv.TenantMint({
-	  tenant: argv.tenant,
-	  marketplace: argv.marketplace,
-	  sku: argv.sku,
-	  addr: argv.addr
-	});
+    for (let f of files) {
+      console.log("\n" + Shuffler.shuffledPath(f) + ":");
 
-	console.log("Mint request submitted: ", res.statusText);
+      let a = await Shuffler.shuffleFile(f, true, argv.seed, argv.check_dupes);
 
+      if (argv.print_js) {
+        console.log(a);
+      } else {
+        a.forEach((line) => {
+          console.log(line);
+        });
+      }
+    }
+    console.log("");
   } catch (e) {
-	console.error("ERROR:", e)
+    console.error("ERROR:", e);
   }
+};
 
-}
+const TenantMint = async ({ argv }) => {
+  console.log(
+    "Tenant mint",
+    argv.tenant,
+    argv.marketplace,
+    argv.sku,
+    argv.addr
+  );
+  try {
+    await Init();
 
-const CmdList = async ({argv}) => {
-	console.log(`list tenant: ${argv.tenant} tenant_slug: ${argv.tenant_slug}`);
-  try{
-		await Init();
-		
-		var res = await elvlv.list({
-			tenantId: argv.tenant,
-			tenantSlug:argv.tenant_slug
-		})
-		
-		console.log(yaml.dump(res));
-	}catch(e){
-		console.error(e);
-	}
-}
+    let res = await elvlv.TenantMint({
+      tenant: argv.tenant,
+      marketplace: argv.marketplace,
+      sku: argv.sku,
+      addr: argv.addr,
+    });
+
+    console.log("Mint request submitted: ", res.statusText);
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
+const CmdList = async ({ argv }) => {
+  console.log(`list tenant: ${argv.tenant} tenant_slug: ${argv.tenant_slug}`);
+  try {
+    await Init();
+
+    var res = await elvlv.list({
+      tenantId: argv.tenant,
+      tenantSlug: argv.tenant_slug,
+    });
+
+    console.log(yaml.dump(res));
+  } catch (e) {
+    console.error(e);
+  }
+};
 
 yargs(hideBin(process.argv))
+  .command(
+    "nft_add_contract <library> <object> <tenant> [minthelper] [cap] [name] [symbol] [nftaddr] [hold]",
+    "Add a new or existing NFT contract to an NFT Template object",
+    (yargs) => {
+      yargs
+        .positional("library", {
+          describe: "NFT Template library ID",
+          type: "string",
+        })
+        .positional("object", {
+          describe: "NFT Template object ID",
+          type: "string",
+        })
+        .positional("tenant", {
+          describe: "Tenant ID",
+          type: "string",
+        })
+        .option("minthelper", {
+          describe: "Mint helper address (hex)",
+          type: "string",
+        })
+        .option("minter", {
+          describe: "Minter address (hex)",
+          type: "string",
+        })
+        .option("cap", {
+          describe: "NFT total supply cap",
+          type: "number",
+        })
+        .option("name", {
+          describe: "NFT collection name",
+          type: "string",
+        })
+        .option("symbol", {
+          describe: "NFT collection symbol",
+          type: "string",
+        })
+        .option("nftaddr", {
+          describe: "NFT contract address (will not create a new one)",
+          type: "string",
+        })
+        .option("hold", {
+          describe: "Hold period in seconds (default 7 days)",
+          type: "number",
+        });
+    },
+    (argv) => {
+      CmfNftTemplateAddNftContract({ argv });
+    }
+  )
 
-  .command('nft_add_contract <library> <object> <tenant> [minthelper] [cap] [name] [symbol] [nftaddr] [hold]',
-		   'Add a new or existing NFT contract to an NFT Template object', (yargs) => {
-			 yargs
-			   .positional('library', {
-				 describe: 'NFT Template library ID',
-				 type: 'string'
-			   })
-			   .positional('object', {
-				 describe: 'NFT Template object ID',
-				 type: 'string'
-			   })
-			   .positional('tenant', {
-				 describe: "Tenant ID",
-				 type: 'string'
-			   })
-			   .option('minthelper', {
-				 describe: "Mint helper address (hex)",
-				 type: 'string'
-			   })
-			   .option('minter', {
-				 describe: "Minter address (hex)",
-				 type: 'string'
-			   })
-			   .option('cap', {
-				 describe: "NFT total supply cap",
-				 type: 'number'
-			   })
-			   .option('name', {
-				 describe: "NFT collection name",
-				 type: 'string'
-			   })
-			   .option('symbol', {
-				 describe: "NFT collection symbol",
-				 type: 'string'
-			   })
-			   .option('nftaddr', {
-				 describe: "NFT contract address (will not create a new one)",
-				 type: 'string'
-			   })
-			   .option('hold', {
-				 describe: "Hold period in seconds (default 7 days)",
-				 type: 'number'
-			   })
-		   }, (argv) => {
+  .command(
+    "nft_add_minter <addr> <minter>",
+    "Add a new or existing NFT contract to an NFT Template object",
+    (yargs) => {
+      yargs
+        .positional("addr", {
+          describe: "NFT address (hex)",
+          type: "string",
+        })
+        .option("minter", {
+          describe: "Minter or mint helper address (hex)",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmfNftAddMintHelper({ argv });
+    }
+  )
 
-			 CmfNftTemplateAddNftContract({argv});
+  .command(
+    "nft_set_proxy <addr> [proxy_addr]",
+    "Set a proxy on an NFT contract",
+    (yargs) => {
+      yargs
+        .positional("addr", {
+          describe: "NFT address (hex)",
+          type: "string",
+        })
+        .option("proxy_addr", {
+          describe: "Proxy contract address (hex)",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmfNftSetProxy({ argv });
+    }
+  )
 
-		   })
+  .command(
+    "nft_balance_of <addr> <owner>",
+    "Call NFT ownerOf - determine if this is an owner",
+    (yargs) => {
+      yargs
+        .positional("addr", {
+          describe: "NFT address (hex)",
+          type: "string",
+        })
+        .positional("owner", {
+          describe: "Owner address to check (hex)",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdNftBalanceOf({ argv });
+    }
+  )
 
-  .command('nft_add_minter <addr> <minter>',
-		   'Add a new or existing NFT contract to an NFT Template object', (yargs) => {
-			 yargs
-			   .positional('addr', {
-				 describe: 'NFT address (hex)',
-				 type: 'string'
-			   })
-			   .option('minter', {
-				 describe: "Minter or mint helper address (hex)",
-				 type: 'string'
-			   })
-		   }, (argv) => {
+  .command(
+    "nft_show <addr>",
+    "Show info on this NFT",
+    (yargs) => {
+      yargs
+        .positional("addr", {
+          describe: "NFT address (hex)",
+          type: "string",
+        })
+        .option("check_minter", {
+          describe: "Check that all NFTs use this mint helper",
+        })
+        .option("show_owners", {
+          describe: "Show up to these many owners (default 0)",
+          type: "integer",
+        });
+    },
+    (argv) => {
+      CmdNftShow({ argv });
+    }
+  )
 
-			 CmfNftAddMintHelper({argv});
+  .command(
+    "nft_proxy_transfer <addr> <token_id> <from_addr> <to_addr>",
+    "Tranfer NFT as a proxy owner",
+    (yargs) => {
+      yargs
+        .positional("addr", {
+          describe: "NFT address (hex)",
+          type: "string",
+        })
+        .positional("token_id", {
+          describe: "NFT address (hex)",
+          type: "integer",
+        })
+        .positional("from_addr", {
+          describe: "Address to transfer from (hex)",
+          type: "string",
+        })
+        .positional("to_addr", {
+          describe: "Address to transfer to (hex)",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdNftProxyTransfer({ argv });
+    }
+  )
 
-		   })
+  .command(
+    "nft_build <library> <object>",
+    "Build the public/nft section based on asset metadata",
+    (yargs) => {
+      yargs
+        .positional("library", {
+          describe: "Content library",
+          type: "string",
+        })
+        .positional("object", {
+          describe: "Content object hash (hq__) or id (iq__)",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdNftBuild({ argv });
+    }
+  )
 
-  .command('nft_set_proxy <addr> [proxy_addr]',
-		   'Set a proxy on an NFT contract', (yargs) => {
-			 yargs
-			   .positional('addr', {
-				 describe: 'NFT address (hex)',
-				 type: 'string'
-			   })
-			   .option('proxy_addr', {
-				 describe: "Proxy contract address (hex)",
-				 type: 'string'
-			   })
-		   }, (argv) => {
+  .command(
+    "nft_lookup <addr> <token_id>",
+    "Decode and look up a local NFT by external token ID",
+    (yargs) => {
+      yargs
+        .positional("addr", {
+          describe: "Local NFT contract address",
+          type: "string",
+        })
+        .positional("token_id", {
+          describe: "External token ID",
+          type: "string", // BigNumber as string
+        });
+    },
+    (argv) => {
+      CmdNftLookup({ argv });
+    }
+  )
 
-			 CmfNftSetProxy({argv});
+  .command(
+    "tenant_show <tenant> <library> <object> [event] [marketplace]",
+    "Show info on this tenant",
+    (yargs) => {
+      yargs
+        .positional("tenant", {
+          describe: "Tenant ID",
+          type: "string",
+        })
+        .positional("library", {
+          describe: "Tenant-level EluvioLive library",
+          type: "string",
+        })
+        .positional("object", {
+          describe: "Tenant-level EluvioLive object ID",
+          type: "string",
+        })
+        .option("event", {
+          describe: "Event ID",
+          type: "string",
+        })
+        .option("marketplace", {
+          describe: "Marketplace ID",
+          type: "string",
+        })
+        .option("check_cauth", {
+          describe:
+            "Check that all NFTs use this minter address in ikms format",
+          type: "string",
+        })
+        .option("check_minter", {
+          describe: "Check that all NFTs use this mint helper",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdTenantShow({ argv });
+    }
+  )
 
-		   })
+  .command(
+    "tenant_balance_of <tenant> <owner>",
+    "Show NFTs owned by this owner in this tenant",
+    (yargs) => {
+      yargs
+        .positional("tenant", {
+          describe: "Tenant ID",
+          type: "string",
+        })
+        .positional("owner", {
+          describe: "Owner address (hex)",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdTenantBalanceOf({ argv });
+    }
+  )
 
+  .command(
+    "fabric_tenant_balance_of <object> <owner>",
+    "Show NFTs owned by this owner in this tenant",
+    (yargs) => {
+      yargs
+        .positional("object", {
+          describe: "Tenant-level EluvioLive object ID",
+          type: "string",
+        })
+        .positional("owner", {
+          describe: "Owner address (hex)",
+          type: "string",
+        })
+        .option("max_results", {
+          describe: "Show up to these many results (default 0)",
+          type: "integer",
+        });
+    },
+    (argv) => {
+      CmdFabricTenantBalanceOf({ argv });
+    }
+  )
 
-  .command('nft_balance_of <addr> <owner>',
-		   'Call NFT ownerOf - determine if this is an owner', (yargs) => {
-			 yargs
-			   .positional('addr', {
-				 describe: 'NFT address (hex)',
-				 type: 'string'
-			   })
-			   .positional('owner', {
-				 describe: 'Owner address to check (hex)',
-				 type: 'string'
-			   })
-		   }, (argv) => {
+  .command(
+    "site_show <library> <object>",
+    "Show info on this site/event",
+    (yargs) => {
+      yargs
+        .positional("library", {
+          describe: "Site library",
+          type: "string",
+        })
+        .positional("object", {
+          describe: "Site object ID",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdSiteShow({ argv });
+    }
+  )
 
-			 CmdNftBalanceOf({argv});
+  .command(
+    "site_set_drop <library> <object> <uuid> <start_date> [options]",
+    "Set drop dates for a site/event",
+    (yargs) => {
+      yargs
+        .positional("library", {
+          describe: "Site library",
+          type: "string",
+        })
+        .positional("object", {
+          describe: "Site object ID",
+          type: "string",
+        })
+        .positional("uuid", {
+          describe: "Drop UUID",
+          type: "string",
+        })
+        .positional("start_date", {
+          describe: "Event start date (ISO format)",
+          type: "string",
+        })
+        .option("end_date", {
+          describe: "Event end date (ISO format)",
+          type: "string",
+        })
+        .option("end_vote", {
+          describe: "Event vote end date (ISO foramt)",
+          type: "string",
+        })
+        .option("start_mint", {
+          describe: "Event start mint date (ISO format)",
+          type: "string",
+        })
+        .option("new_uuid", {
+          describe: "Assign a new UUID",
+          type: "boolean",
+        })
+        .option("update", {
+          describe: "Tenant-level EluvioLive object to update",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdSiteSetDrop({ argv });
+    }
+  )
 
-		   })
+  .command(
+    "shuffle <file> [options]",
+    "Sort each line deterministically based on the seed",
+    (yargs) => {
+      yargs
+        .positional("file", {
+          describe: "File or directory path",
+          type: "string",
+        })
+        .option("seed", {
+          describe:
+            "Determines the order. If no seed is provided, the shuffler uses a random one.",
+          type: "string",
+        })
+        .option("check_dupes", {
+          describe: "Abort if duplicate is found",
+          type: "boolean",
+        })
+        .option("print_js", {
+          describe: "Print result as an array in JavaScript",
+          type: "boolean",
+        });
+    },
+    (argv) => {
+      CmdShuffle({ argv });
+    }
+  )
 
-  .command('nft_show <addr>',
-		   'Show info on this NFT', (yargs) => {
-			 yargs
-			   .positional('addr', {
-				 describe: 'NFT address (hex)',
-                 type: 'string'
-               })
-               .option('check_minter', {
-                 describe: 'Check that all NFTs use this mint helper',
-			   })
-               .option('show_owners', {
-				 describe: 'Show up to these many owners (default 0)',
-				 type: 'integer'
-			   })
-		   }, (argv) => {
+  .command(
+    "tenant_mint <tenant> <marketplace> <sku> <addr>",
+    "Mint a marketplace NFT by SKU as tenant admin",
+    (yargs) => {
+      yargs
+        .positional("tenant", {
+          describe: "Tenant ID",
+          type: "string",
+        })
+        .positional("marketplace", {
+          describe: "Marketplace ID",
+          type: "string",
+        })
+        .positional("sku", {
+          describe: "NFT marketplace SKU",
+          type: "string",
+        })
+        .positional("addr", {
+          describe: "Target address to mint to",
+          type: "string",
+        });
+    },
+    (argv) => {
+      TenantMint({ argv });
+    }
+  )
 
-			 CmdNftShow({argv});
-
-		   })
-
-  .command('nft_proxy_transfer <addr> <token_id> <from_addr> <to_addr>',
-		   'Tranfer NFT as a proxy owner', (yargs) => {
-			 yargs
-			   .positional('addr', {
-				 describe: 'NFT address (hex)',
-                 type: 'string'
-               })
-			   .positional('token_id', {
-				 describe: 'NFT address (hex)',
-                 type: 'integer'
-               })
-			   .positional('from_addr', {
-				 describe: 'Address to transfer from (hex)',
-                 type: 'string'
-               })
-			   .positional('to_addr', {
-				 describe: 'Address to transfer to (hex)',
-                 type: 'string'
-               })
-		   }, (argv) => {
-
-			 CmdNftProxyTransfer({argv});
-
-		   })
-
-  .command('nft_build <library> <object>',
-		   'Build the public/nft section based on asset metadata', (yargs) => {
-			 yargs
-			   .positional('library', {
-				 describe: 'Content library',
-				 type: 'string'
-			   })
-			   .positional('object', {
-				 describe: 'Content object hash (hq__) or id (iq__)',
-				 type: 'string'
-			   })
-		   }, (argv) => {
-
-			 CmdNftBuild({argv});
-
-		   })
-
-  .command('nft_lookup <addr> <token_id>',
-		   'Decode and look up a local NFT by external token ID', (yargs) => {
-			 yargs
-			   .positional('addr', {
-				 describe: 'Local NFT contract address',
-				 type: 'string'
-			   })
-			   .positional('token_id', {
-				 describe: 'External token ID',
-				 type: 'string' // BigNumber as string
-			   })
-		   }, (argv) => {
-
-			 CmdNftLookup({argv});
-
-		   })
-
-  .command('tenant_show <tenant> <library> <object> [event] [marketplace]',
-		   'Show info on this tenant', (yargs) => {
-			 yargs
-			   .positional('tenant', {
-				 describe: 'Tenant ID',
-				 type: 'string'
-			   })
-			   .positional('library', {
-				 describe: 'Tenant-level EluvioLive library',
-				 type: 'string'
-			   })
-			   .positional('object', {
-				 describe: 'Tenant-level EluvioLive object ID',
-				 type: 'string'
-			   })
-			   .option('event', {
-				 describe: 'Event ID',
-				 type: 'string'
-			   })
-			   .option('marketplace', {
-				 describe: 'Marketplace ID',
-				 type: 'string'
-			   })
-			   .option('check_cauth', {
-				 describe: 'Check that all NFTs use this minter address in ikms format',
-				 type: 'string'
-			   })
-			   .option('check_minter', {
-				 describe: 'Check that all NFTs use this mint helper',
-				 type: 'string'
-			   })
-
-		   }, (argv) => {
-
-			 CmdTenantShow({argv});
-
-		   })
-
-  .command('tenant_balance_of <tenant> <owner>',
-		   'Show NFTs owned by this owner in this tenant', (yargs) => {
-			 yargs
-			   .positional('tenant', {
-						describe: 'Tenant ID',
-						type: 'string'
-			   })
-			   .positional('owner', {
-						describe: 'Owner address (hex)',
-						type: 'string'
-			   })
-		   }, (argv) => {
-
-			 CmdTenantBalanceOf({argv});
-
-		   })
-
-	.command('fabric_tenant_balance_of <object> <owner>',
-		  'Show NFTs owned by this owner in this tenant', (yargs) => {
-			yargs
-				.positional('object', {
-					describe: 'Tenant-level EluvioLive object ID',
-					type: 'string'
-				})
-				.positional('owner', {
-					describe: 'Owner address (hex)',
-					type: 'string'
-				})
-				.option('max_results', {
-					describe: 'Show up to these many results (default 0)',
-					type: 'integer'
-				})
-		   }, (argv) => {
-
-			 CmdFabricTenantBalanceOf({argv});
-
-	})
-
-  .command('site_show <library> <object>',
-		   'Show info on this site/event', (yargs) => {
-			 yargs
-			   .positional('library', {
-				 describe: 'Site library',
-				 type: 'string'
-			   })
-			   .positional('object', {
-				 describe: 'Site object ID',
-				 type: 'string'
-			   })
-		   }, (argv) => {
-
-			 CmdSiteShow({argv});
-
-		   })
-
-  .command('site_set_drop <library> <object> <uuid> <start_date> [options]',
-		   'Set drop dates for a site/event', (yargs) => {
-			 yargs
-			   .positional('library', {
-				 describe: 'Site library',
-				 type: 'string'
-			   })
-			   .positional('object', {
-				 describe: 'Site object ID',
-				 type: 'string'
-			   })
-			   .positional('uuid', {
-				 describe: 'Drop UUID',
-				 type: 'string'
-			   })
-			   .positional('start_date', {
-				 describe: 'Event start date (ISO format)',
-				 type: 'string'
-			   })
-			   .option('end_date', {
-				 describe: 'Event end date (ISO format)',
-				 type: 'string'
-			   })
-			   .option('end_vote', {
-				 describe: 'Event vote end date (ISO foramt)',
-				 type: 'string'
-			   })
-			   .option('start_mint', {
-				 describe: 'Event start mint date (ISO format)',
-				 type: 'string'
-			   })
-			   .option('new_uuid', {
-				 describe: 'Assign a new UUID',
-				 type: 'boolean'
-			   })
-			   .option('update', {
-				 describe: 'Tenant-level EluvioLive object to update',
-				 type: 'string'
-			   })
-
-		   }, (argv) => {
-
-			 CmdSiteSetDrop({argv});
-
-		   })
-
-    .command('shuffle <file> [options]',
-		'Sort each line deterministically based on the seed', (yargs) => {
-			yargs
-				.positional('file', {
-					describe: 'File or directory path',
-					type: 'string'
-				})
-				.option('seed', {
-					describe: 'Determines the order. If no seed is provided, the shuffler uses a random one.',
-					type: 'string'
-				})
-				.option('check_dupes', {
-					describe: 'Abort if duplicate is found',
-					type: 'boolean'
-				})
-				.option('print_js', {
-					describe: 'Print result as an array in JavaScript',
-					type: 'boolean'
-				})
-		}, (argv) => {
-			CmdShuffle({argv});
-		})
-
-    .command('tenant_mint <tenant> <marketplace> <sku> <addr>',
-	    'Mint a marketplace NFT by SKU as tenant admin', (yargs) => {
-		  yargs
-			.positional('tenant', {
-			  describe: 'Tenant ID',
-			  type: 'string'
-			})
-			.positional('marketplace', {
-			  describe: 'Marketplace ID',
-			  type: 'string'
-			})
-			.positional('sku', {
-			  describe: 'NFT marketplace SKU',
-			  type: 'string'
-			})
-			.positional('addr', {
-			  describe: 'Target address to mint to',
-			  type: 'string'
-			})
-		}, (argv) => {
-			TenantMint({argv});
-		})
-
-		.command('list [options]',
-		'List the Eluvio Live Tenants', (yargs) => {
-			yargs
-				.option('tenant', {
-					describe: 'Show the tenant based on id. Eg. itenXXX...',
-					type: 'string'
-				})
-				.option('tenant_slug', {
-					describe: 'Show the tenant based on slug. Eg. elv-live',
-					type: 'string'
-				})
-		}, (argv) => {
-			CmdList({argv});
-		})
+  .command(
+    "list [options]",
+    "List the Eluvio Live Tenants",
+    (yargs) => {
+      yargs
+        .option("tenant", {
+          describe: "Show the tenant based on id. Eg. itenXXX...",
+          type: "string",
+        })
+        .option("tenant_slug", {
+          describe: "Show the tenant based on slug. Eg. elv-live",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdList({ argv });
+    }
+  )
 
   .help()
-  .usage('EluvioLive CLI\n\nUsage: elv-live <command>')
-  .scriptName('')
-  .demandCommand(1)
-  .argv
+  .usage("EluvioLive CLI\n\nUsage: elv-live <command>")
+  .scriptName("")
+  .demandCommand(1).argv;
 
 // For unit testing
-exports.CmdShuffle = CmdShuffle
+exports.CmdShuffle = CmdShuffle;

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -262,6 +262,21 @@ const CmdShuffle = async ({argv}) => {
 	}
 }
 
+const CmdList = async ({argv}) => {
+	console.log("list ", argv.tenant);
+  try{
+		await Init();
+		
+		var res = await elvlv.list({
+			tenantId: argv.tenant
+		})
+		
+		console.log(yaml.dump(res));
+	}catch(e){
+		console.error(e);
+	}
+}
+
 yargs(hideBin(process.argv))
 
   .command('nft_add_contract <library> <object> <tenant> [minthelper] [cap] [name] [symbol] [nftaddr] [hold]',
@@ -604,6 +619,17 @@ yargs(hideBin(process.argv))
 				})
 		}, (argv) => {
 			CmdShuffle({argv});
+		})
+
+		.command('list [options]',
+		'List the whole eluvio media platform', (yargs) => {
+			yargs
+				.option('tenant', {
+					describe: 'The tenant ID branch to show.',
+					type: 'string'
+				})
+		}, (argv) => {
+			CmdList({argv});
 		})
 
   .help()

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -263,12 +263,13 @@ const CmdShuffle = async ({argv}) => {
 }
 
 const CmdList = async ({argv}) => {
-	console.log("list ", argv.tenant);
+	console.log("list ",argv.tenant, argv.tenant_slug);
   try{
 		await Init();
 		
 		var res = await elvlv.list({
-			tenantId: argv.tenant
+			tenantId: argv.tenant,
+			tenantSlug:argv.tenant_slug
 		})
 		
 		console.log(yaml.dump(res));
@@ -625,7 +626,11 @@ yargs(hideBin(process.argv))
 		'List the whole eluvio media platform', (yargs) => {
 			yargs
 				.option('tenant', {
-					describe: 'The tenant ID branch to show.',
+					describe: 'The tenant ID branch to show. Eg. itenXXX...',
+					type: 'string'
+				})
+				.option('tenant_slug', {
+					describe: 'The tenant url id branch to show. A url id is a dash separated human readable identifier for web paths. Eg. elv-live',
 					type: 'string'
 				})
 		}, (argv) => {


### PR DESCRIPTION
Implemented 2 versions which should return the same results:

`./elv-live list --tenant iten2Fd7H46YFSzP4UaBDhiQEUBHTnEt`
`./elv-live list --tenant_slug sony-live`

Result:
 ```
Network: demov3
.:
  source: >-
    hq__Cg96m7c94PL922s33dpfv87hsdsiJaoPaFF1z7CtcFjhm7Me5PEnZkFStkZx12eeJKvLMNRCcP
asset_type: primary
collections: {}
display_title: SONY Live
images: {}
info:
  copyright: ''
  logo: null
  name: SONY Live
  privacy_policy: ''
  privacy_policy_html: null
  talent: {}
  terms: ''
  terms_html: null
marketplaces:
  spiderman-marketplace:
    .:
      source: >-
        hq__75NZUZSudYQD5XTM8Fb4svvVjfg8Qj52BpRmX5MbbKchbuNrw55TtsWVW3dZMCVNnsBUwZd7eb
    asset_type: primary
    display_title: Spiderman Marketplace
    images: {}
    info:
```

TODO later we want to make marketplaces and sites more concise (just an array of slugs maybe?), and then add --marketplace and --site




 