### PR TITLE
Add tenant_primary_sales and tenant_secondary_sales

### DIFF
--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -1289,10 +1289,9 @@ Lookup NFT: https://wallet.contentfabric.io/lookup/`; */
     return res;
   }
 
-  async GetServiceRequest({ path, limit = Number.MAX_SAFE_INTEGER }) {
+  async GetServiceRequest({ path, limit }) {
     let ts = Date.now();
-    //var newPath = urljoin(path,`?ts=${now}`);
-    var newPath = path + `?ts=${ts}` + `&limit=${limit}`;
+    var newPath = !limit? path + `?ts=${ts}` : path + `?ts=${ts}` + `&limit=${limit}`;
 
     const { multiSig } = await this.Sign({
       message: newPath,
@@ -1304,7 +1303,7 @@ Lookup NFT: https://wallet.contentfabric.io/lookup/`; */
       headers: {
         Authorization: `Bearer ${multiSig}`,
       },
-      queryParams: { ts, limit },
+      queryParams: !limit? {ts} : { ts, limit },
     });
 
     return await res.json();
@@ -1438,6 +1437,105 @@ Lookup NFT: https://wallet.contentfabric.io/lookup/`; */
 
     results.warns = warns;
 
+    return results;
+  }
+
+  /**
+   * Get primary sales history for the tenant
+   *
+   * @namedParams
+   * @param {string} tenant - The Tenant ID
+   * @param {string} marketplace - The marketplace ID
+   * @return {Promise<Object>} - The API Response containing primary sales info
+   */
+  async TenantPrimarySales({ tenant, marketplace}) {
+    let results = {};
+    let warns = [];
+    
+    let processor = "stripe";
+    let res = null;
+    try {
+      res = await this.GetServiceRequest({
+        path: urljoin("/tnt/purchases/", tenant, marketplace,processor)
+      });
+
+      results[processor] = res;
+    } catch (e){
+      warns.push(e);
+    }
+    
+    processor = "coinbase";
+    try {
+      res = await this.GetServiceRequest({
+        path: urljoin("/tnt/purchases/", tenant, marketplace,processor)
+      });
+
+      results[processor] = res;
+    } catch (e){
+      warns.push(e);
+    }
+    
+    processor = "eluvio";
+    try {
+      res = await this.GetServiceRequest({
+        path: urljoin("/tnt/purchases/", tenant, marketplace,processor)
+      });
+
+      results[processor] = res;
+    } catch (e){
+      warns.push(e);
+    }
+
+    results.warns = warns;
+    return results;
+  }
+
+  /**
+   * Get primary sales history for the tenant
+   *
+   * @namedParams
+   * @param {string} tenant - The Tenant ID
+   * @return {Promise<Object>} - The API Response containing primary sales info
+   */
+  async TenantSecondarySales({ tenant }) {
+    let results = {};
+    let warns = [];
+    
+    let processor = "stripe";
+    let res = null;
+    try {
+      res = await this.GetServiceRequest({
+        path: urljoin("/tnt/payments/", tenant,processor)
+      });
+
+      results[processor] = res;
+    } catch (e){
+      warns.push(e);
+    }
+    
+    processor = "coinbase";
+    try {
+      res = await this.GetServiceRequest({
+        path: urljoin("/tnt/payments/", tenant,processor)
+      });
+
+      results[processor] = res;
+    } catch (e){
+      warns.push(e);
+    }
+    
+    processor = "eluvio";
+    try {
+      res = await this.GetServiceRequest({
+        path: urljoin("/tnt/payments/", tenant,processor)
+      });
+
+      results[processor] = res;
+    } catch (e){
+      warns.push(e);
+    }
+
+    results.warns = warns;
     return results;
   }
 

--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -1309,6 +1309,26 @@ Lookup NFT: https://wallet.contentfabric.io/lookup/`; */
     return await res.json();
   }
 
