### PR TITLE
Add nft_get_transfer_fee and nft_set_transfer_fee

### DIFF
--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -1087,6 +1087,9 @@ class EluvioLive {
     });
     nftInfo.totalSupply = Number(totalSupply);
 
+    nftInfo.transferFee = await this.NftGetTransferFee({address: addr});
+    
+
     try {
       const minted = await this.client.CallContractMethod({
         contractAddress: addr,
@@ -1747,6 +1750,51 @@ Lookup NFT: https://wallet.contentfabric.io/lookup/`; */
     return await res.json();
   }
 
+  /**
+   * Gets the baseTransferFee of the NFT Contract
+   *
+   * @namedParams
+   * @param {string} address - The NFT contract address
+   * @return {string} - The fee as a big number sring
+   */
+  async NftGetTransferFee({address}) {
+    const abi = fs.readFileSync(
+      path.resolve(__dirname, "../contracts/v3/ElvTradableLocal.abi")
+    );
+
+    var res = await this.client.CallContractMethod({
+      contractAddress: address,
+      abi: JSON.parse(abi),
+      methodName: "baseTransferFee",
+      formatArguments: true,
+    });
+
+    return Number(res);
+  }
+  
+  /**
+   * Sets the baseTransferFee of the NFT Contract
+   *
+   * @namedParams
+   * @param {string} address - The NFT contract address
+   * @param {string} fee - Fee in ETH to set as a big number string
+   * @return {Promise<Object>} - The Contract transaction logs
+   */
+  async NftSetTransferFee({address, fee}) {
+    const abi = fs.readFileSync(
+      path.resolve(__dirname, "../contracts/v3/ElvTradableLocal.abi")
+    );
+
+    var res = await this.client.CallContractMethodAndWait({
+      contractAddress: address,
+      abi: JSON.parse(abi),
+      methodName: "setBaseTransferFee",
+      methodArgs: [fee],
+      formatArguments: true,
+    });
+
+    return res;
+  }
 
   async Sign({ message }) {
     const signature = await this.client.authClient.Sign(

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -709,6 +709,41 @@ const CmdStorefrontSectionRemoveItem = async ({ argv }) => {
   }
 };
 
+const CmdNftSetTransferFee = async ({ argv }) => {
+  console.log("NFT Set Transfer Fee");
+  console.log(`NFT Contract Address: ${argv.addr}`);
+  console.log(`Fee: ${argv.fee}`);
+
+  try {
+    await Init();
+
+    res = await elvlv.NftSetTransferFee({ 
+      address: argv.addr,
+      fee: argv.fee 
+    });
+
+    console.log(yaml.dump(res));
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
+const CmdNftGetTransferFee = async ({ argv }) => {
+  console.log("NFT Get Transfer Fee");
+  console.log(`NFT Contract Address: ${argv.addr}`);
+
+  try {
+    await Init();
+
+    res = await elvlv.NftGetTransferFee({address: argv.addr});
+
+    console.log(yaml.dump(res));
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
+
 yargs(hideBin(process.argv))
   .command(
     "nft_add_contract <library> <object> <tenant> [minthelper] [cap] [name] [symbol] [nftaddr] [hold]",
@@ -911,6 +946,41 @@ yargs(hideBin(process.argv))
       console.log(x);
     }
   )
+
+  .command(
+    "nft_set_transfer_fee <addr> <fee>",
+    "Decode and look up a local NFT by external token ID",
+    (yargs) => {
+      yargs
+        .positional("addr", {
+          describe: "NFT contract address",
+          type: "string",
+        })
+        .positional("fee", {
+          describe: "Fee in ETH",
+          type: "string", // BigNumber as string
+        });
+    },
+    (argv) => {
+      CmdNftSetTransferFee({ argv });
+    }
+  )
+
+  .command(
+    "nft_get_transfer_fee <addr>",
+    "Decode and look up a local NFT by external token ID",
+    (yargs) => {
+      yargs
+        .positional("addr", {
+          describe: "NFT contract address",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdNftGetTransferFee({ argv });
+    }
+  )
+
 
   .command(
     "tenant_show <tenant> [options]",


### PR DESCRIPTION
Add methods to get and set the baseTransferFee on an NFT Contract. Also added the transfer_fee info for nft_show.

eg.
```
./elv-live nft_set_transfer_fee 0xccd4182b6ce2799dd6dd76269b205fa9661aca1d 2
NFT Set Transfer Fee
NFT Contract Address: 0xccd4182b6ce2799dd6dd76269b205fa9661aca1d
Fee: 2
Network: demov3
to: '0xCCd4182b6cE2799Dd6dd76269B205Fa9661aCA1d'
from: '0x5557f80D0537E7bB439d919841e0eb9ed449e6BB'
contractAddress: null
transactionIndex: 0
gasUsed:
  _hex: '0xaa39'

.....etc
```

```
./elv-live nft_get_transfer_fee 0xccd4182b6ce2799dd6dd76269b205fa9661aca1d
NFT Get Transfer Fee
NFT Contract Address: 0xccd4182b6ce2799dd6dd76269b205fa9661aca1d
Network: demov3
2

```