### PR TITLE
Add notifier and notif_send command

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -20,7 +20,9 @@ const consts = {
     kmsAddress: "0xd962aff088ca845de83ce0db0c91b9a0b93d294f",
     spaceAddress: "0x6612d94a31fab146b4c7ace60ddf3a1e5e40e500",
     claimerAddressTest: "0x2c0a54f3f2b4c95d162bbb7696bd161125222a26",
-    claimerAddress: "0x27fdfa3a50de40b79cbfa3dd5921715c51db93c4"
+    claimerAddress: "0x27fdfa3a50de40b79cbfa3dd5921715c51db93c4",
+    notificationService: "https://appsvc.svc.eluv.io/push/main"
+
   },
   demov3: {
     tokenUriStart: "https://demov3.net955210.contentfabric.io/s/demov3/q/",
@@ -28,6 +30,7 @@ const consts = {
     kmsAddress: "0x501382e5f15501427d1fc3d93e949c96b25a2224",
     spaceAddress: "0x9b29360efb1169c801bbcbe8e50d0664dcbc78d3",
     claimerAddress: "0x",
+    notificationService: "https://appsvc.svc.eluv.io/push/dv3"
   },
   test: {
     tokenUriStart: "https://test.net955205.contentfabric.io/s/test/q/",

--- a/src/Notifier.js
+++ b/src/Notifier.js
@@ -1,0 +1,85 @@
+const { ElvClient } = require("@eluvio/elv-client-js");
+const HttpClient = require("@eluvio/elv-client-js/src/HttpClient");
+const { Config } = require("./Config.js");
+const { ElvAccount } = require("./ElvAccount");
+var urljoin = require("url-join");
+
+/**
+ * Notifier is a basic SDK for accessing the Eluvio Notification Service
+ */
+class Notifier {
+
+  /**
+   * Instantiate the notifier SDK
+   *
+   * @namedParams
+   * @param {string} notifUrl - The notification service endpoint (optional)
+   * @return {EluvioLive} - New ElvNotif object connected to the specified endpoint
+   */
+  constructor({ notifUrl }) {
+    this.notifUrl = notifUrl || Config.consts[Config.net].notificationService;
+    this.configUrl = Config.networks[Config.net];
+    this.debug = false;
+  }
+
+  async Init() {
+
+    // Split the notification service URL into the base URL and path
+    // This is needed because HttpClient requires a base URLs
+    const url = new URL(this.notifUrl);
+    this.notifUrlPath = url.pathname;
+
+    this.HttpClient = new HttpClient({uris: [this.notifUrl], debug: this.debug});
+
+    this.client = await ElvClient.FromConfigurationUrl({
+      configUrl: this.configUrl,
+    });
+    let wallet = this.client.GenerateWallet();
+    let signer = wallet.AddAccount({
+      privateKey: process.env.PRIVATE_KEY,
+    });
+    this.client.SetSigner({ signer });
+    this.client.ToggleLogging(this.debug);
+  }
+
+  async Send({userAddr, tenantId, eventType, nftAddr, tokenId}) {
+
+    let body = {
+      contract: nftAddr,
+      token: tokenId
+    };
+    let path = urljoin("/notify_user/", userAddr, tenantId, eventType);
+    let res = this.Post({path, body});
+    return res;
+  }
+
+  /**
+   * Post a notification
+   * @param {*} param0
+   * @returns
+   */
+  async Post({ path, body }) {
+    if (!body) {
+      body = {};
+    }
+
+    let token = await this.client.CreateFabricToken({duration:ElvAccount.TOKEN_DURATION});
+
+    // Temporary - to figure out how to store full endpoint in HttpClient
+    path = urljoin(this.notifUrlPath, path);
+
+    let res = await this.HttpClient.Request({
+      method: "POST",
+      path,
+      body,
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    return await res.json();
+  }
+
+}
+
+exports.Notifier = Notifier;

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -5,6 +5,7 @@ const { InitializeTenant, AddConsumerGroup } = require("../src/Provision");
 const { Config } = require("../src/Config.js");
 const { Shuffler } = require("../src/Shuffler");
 const { Marketplace } = require("../src/Marketplace");
+const { Notifier } = require ("../src/Notifier");
 
 const yargs = require("yargs/yargs");
 const { hideBin } = require("yargs/helpers");
@@ -1058,6 +1059,27 @@ const CmdNFTSetPolicyPermissions = async ({ argv }) => {
       policyPath: argv.policy_path,
       addresses: argv.addrs,
       clearAddresses: argv.clear
+    });
+
+    console.log("\n" + yaml.dump(res));
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
+const CmdNotifSend = async ({ argv }) => {
+  console.log("Send notification", argv.userAddr, argv.tenant, argv.event);
+
+  try {
+    let notifier = new Notifier({notifUrl: argv.notif_url});
+    await notifier.Init();
+
+    let res = await notifier.Send({
+      userAddr: argv.user_addr,
+      tenantId: argv.tenant,
+      eventType: argv.event,
+      nftAddr: argv.nft_addr,
+      tokenId: argv.token_id
     });
 
     console.log("\n" + yaml.dump(res));
@@ -2126,6 +2148,44 @@ yargs(hideBin(process.argv))
     },
     (argv) => {
       CmdNFTSetPolicyPermissions({ argv });
+    }
+  )
+
+  .command(
+    "notif_send <user_addr> <tenant> <event>",
+    "Sends a notification (using the notification service).",
+    (yargs) => {
+      yargs
+      .positional("user_addr", {
+        describe: "User address",
+        type: "string",
+      })
+      .positional("tenant", {
+          describe: "Tenant ID",
+          type: "string",
+        })
+        .positional("event", {
+          describe: "One of: TOKEN_UPDATED",
+          type: "string",
+        })
+        .option("nft_addr", {
+          describe: "NFT contract address (hex)",
+          type: "string",
+          default: ""
+        })
+        .option("token_id", {
+          describe: "NFT token ID",
+          type: "string",
+          default: ""
+        })
+        .option("notif_url", {
+          describe: "Notification service URL",
+          type: "string",
+          default: ""
+        });
+    },
+    (argv) => {
+      CmdNotifSend({ argv });
     }
   )
 


### PR DESCRIPTION
Add notification service support in elv-live-js and 2 commands:
- `notif_send`  - sends one individual notification to one user and takes the 'event type' as parameter
- `notif_send_token_update` - sends the *TOKEN_UPDATE* notification to all owners of this NFT


Example command:

```
./elv-live notif_send  0x7aa1b8ead455334c6dc8c952687773970c4676fa  itenKGHd3iedqtA39krJUPkBTCNoTeX TOKEN_UPDATED --nft_addr 0xef978fbdac3b8bb6ab8ee80db35a25e7a6a7fbc0 --token_id 16
```

Help:

```
./elv-live notif_send
 notif_send <user_addr> <tenant> <event>

Sends a notification (using the notification service).

Positionals:
  user_addr  User address                                    [string] [required]
  tenant     Tenant ID                                       [string] [required]
  event      One of: TOKEN_UPDATED                           [string] [required]

Options:
      --version    Show version number                                 [boolean]
  -v, --verbose    Verbose mode                                        [boolean]
      --help       Show help                                           [boolean]
      --nft_addr   NFT contract address (hex)             [string] [default: ""]
      --token_id   NFT token ID                           [string] [default: ""]
      --notif_url  Notification service URL               [string] [default: ""]
```