+  async GetDumpRequest({ path, offset }) {
+    let ts = Date.now();
+    var newPath = path + `?ts=${ts}` + `&offset=${offset}`;
+
+    const { multiSig } = await this.Sign({
+      message: newPath,
+    });
+
+    let res = await this.client.authClient.MakeAuthServiceRequest({
+      method: "GET",
+      path: urljoin("/as", path),
+      headers: {
+        Authorization: `Bearer ${multiSig}`,
+      },
+      queryParams: { ts, offset },
+    });
+
+    return await res.json();
+  }
+
   /**
    * Mint an NFT using Tenant Auth
    *
@@ -1448,37 +1468,39 @@ Lookup NFT: https://wallet.contentfabric.io/lookup/`; */
    * @param {string} marketplace - The marketplace ID
    * @return {Promise<Object>} - The API Response containing primary sales info
    */
-  async TenantPrimarySales({ tenant, marketplace}) {
+  async TenantPrimarySales({ tenant, marketplace, offset }) {
     let results = {};
     let warns = [];
-    
     let processor = "stripe";
     let res = null;
     try {
-      res = await this.GetServiceRequest({
-        path: urljoin("/tnt/purchases/", tenant, marketplace,processor)
+      res = await this.GetDumpRequest({
+        path: urljoin("/tnt/purchases/", tenant, marketplace, processor),
+        offset: offset,
       });
 
       results[processor] = res;
     } catch (e){
       warns.push(e);
     }
-    
+
     processor = "coinbase";
     try {
-      res = await this.GetServiceRequest({
-        path: urljoin("/tnt/purchases/", tenant, marketplace,processor)
+      res = await this.GetDumpRequest({
+        path: urljoin("/tnt/purchases/", tenant, marketplace, processor),
+        offset: offset,
       });
 
       results[processor] = res;
     } catch (e){
       warns.push(e);
     }
-    
+
     processor = "eluvio";
     try {
-      res = await this.GetServiceRequest({
-        path: urljoin("/tnt/purchases/", tenant, marketplace,processor)
+      res = await this.GetDumpRequest({
+        path: urljoin("/tnt/purchases/", tenant, marketplace, processor),
+        offset: offset,
       });
 
       results[processor] = res;
@@ -1497,37 +1519,40 @@ Lookup NFT: https://wallet.contentfabric.io/lookup/`; */
    * @param {string} tenant - The Tenant ID
    * @return {Promise<Object>} - The API Response containing primary sales info
    */
-  async TenantSecondarySales({ tenant }) {
+  async TenantSecondarySales({ tenant, offset }) {
     let results = {};
     let warns = [];
-    
+
     let processor = "stripe";
     let res = null;
     try {
-      res = await this.GetServiceRequest({
-        path: urljoin("/tnt/payments/", tenant,processor)
+      res = await this.GetDumpRequest({
+        path: urljoin("/tnt/payments/", tenant, processor),
+        offset: offset,
       });
 
       results[processor] = res;
     } catch (e){
       warns.push(e);
     }
-    
+
     processor = "coinbase";
     try {
-      res = await this.GetServiceRequest({
-        path: urljoin("/tnt/payments/", tenant,processor)
+      res = await this.GetDumpRequest({
+        path: urljoin("/tnt/payments/", tenant, processor),
+        offset: offset,
       });
 
       results[processor] = res;
     } catch (e){
       warns.push(e);
     }
-    
+
     processor = "eluvio";
     try {
-      res = await this.GetServiceRequest({
-        path: urljoin("/tnt/payments/", tenant,processor)
+      res = await this.GetDumpRequest({
+        path: urljoin("/tnt/payments/", tenant, processor),
+        offset: offset,
       });
 
       results[processor] = res;

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -330,35 +330,53 @@ const CmdList = async ({ argv }) => {
 };
 
 const CmdTenantPrimarySales = async ({ argv }) => {
-  console.log(`Tenant Primary Sales: ${argv.tenant} ${argv.marketplace}`);
-  console.log(`Offset: ${argv.offset}`)
+  console.log(
+    `Tenant Primary Sales: ${argv.tenant} ${argv.marketplace} ${argv.processor}`
+  );
+  console.log(`Offset: ${argv.offset}`);
+  console.log(`CSV: ${argv.csv}`);
+
   try {
     await Init();
 
     let res = await elvlv.TenantPrimarySales({
       tenant: argv.tenant,
       marketplace: argv.marketplace,
+      processor: argv.processor,
+      csv: argv.csv,
       offset: argv.offset,
     });
 
-    console.log(yaml.dump(res));
+    if (argv.csv && argv.csv != "") {
+      fs.writeFileSync(argv.csv, res);
+    } else {
+      console.log(yaml.dump(res));
+    }
   } catch (e) {
     console.error("ERROR:", e);
   }
 };
 
 const CmdTenantSecondarySales = async ({ argv }) => {
-  console.log(`Tenant Secondary Sales: ${argv.tenant}`);
-  console.log(`Offset: ${argv.offset}`)
+  console.log(`Tenant Secondary Sales: ${argv.tenant} ${argv.processor}`);
+  console.log(`Offset: ${argv.offset}`);
+  console.log(`CSV: ${argv.csv}`);
+
   try {
     await Init();
 
     let res = await elvlv.TenantSecondarySales({
       tenant: argv.tenant,
+      processor: argv.processor,
+      csv: argv.csv,
       offset: argv.offset,
     });
 
-    console.log(yaml.dump(res));
+    if (argv.csv && argv.csv != "") {
+      fs.writeFileSync(argv.csv, res);
+    } else {
+      console.log(yaml.dump(res));
+    }
   } catch (e) {
     console.error("ERROR:", e);
   }
@@ -847,7 +865,7 @@ yargs(hideBin(process.argv))
   )
 
   .command(
-    "tenant_primary_sales <tenant> <marketplace>",
+    "tenant_primary_sales <tenant> <marketplace> <processor>",
     "Show tenant primary sales history",
     (yargs) => {
       yargs
@@ -857,6 +875,14 @@ yargs(hideBin(process.argv))
         })
         .positional("marketplace", {
           describe: "Marketplace ID",
+          type: "string",
+        })
+        .positional("processor", {
+          describe: "Payment processor: eg. stripe, coinbase, eluvio",
+          type: "string",
+        })
+        .option("csv", {
+          describe: "File path to output csv",
           type: "string",
         })
         .option("offset", {
@@ -872,12 +898,20 @@ yargs(hideBin(process.argv))
   )
 
   .command(
-    "tenant_secondary_sales <tenant>",
+    "tenant_secondary_sales <tenant> <processor>",
     "Show tenant secondary sales history",
     (yargs) => {
       yargs
         .positional("tenant", {
           describe: "Tenant ID",
+          type: "string",
+        })
+        .positional("processor", {
+          describe: "Payment processor: eg. stripe, coinbase, eluvio",
+          type: "string",
+        })
+        .option("csv", {
+          describe: "File path to output csv",
           type: "string",
         })
         .option("offset", {

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -330,15 +330,15 @@ const CmdList = async ({ argv }) => {
 };
 
 const CmdTenantPrimarySales = async ({ argv }) => {
-  console.log(
-    `Tenant Primary Sales: ${argv.tenant} ${argv.marketplace}`
-  );
+  console.log(`Tenant Primary Sales: ${argv.tenant} ${argv.marketplace}`);
+  console.log(`Offset: ${argv.offset}`)
   try {
     await Init();
 
     let res = await elvlv.TenantPrimarySales({
       tenant: argv.tenant,
       marketplace: argv.marketplace,
+      offset: argv.offset,
     });
 
     console.log(yaml.dump(res));
@@ -348,14 +348,14 @@ const CmdTenantPrimarySales = async ({ argv }) => {
 };
 
 const CmdTenantSecondarySales = async ({ argv }) => {
-  console.log(
-    `Tenant Secondary Sales: ${argv.tenant}`
-  );
+  console.log(`Tenant Secondary Sales: ${argv.tenant}`);
+  console.log(`Offset: ${argv.offset}`)
   try {
     await Init();
 
     let res = await elvlv.TenantSecondarySales({
-      tenant: argv.tenant
+      tenant: argv.tenant,
+      offset: argv.offset,
     });
 
     console.log(yaml.dump(res));
@@ -858,6 +858,12 @@ yargs(hideBin(process.argv))
         .positional("marketplace", {
           describe: "Marketplace ID",
           type: "string",
+        })
+        .option("offset", {
+          describe:
+            "Offset in months to dump data where 0 is the current month",
+          type: "number",
+          default: 1,
         });
     },
     (argv) => {
@@ -873,6 +879,12 @@ yargs(hideBin(process.argv))
         .positional("tenant", {
           describe: "Tenant ID",
           type: "string",
+        })
+        .option("offset", {
+          describe:
+            "Offset in months to dump data where 0 is the current month",
+          type: "number",
+          default: 1,
         });
     },
     (argv) => {

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -329,6 +329,41 @@ const CmdList = async ({ argv }) => {
   }
 };
 
+const CmdTenantPrimarySales = async ({ argv }) => {
+  console.log(
+    `Tenant Primary Sales: ${argv.tenant} ${argv.marketplace}`
+  );
+  try {
+    await Init();
+
+    let res = await elvlv.TenantPrimarySales({
+      tenant: argv.tenant,
+      marketplace: argv.marketplace,
+    });
+
+    console.log(yaml.dump(res));
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
+const CmdTenantSecondarySales = async ({ argv }) => {
+  console.log(
+    `Tenant Secondary Sales: ${argv.tenant}`
+  );
+  try {
+    await Init();
+
+    let res = await elvlv.TenantSecondarySales({
+      tenant: argv.tenant
+    });
+
+    console.log(yaml.dump(res));
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
 FilterListTenant = ({ tenant }) => {
   let res = {};
   res.result = {};
@@ -808,6 +843,40 @@ yargs(hideBin(process.argv))
     },
     (argv) => {
       CmdList({ argv });
+    }
+  )
+
+  .command(
+    "tenant_primary_sales <tenant> <marketplace>",
+    "Show tenant primary sales history",
+    (yargs) => {
+      yargs
+        .positional("tenant", {
+          describe: "Tenant ID",
+          type: "string",
+        })
+        .positional("marketplace", {
+          describe: "Marketplace ID",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdTenantPrimarySales({ argv });
+    }
+  )
+
+  .command(
+    "tenant_secondary_sales <tenant>",
+    "Show tenant secondary sales history",
+    (yargs) => {
+      yargs
+        .positional("tenant", {
+          describe: "Tenant ID",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdTenantSecondarySales({ argv });
     }
   )
 

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -925,7 +925,7 @@ yargs(hideBin(process.argv))
       CmdTenantSecondarySales({ argv });
     }
   )
-
+  .strict()
   .help()
   .usage("EluvioLive CLI\n\nUsage: elv-live <command>")
   .scriptName("")


### PR DESCRIPTION
Added:
`tenant_primary_sales <tenant> <marketplace> <processor> [options]`
`tenant_secondary_sales <tenant> <processor> [options]`

where options are --csv [FILE] and --offset [INT]

@elv-ccampbell will remove the ord from the results and maybe pagination for consitency?

Eg:
./elv-live tenant_primary_sales itenYQbgk66W1BFEqWr95xPmHZEjmdF iq__2FrA2S1XBy4zdRGQn1knakpbrBV4 stripe

```
Tenant Primary Sales: itenYQbgk66W1BFEqWr95xPmHZEjmdF iq__2FrA2S1XBy4zdRGQn1knakpbrBV4
Network: demov3
  - ord: 607
    ident: 'stripe:cus_ku905kjowd9ekv'
    trans_id: B9TZ3qtusidd7QQbZHNscj
    addr: '0x6fcffb1d00648ba6777e8e0398410b973665e2e2'
    name: Consolation Pack - Week 1
    sku: L5Nvg13DgjUJsVGgnrZ9d3
    quantity: 1
    status: complete
    ts: 1641332342
```
./elv-live tenant_secondary_sales itenYQbgk66W1BFEqWr95xPmHZEjmdF
```
Tenant Secondary Sales: itenYQbgk66W1BFEqWr95xPmHZEjmdF
Network: demov3
  - id: 8f049a53-6069-461a-8977-2281bd2605db
    addr: '0x3c48a30fc0085e63db0d88d46551435b7ba5fd37'
    buyer: '0xfdfe04a3826d742be4f46f867e9299b14be292c5'
    amount: 90
    royalty: 10
    fee: 5
    currency: USD
    item: 234ab22a-b8cb-46d4-a0cf-c4d3c85005e9
    processor: 'stripe:cus_KuwecWXSabRFpk'
    processed_at: 1641517002
    created: 1641517017
    extra_json:
      trans_id: T-59jdD5chTGrvU64dLaDsEs
    name: Test - S01 Peacock

```
