### PR TITLE
Add tenant, account_name, funds to create_account

### DIFF
--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -43,7 +43,7 @@ class EluvioLive {
     this.client.ToggleLogging(false);
   }
 
-  async CreateAccount({ funds = 0.1, accountName, tenantId }) {
+  async CreateAccount({ funds = 0.25, accountName, tenantId }) {
     if (!this.client) {
       throw Error("EluvioLive not intialized");
     }

--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -43,6 +43,16 @@ class EluvioLive {
     this.client.ToggleLogging(false);
   }
 
+  /**
+   * Creates a new account including wallet object and contract.
+   * Current client must be initialized and funded.
+   *
+   * @namedParams
+   * @param {number} funds - The amount in ETH to fund the new account.
+   * @cauth {string} accountName - The name of the account to set in it's wallet metadata (Optional)
+   * @cauth {string} tenantId - The tenant ID to set for the user's wallet (Optional)
+   * @return {Promise<Object>} - An object containing the new account mnemonic, privateKey, address, accountName, balance
+   */
   async CreateAccount({ funds = 0.25, accountName, tenantId }) {
     if (!this.client) {
       throw Error("EluvioLive not intialized");
@@ -79,6 +89,23 @@ class EluvioLive {
 
     let balance = await wallet.GetAccountBalance({ signer });
     return { mnemonic, privateKey, address, accountName, balance };
+  }
+
+  /**
+   * Show info about this account.
+   */
+  async AccountShow() {
+    if (!this.client) {
+      throw Error("EluvioLive not intialized");
+    }
+
+    let tenantId = await this.client.userProfileClient.TenantId();
+    let walletAddress = await this.client.userProfileClient.WalletAddress();
+    let userWalletObject =
+      await this.client.userProfileClient.UserWalletObjectInfo();
+    let userMetadata = await this.client.userProfileClient.UserMetadata();
+
+    return { tenantId, walletAddress, userWalletObject, userMetadata };
   }
 
   /**

--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -50,10 +50,10 @@ class EluvioLive {
    * @namedParams
    * @param {number} funds - The amount in ETH to fund the new account.
    * @cauth {string} accountName - The name of the account to set in it's wallet metadata (Optional)
-   * @cauth {string} tenantId - The tenant ID to set for the user's wallet (Optional)
+   * @cauth {string} tenantAdminsGroup - The tenant admins group ID to set for the user's wallet (Optional)
    * @return {Promise<Object>} - An object containing the new account mnemonic, privateKey, address, accountName, balance
    */
-  async CreateAccount({ funds = 0.25, accountName, tenantId }) {
+  async AccountCreate({ funds = 0.25, accountName, tenantAdminsId }) {
     if (!this.client) {
       throw Error("EluvioLive not intialized");
     }
@@ -76,8 +76,9 @@ class EluvioLive {
 
     await client.userProfileClient.CreateWallet();
 
-    if (tenantId) {
-      await client.userProfileClient.SetTenantId({ id: tenantId });
+    if (tenantAdminsId) {
+      await client.userProfileClient.SetTenantId({ id: tenantAdminsId });
+      tenantAdminsId = await this.client.userProfileClient.TenantId();
     }
 
     if (accountName) {
@@ -88,7 +89,14 @@ class EluvioLive {
     }
 
     let balance = await wallet.GetAccountBalance({ signer });
-    return { mnemonic, privateKey, address, accountName, balance };
+    return {
+      tenantAdminsId,
+      mnemonic,
+      privateKey,
+      address,
+      accountName,
+      balance,
+    };
   }
 
   /**
@@ -99,13 +107,13 @@ class EluvioLive {
       throw Error("EluvioLive not intialized");
     }
 
-    let tenantId = await this.client.userProfileClient.TenantId();
+    let tenantAmdinsId = await this.client.userProfileClient.TenantId();
     let walletAddress = await this.client.userProfileClient.WalletAddress();
     let userWalletObject =
       await this.client.userProfileClient.UserWalletObjectInfo();
     let userMetadata = await this.client.userProfileClient.UserMetadata();
 
-    return { tenantId, walletAddress, userWalletObject, userMetadata };
+    return { tenantAmdinsId, walletAddress, userWalletObject, userMetadata };
   }
 
   /**

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -478,17 +478,31 @@ FilterListTenant = ({ tenant }) => {
   return res;
 };
 
-// eslint-disable-next-line no-unused-vars
-const CmdCreateAccount = async ({ argv }) => {
-  console.log("Create Account\n");
+const CmdAccountCreate = async ({ argv }) => {
+  console.log("Account Create\n");
+  console.log(`funds: ${argv.funds}`);
+  console.log(`account_name: ${argv.account_name}`);
+  console.log(`tenant: ${argv.tenant}`);
 
   try {
     await Init();
     let res = await elvlv.CreateAccount({
       funds: argv.funds,
       accountName: argv.account_name,
-      tenantId: argv.tenantId,
+      tenantId: argv.tenant,
     });
+    console.log(yaml.dump(res));
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
+const CmdAccountShow = async () => {
+  console.log("Account Show\n");
+
+  try {
+    await Init();
+    let res = await elvlv.AccountShow();
     console.log(yaml.dump(res));
   } catch (e) {
     console.error("ERROR:", e);
@@ -1068,7 +1082,7 @@ yargs(hideBin(process.argv))
   )
 
   .command(
-    "create_account <funds> <account_name> <tenant>",
+    "account_create <funds> <account_name> <tenant>",
     "Create a new account -> mnemonic, address, private key",
     (yargs) => {
       yargs
@@ -1087,9 +1101,13 @@ yargs(hideBin(process.argv))
         });
     },
     (argv) => {
-      CmdCreateAccount({ argv });
+      CmdAccountCreate({ argv });
     }
   )
+
+  .command("account_show", "Shows current account information.", () => {
+    CmdAccountShow();
+  })
 
   .command(
     "tenant_nft_remove <tenant> <addr>",

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -482,14 +482,14 @@ const CmdAccountCreate = async ({ argv }) => {
   console.log("Account Create\n");
   console.log(`funds: ${argv.funds}`);
   console.log(`account_name: ${argv.account_name}`);
-  console.log(`tenant: ${argv.tenant}`);
+  console.log(`tenant_admins: ${argv.tenant_admins}`);
 
   try {
     await Init();
-    let res = await elvlv.CreateAccount({
+    let res = await elvlv.AccountCreate({
       funds: argv.funds,
       accountName: argv.account_name,
-      tenantId: argv.tenant,
+      tenantAdminsId: argv.tenant_admins,
     });
     console.log(yaml.dump(res));
   } catch (e) {
@@ -1082,7 +1082,7 @@ yargs(hideBin(process.argv))
   )
 
   .command(
-    "account_create <funds> <account_name> <tenant>",
+    "account_create <funds> <account_name> <tenant_admins>",
     "Create a new account -> mnemonic, address, private key",
     (yargs) => {
       yargs
@@ -1095,8 +1095,8 @@ yargs(hideBin(process.argv))
           describe: "Account Name",
           type: "string",
         })
-        .positional("tenant", {
-          describe: "Tenant ID",
+        .positional("tenant_admins", {
+          describe: "Tenant Admins group ID",
           type: "string",
         });
     },

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -483,11 +483,12 @@ const CmdCreateAccount = async ({ argv }) => {
   console.log("Create Account\n");
 
   try {
-    elvlv = new EluvioLive({
-      configUrl: Config.networks[Config.net],
-      mainObjectId: Config.mainObjects[Config.net],
+    await Init();
+    let res = await elvlv.CreateAccount({
+      funds: argv.funds,
+      accountName: argv.account_name,
+      tenantId: argv.tenantId,
     });
-    let res = await elvlv.InitNew();
     console.log(yaml.dump(res));
   } catch (e) {
     console.error("ERROR:", e);
@@ -1067,8 +1068,24 @@ yargs(hideBin(process.argv))
   )
 
   .command(
-    "create_account",
+    "create_account <funds> <account_name> <tenant>",
     "Create a new account -> mnemonic, address, private key",
+    (yargs) => {
+      yargs
+        .positional("funds", {
+          describe:
+            "How much to fund the new account from this private key in ETH.",
+          type: "string",
+        })
+        .positional("account_name", {
+          describe: "Account Name",
+          type: "string",
+        })
+        .positional("tenant", {
+          describe: "Tenant ID",
+          type: "string",
+        });
+    },
     (argv) => {
       CmdCreateAccount({ argv });
     }


### PR DESCRIPTION
Creates a new account with funds, account_name and tenantId.

./elv-live create_account 0.1 test iten3gVtWToi2hmCKfwxXfxtkY46HFDv
Create Account

Network: demov3
mnemonic: >-
  XXX XXX XXX
privateKey: '0xXXXXXXX'
address: '0xXXXX'
accountName: test
balance: '0.058687656'


### Also Added account_show
./elv-live account_show
Account Show

Network: demov3
tenantId: iten3gVtWToi2hmCKfwxXfxtkY46HFDv
walletAddress: '0xa1d85Bb5bD07aDe0db73c2c013D3611DB69c40BC'
userWalletObject:
  libraryId: ilib3ANoVSzNA3P6t7abLR69ho5YPPZU
  objectId: iq__3Fn4en4mRXRiPRzuMivgdRK1iweT
userMetadata:
  commit:
    author: '0x211446b91f03a2657582073ba8a1a895ace2c187'
    author_address: '0x211446b91f03a2657582073ba8a1a895ace2c187'
    message: Replace user metadata
    timestamp: '2022-04-11T20:34:49.194Z'
  public:
    name: test





