### PR TITLE
Tenant use minter config

### DIFF
--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -737,6 +737,46 @@ class EluvioLive {
       path.resolve(__dirname, "../contracts/v3/ElvTradableLocal.bin")
     );
 
+    let minterConfigResp = {};
+
+    try {
+      minterConfigResp = await this.TenantGetMinterConfig({tenant: tenantId});
+
+      if (this.debug){
+        console.log("minterConfig: ", minterConfigResp);
+      }
+    } catch (e) {
+      console.log("Warning: ", e);
+    }
+
+    if (proxyAddress == null || proxyAddress == "") {
+      try {
+        proxyAddress = minterConfigResp.config.proxy_owner_address;
+        console.log("Using tenant config proxy address: ", proxyAddress);
+      } catch (e){
+        console.warn("tenant config proxy_owner_address error: ", e);
+      }
+    }
+
+    if (minterAddr == null || minterAddr == "") {
+      try {
+        minterAddr = minterConfigResp.config.minter_address;
+        console.log("Using tenant config minter address: ", minterAddr);
+      } catch (e){
+        console.warn("tenant config minter_address error: ", e);
+      }
+    }
+
+    if (mintHelperAddr == null || mintHelperAddr == "") {
+      try {
+        mintHelperAddr = minterConfigResp.config.minter_helper;
+        console.log("Using tenant config minter helper address: ", mintHelperAddr);
+      } catch (e){
+        console.warn("tenant config minter_helper error: ", e);
+      }
+    }
+
+    //Create new Transfer Proxy if config and command line does not exist.
     if (proxyAddress == null || proxyAddress == "") {
       proxyAddress = await this.CreateNftTransferProxy({});
     }

--- a/src/Provision.js
+++ b/src/Provision.js
@@ -251,6 +251,8 @@ const InitializeTenant = async ({client, kmsId, tenantName, debug=false}) => {
     metadata: STANDARD_DRM_CERT
   });
 
+  // NFT Templates library not used for now
+  /*
   const nftLibraryId = await client.CreateContentLibrary({
     name: `${tenantName} - NFT Templates`,
     kmsId,
@@ -258,20 +260,20 @@ const InitializeTenant = async ({client, kmsId, tenantName, debug=false}) => {
   });
 
   await SetLibraryPermissions(client, nftLibraryId, tenantAdminGroupAddress, contentAdminGroupAddress, contentViewersGroupAddress);
-
+*/
   if (debug) {
     console.log("\nTenant Libraries:\n");
     console.log(`\t${tenantName} - Properties: ${propertiesLibraryId}`);
     console.log(`\t${tenantName} - Title Masters: ${mastersLibraryId}`);
     console.log(`\t${tenantName} - Title Mezzanines: ${mezzanineLibraryId}`);
-    console.log(`\t${tenantName} - NFT Templates: ${nftLibraryId}`);
+    //console.log(`\t${tenantName} - NFT Templates: ${nftLibraryId}`);
   }
 
   let libraries = {
     propertiesLibraryId,
     mastersLibraryId,
     mezzanineLibraryId,
-    nftLibraryId
+    //nftLibraryId
   };
 
   /* Create a site object */

--- a/src/Provision.js
+++ b/src/Provision.js
@@ -3,12 +3,18 @@ const fs = require("fs");
 const path = require("path");
 const { ElvUtils } = require("../src/Utils");
 
+const TYPE_LIVE_DROP_EVENT_SITE = "Eluvio LIVE Drop Event Site";
+const TYPE_LIVE_TENANT = "Eluvio LIVE Tenant";
+const TYPE_LIVE_MARKETPLACE = "Eluvio LIVE Marketplace";
+const TYPE_LIVE_NFT_COLLECTION = "NFT Collection";
+const TYPE_LIVE_NFT_TEMPLATE = "NFT Template";
+
 const liveTypes = [
-  { name: "Eluvio LIVE Drop Event Site", spec: require("@eluvio/elv-client-js/typeSpecs/DropEventSite") },
-  { name: "Eluvio LIVE Marketplace", spec: require("@eluvio/elv-client-js/typeSpecs/Marketplace") },
-  { name: "Eluvio LIVE Tenant", spec: require("@eluvio/elv-client-js/typeSpecs/EventTenant") },
-  { name: "NFT Collection", spec: require("@eluvio/elv-client-js/typeSpecs/NFTCollection") },
-  { name: "NFT Template", spec: require("@eluvio/elv-client-js/typeSpecs/NFTTemplate") }
+  { name: TYPE_LIVE_DROP_EVENT_SITE, spec: require("@eluvio/elv-client-js/typeSpecs/DropEventSite") },
+  { name: TYPE_LIVE_MARKETPLACE, spec: require("@eluvio/elv-client-js/typeSpecs/Marketplace") },
+  { name: TYPE_LIVE_TENANT, spec: require("@eluvio/elv-client-js/typeSpecs/EventTenant") },
+  { name: TYPE_LIVE_NFT_COLLECTION, spec: require("@eluvio/elv-client-js/typeSpecs/NFTCollection") },
+  { name: TYPE_LIVE_NFT_TEMPLATE, spec: require("@eluvio/elv-client-js/typeSpecs/NFTTemplate") }
 ];
 
 const STANDARD_DRM_CERT={
@@ -55,7 +61,7 @@ const SetObjectPermissions = async (client, objectId, tenantAdmins, contentAdmin
   await Promise.all(promises);
 };
 
-const InitializeTenant = async ({client, kmsId, tenantName, debug=false}) => {
+const InitializeTenant = async ({client, kmsId, tenantName, tenantId, debug=false}) => {
   let tenantAdminId = await client.userProfileClient.TenantId();
   let tenantAdminSigner = client.signer;
 
@@ -209,6 +215,8 @@ const InitializeTenant = async ({client, kmsId, tenantName, debug=false}) => {
     streamTypeId
   };
 
+  let liveTypeIds = {};
+
   for (let i = 0; i < liveTypes.length; i++) {
     const typeId = await client.CreateContentType({
       name: `${tenantName} - ${liveTypes[i].name}`,
@@ -226,6 +234,7 @@ const InitializeTenant = async ({client, kmsId, tenantName, debug=false}) => {
     if (debug) {
       console.log(`\t${tenantName} - ${liveTypes[i].name}: ${typeId}`);
     }
+    liveTypeIds[liveTypes[i].name] = typeId;
   }
 
 
@@ -277,47 +286,174 @@ const InitializeTenant = async ({client, kmsId, tenantName, debug=false}) => {
   };
 
   /* Create a site object */
+
+  let objectName = `Site - ${tenantName}`;
+
+  publicMetadata = {
+    name: objectName,
+    asset_metadata: {
+      title: objectName,
+      display_title: objectName,
+      slug: `site-${tenantSlug}`,
+      title_type: "site",
+      asset_type: "primary"
+    }
+  };
+
+  let siteId = await CreateFabricObject({client, 
+    libraryId: propertiesLibraryId, 
+    typeId: titleCollectionTypeId, 
+    publicMetadata, 
+    tenantAdminGroupAddress, 
+    contentAdminGroupAddress, 
+    contentViewersGroupAddress});
+
+  if (debug) {
+    console.log("\nSite Object: \n");
+    console.log(`\t${objectName}: ${siteId}\n\n`);
+  }
+
+  /* Create a marketplace object */
+
+  objectName = `${TYPE_LIVE_MARKETPLACE} - ${tenantName}`;
+
+  publicMetadata = {
+    name: objectName,
+    asset_metadata: {
+      slug: `${tenantSlug}-marketplace`,
+      info: {
+        tenant_id: tenantId,
+        tenant_slug: tenantSlug,
+        tenant_name: tenantName,
+        branding: {
+          color_scheme: "Dark"
+        }
+      }
+    }
+  };
+
+  let marketplaceId = await CreateFabricObject({client, 
+    libraryId: propertiesLibraryId, 
+    typeId: liveTypeIds[TYPE_LIVE_MARKETPLACE], 
+    publicMetadata, 
+    tenantAdminGroupAddress, 
+    contentAdminGroupAddress, 
+    contentViewersGroupAddress});
+
+  if (debug) {
+    console.log("\nMaketplace Object: \n");
+    console.log(`\t${objectName}: ${marketplaceId}\n\n`);
+  }
+
+  let marketplaceHash = await client.LatestVersionHash({objectId: marketplaceId});
+
+  /* Create a drop event object */
+
+  objectName = `${TYPE_LIVE_DROP_EVENT_SITE} - ${tenantName}`;
+
+  publicMetadata = {
+    name: objectName,
+    asset_metadata: {
+      info: {
+        tenant_id: tenantId,
+        tenant_slug: tenantSlug,
+        marketplace_info: {
+          tenant_slug: tenantSlug,
+          marketplace_slug: `${tenantSlug}-marketplace`
+        }
+      }
+    }
+  };
+
+  let dropEventId = await CreateFabricObject({client, 
+    libraryId: propertiesLibraryId, 
+    typeId: liveTypeIds[TYPE_LIVE_DROP_EVENT_SITE], 
+    publicMetadata, 
+    tenantAdminGroupAddress, 
+    contentAdminGroupAddress, 
+    contentViewersGroupAddress});
+
+  let dropEventHash = await client.LatestVersionHash({objectId: dropEventId});
+
+  if (debug) {
+    console.log("\nDrop Event Site Object: \n");
+    console.log(`\t${objectName}: ${dropEventId}\n\n`);
+  }
+
+  /* Create the tenant object */
+
+  objectName = `${TYPE_LIVE_TENANT} - ${tenantName}`;
+
+  publicMetadata = {
+    name: objectName,
+    asset_metadata: {
+      info: {
+        tenant_id: tenantId
+      },
+      slug: tenantSlug,
+      marketplaces:{
+        [`${tenantSlug}-marketplace`]: {
+          "/":`/qfab/${marketplaceHash}/meta/public/asset_metadata`,
+          "order": 0
+        }
+      },
+      sites: {
+        [`${tenantSlug}-drop-event`]: {
+          "/":`/qfab/${dropEventHash}/meta/public/asset_metadata`,
+          "order": 0
+        }
+      }
+    }
+  };
+
+  let tenantObjectId = await CreateFabricObject({client, 
+    libraryId: propertiesLibraryId, 
+    typeId: liveTypeIds[TYPE_LIVE_TENANT], 
+    publicMetadata, 
+    tenantAdminGroupAddress, 
+    contentAdminGroupAddress, 
+    contentViewersGroupAddress});
+
+  if (debug) {
+    console.log("\nDrop Event Site Object: \n");
+    console.log(`\t${objectName}: ${tenantObjectId}\n\n`);
+  }
+
+
+  return {
+    tenantTypes,
+    libraries,
+    groups,
+    siteId,
+    marketplaceId,
+    dropEventId,
+    tenantObjectId
+  };
+};
+
+const CreateFabricObject = async ({client, libraryId, typeId, publicMetadata, tenantAdminGroupAddress, contentAdminGroupAddress, contentViewersGroupAddress}) => {
   const {id, write_token} = await client.CreateContentObject({
-    libraryId: propertiesLibraryId,
-    options: {type: titleCollectionTypeId}
+    libraryId,
+    options: {type: typeId}
   });
 
   await client.ReplaceMetadata({
-    libraryId: propertiesLibraryId,
+    libraryId,
     objectId: id,
     writeToken: write_token,
     metadataSubtree: "public",
-    metadata: {
-      name: `Site - ${tenantName}`,
-      asset_metadata: {
-        title: `Site - ${tenantName}`,
-        display_title: `Site - ${tenantName}`,
-        slug: `site-${tenantSlug}`,
-        title_type: "site",
-        asset_type: "primary"
-      }
-    }
+    metadata: publicMetadata
   });
 
   await client.FinalizeContentObject({
-    libraryId: propertiesLibraryId,
+    libraryId,
     objectId: id,
     writeToken: write_token
   });
 
   await SetObjectPermissions(client, id, tenantAdminGroupAddress, contentAdminGroupAddress, contentViewersGroupAddress);
 
-  if (debug) {
-    console.log("\nSite Object: \n");
-    console.log(`\tSite - ${tenantName}: ${id}\n\n`);
-  }
-
-  return {
-    tenantTypes,
-    libraries,
-    groups,
-    siteId: id
-  };
+  return id;
 };
 
 const AddConsumerGroup = async ({client, tenantAddress, debug = false}) => {

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -1009,7 +1009,8 @@ const CmdASNftRedeemOffer = async ({ argv }) => {
 
 const CmdTenantProvision = async ({ argv }) => {
   console.log("Tenant Provision");
-  console.log(`tenantName: ${argv.tenant_name}`);
+  console.log(`Tenant ID: ${argv.tenant}`);
+  console.log(`Tenant Name: ${argv.tenant_name}`);
   console.log(`verbose: ${argv.verbose}`);
 
   try {
@@ -1025,7 +1026,8 @@ const CmdTenantProvision = async ({ argv }) => {
       client,
       kmsId,
       tenantName: argv.tenant_name,
-      debug: argv.verbose
+      tenantId: argv.tenant,
+      debug: true
     });
 
     console.log(yaml.dump(res));
@@ -2288,9 +2290,13 @@ yargs(hideBin(process.argv))
   )
 
   .command(
-    "tenant_provision <tenant_name>",
+    "tenant_provision <tenant> <tenant_name>",
     "Provisions a new tenant account with standard media libraries and content types. Note this account must be created using space_tenant_create.",
     (yargs) => {
+      yargs.positional("tenant", {
+        describe: "Tenant ID",
+        type: "string",
+      });
       yargs.positional("tenant_name", {
         describe: "Name of the tenant (without the elv-admin postfix). Used to create access groups name",
         type: "string",

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -34,34 +34,25 @@ const Init = async ({debugLogging = false}={}) => {
 const CmfNftTemplateAddNftContract = async ({ argv }) => {
   console.log(
     "\nNFT Template - set contract",
-    "\nLibrary ID " + argv.library,
     "\nObject ID " + argv.object,
     "\nCollection Name " + argv.name,
     "\nCollection Symbol " + argv.symbol,
-    "\nNFT Address " + argv.nftaddr,
     "\nTenant ID " + argv.tenant,
-    "\nMinter Helper " + argv.minthelper,
-    "\nMinter Address " + argv.minter,
     "\nCap " + argv.cap,
-    "\nProxy Address " + argv.proxyaddr,
+    "\nHold " + argv.hold,
     "\nVerbose ", argv.verbose
   );
   try {
     await Init({debugLogging: argv.verbose});
 
     await elvlv.NftTemplateAddNftContract({
-      libraryId: argv.library,
       objectId: argv.object,
-      nftAddr: argv.nftaddr,
       tenantId: argv.tenant,
-      mintHelperAddr: argv.minthelper,
-      minterAddr: argv.minter,
       totalSupply: argv.cap,
       collectionName: argv.name,
       collectionSymbol: argv.symbol,
       hold: argv.hold,
       contractUri: "",
-      proxyAddress: argv.proxyaddr,
     });
   } catch (e) {
     console.error("ERROR:", e);
@@ -1294,48 +1285,28 @@ yargs(hideBin(process.argv))
     alias: "v"
   })
   .command(
-    "nft_add_contract <library> <object> <tenant> [options]",
+    "nft_add_contract <tenant> <object> <cap> <name> <symbol> [options]",
     "Add a new or existing NFT contract to an NFT Template object",
     (yargs) => {
       yargs
-        .positional("library", {
-          describe: "NFT Template library ID",
+        .positional("tenant", {
+          describe: "Tenant ID",
           type: "string",
         })
         .positional("object", {
           describe: "NFT Template object ID",
           type: "string",
         })
-        .positional("tenant", {
-          describe: "Tenant ID",
-          type: "string",
-        })
-        .option("minthelper", {
-          describe: "Mint helper address (hex). Default from tenant configuration.",
-          type: "string",
-        })
-        .option("minter", {
-          describe: "Minter address (hex). Default from tenant configuration.",
-          type: "string",
-        })
-        .option("cap", {
+        .positional("cap", {
           describe: "NFT total supply cap",
           type: "number",
         })
-        .option("name", {
+        .positional("name", {
           describe: "NFT collection name",
           type: "string",
         })
-        .option("symbol", {
+        .positional("symbol", {
           describe: "NFT collection symbol",
-          type: "string",
-        })
-        .option("nftaddr", {
-          describe: "NFT contract address (will not create a new one)",
-          type: "string",
-        })
-        .option("proxyaddr", {
-          describe: "Proxy Address (hex). Default from tenant configuration.",
           type: "string",
         })
         .option("hold", {

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -244,16 +244,12 @@ const CmdNftTransfer = async ({ argv }) => {
 
 const CmdTenantShow = async ({ argv }) => {
   console.log("Tenant - show", argv.tenant);
-  console.log("check_cauth", argv.check_cauth);
-  console.log("check_minter", argv.check_minter);
   console.log("check_nfts", argv.check_nfts);
   try {
     await Init({debugLogging: argv.verbose});
 
     let res = await elvlv.TenantShow({
       tenantId: argv.tenant,
-      cauth: argv.check_cauth,
-      mintHelper: argv.check_minter,
       checkNft: argv.check_nfts,
     });
 
@@ -1726,15 +1722,6 @@ yargs(hideBin(process.argv))
       yargs
         .positional("tenant", {
           describe: "Tenant ID",
-          type: "string",
-        })
-        .option("check_cauth", {
-          describe:
-            "Check that all NFTs use this minter address in ikms format",
-          type: "string",
-        })
-        .option("check_minter", {
-          describe: "Check that all NFTs use this mint helper",
           type: "string",
         })
         .option("check_nfts", {

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -33,33 +33,35 @@ const Init = async ({debugLogging = false}={}) => {
 
 const CmfNftTemplateAddNftContract = async ({ argv }) => {
   console.log(
-    "NFT Template - set contract",
-    argv.library,
-    argv.object,
-    argv.tenant,
-    argv.minthelper,
-    argv.minter,
-    argv.cap,
-    argv.name,
-    argv.symbol,
-    argv.nftAddress
+    "\nNFT Template - set contract",
+    "\nLibrary ID " + argv.library,
+    "\nObject ID " + argv.object,
+    "\nCollection Name " + argv.name,
+    "\nCollection Symbol " + argv.symbol,
+    "\nNFT Address " + argv.nftaddr,
+    "\nTenant ID " + argv.tenant,
+    "\nMinter Helper " + argv.minthelper,
+    "\nMinter Address " + argv.minter,
+    "\nCap " + argv.cap,
+    "\nProxy Address " + argv.proxyaddr,
+    "\nVerbose ", argv.verbose
   );
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
-    let c = await elvlv.NftTemplateAddNftContract({
+    await elvlv.NftTemplateAddNftContract({
       libraryId: argv.library,
       objectId: argv.object,
-      //nftAddr,
+      nftAddr: argv.nftaddr,
       tenantId: argv.tenant,
-      mintHelperAddr: argv.minthelper, //"0x59e79eFE007F5208857a646Db5cBddA82261Ca81",
+      mintHelperAddr: argv.minthelper,
       minterAddr: argv.minter,
       totalSupply: argv.cap,
       collectionName: argv.name,
       collectionSymbol: argv.symbol,
       hold: argv.hold,
       contractUri: "",
-      proxyAddress: "",
+      proxyAddress: argv.proxyaddr,
     });
   } catch (e) {
     console.error("ERROR:", e);
@@ -69,9 +71,9 @@ const CmfNftTemplateAddNftContract = async ({ argv }) => {
 const CmfNftAddMintHelper = async ({ argv }) => {
   console.log("NFT - add mint helper", argv.addr, argv.minter);
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
-    let c = await elvlv.NftAddMinter({
+    await elvlv.NftAddMinter({
       addr: argv.addr,
       minterAddr: argv.minter,
     });
@@ -83,7 +85,7 @@ const CmfNftAddMintHelper = async ({ argv }) => {
 const CmfNftSetProxy = async ({ argv }) => {
   console.log("NFT - set proxy", argv.addr, argv.proxy_addr);
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     let p = await elvlv.NftSetTransferProxy({
       addr: argv.addr,
@@ -98,7 +100,7 @@ const CmfNftSetProxy = async ({ argv }) => {
 const CmdNftBalanceOf = async ({ argv }) => {
   console.log("NFT - call", argv.addr, argv.owner);
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     let res = await elvlv.NftBalanceOf({
       addr: argv.addr,
@@ -114,7 +116,7 @@ const CmdNftBalanceOf = async ({ argv }) => {
 const CmdNftBurn = async ({ argv }) => {
   console.log("NFT burn ", argv.addr, argv.token_id);
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     let res = await elvlv.NftBurn({
       addr: argv.addr,
@@ -130,7 +132,7 @@ const CmdNftBurn = async ({ argv }) => {
 const CmdNftProxyBurn = async ({ argv }) => {
   console.log("NFT Proxy burn ", argv.addr, argv.token_id);
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     let res = await elvlv.NftProxyBurn({
       addr: argv.addr,
@@ -150,7 +152,7 @@ const CmdNftShow = async ({ argv }) => {
   console.log("show_owners ", argv.show_owners);
   console.log("token_id ", argv.token_id);
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     let res = await elvlv.NftShow({
       addr: argv.addr,
@@ -171,7 +173,7 @@ const CmdNftBuild = async ({ argv }) => {
   console.log("NFT - objectId ", argv.object);
   console.log("NFT - nftDir ", argv.nft_dir);
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     let res = await elvlv.NftBuild({
       libraryId: argv.library,
@@ -193,7 +195,7 @@ const CmdNftProxyTransfer = async ({ argv }) => {
     argv.to_addr
   );
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     let res = await elvlv.NftProxyTransferFrom({
       addr: argv.addr,
@@ -217,7 +219,7 @@ const CmdNftTransfer = async ({ argv }) => {
     argv.auth_service
   );
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     let res;
     if (argv.auth_service) {
@@ -246,7 +248,7 @@ const CmdTenantShow = async ({ argv }) => {
   console.log("check_minter", argv.check_minter);
   console.log("check_nfts", argv.check_nfts);
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     let res = await elvlv.TenantShow({
       tenantId: argv.tenant,
@@ -264,7 +266,7 @@ const CmdTenantShow = async ({ argv }) => {
 const CmdSiteShow = async ({ argv }) => {
   console.log("Site - show", argv.object);
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     let res = await elvlv.SiteShow({
       libraryId: argv.library,
@@ -281,7 +283,7 @@ const CmdSiteSetDrop = async ({ argv }) => {
   console.log("Site - set drop", argv.object, argv.uuid, "update", argv.update);
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     let res = await elvlv.SiteSetDrop({
       libraryId: argv.library,
@@ -304,7 +306,7 @@ const CmdSiteSetDrop = async ({ argv }) => {
 const CmdTenantBalanceOf = async ({ argv }) => {
   console.log("Tenant - balance of", argv.tenant, argv.owner, argv.max_results);
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     let res = await elvlv.TenantBalanceOf({
       tenantId: argv.tenant,
@@ -321,7 +323,7 @@ const CmdTenantBalanceOf = async ({ argv }) => {
 const CmdFabricTenantBalanceOf = async ({ argv }) => {
   console.log("Fabric Tenant - balance of", argv.object, argv.owner);
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     let res = await elvlv.FabricTenantBalanceOf({
       objectId: argv.object,
@@ -375,7 +377,7 @@ const CmdTenantMint = async ({ argv }) => {
   );
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     let res = await elvlv.TenantMint({
       tenant: argv.tenant,
@@ -396,7 +398,7 @@ const CmdTenantWallets = async ({ argv }) => {
     `Tenant wallets tenant: ${argv.tenant} max_results: ${argv.max_results}`
   );
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     let res = await elvlv.TenantWallets({
       tenant: argv.tenant,
@@ -415,7 +417,7 @@ const CmdNFTRefresh = async ({ argv }) => {
   console.log(`address: ${argv.addr}}`);
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     let res = await elvlv.NFTRefresh({
       tenant: argv.tenant,
@@ -432,7 +434,7 @@ const CmdNFTRefresh = async ({ argv }) => {
 const CmdList = async ({ argv }) => {
   console.log(`list tenant: ${argv.tenant} tenant_slug: ${argv.tenant_slug}`);
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     let res = await elvlv.List({
       tenantId: argv.tenant,
@@ -467,7 +469,7 @@ const CmdTenantPrimarySales = async ({ argv }) => {
   console.log(`CSV: ${argv.csv}`);
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     let res = await elvlv.TenantPrimarySales({
       tenant: argv.tenant,
@@ -493,7 +495,7 @@ const CmdTenantSecondarySales = async ({ argv }) => {
   console.log(`CSV: ${argv.csv}`);
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     let res = await elvlv.TenantSecondarySales({
       tenant: argv.tenant,
@@ -518,7 +520,7 @@ const CmdTenantUnifiedSales = async ({ argv }) => {
   console.log(`CSV: ${argv.csv}`);
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     let res = await elvlv.TenantUnifiedSales({
       tenant: argv.tenant,
@@ -541,7 +543,7 @@ const CmdTenantTransferFailures = async ({ argv }) => {
   console.log(`Tenant Trasfer Failures: ${argv.tenant}`);
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     let res = await elvlv.TenantTransferFailures({
       tenant: argv.tenant,
@@ -610,7 +612,7 @@ const CmdAccountCreate = async ({ argv }) => {
   console.log(`tenant_admins: ${argv.tenant_admins}`);
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
     let res = await elvlv.AccountCreate({
       funds: argv.funds,
       accountName: argv.account_name,
@@ -626,7 +628,7 @@ const CmdAccountShow = async () => {
   console.log("Account Show\n");
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
     let res = await elvlv.AccountShow();
     console.log(yaml.dump(res));
   } catch (e) {
@@ -640,7 +642,7 @@ const CmdTenantNftRemove = async ({ argv }) => {
   console.log(`NFT Address: ${argv.addr}`);
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     console.log("Searching for NFT address in tenant contract...");
     let res = await elvlv.TenantHasNft({
@@ -680,7 +682,7 @@ const CmdTenantNftList = async ({ argv }) => {
   console.log(`Tenant ID: ${argv.tenant}`);
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
     res = await elvlv.TenantNftList({ tenantId: argv.tenant });
 
     console.log(yaml.dump(res));
@@ -695,7 +697,7 @@ const CmdTenantHasNft = async ({ argv }) => {
   console.log(`NFT Address: ${argv.addr}`);
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
     res = await elvlv.TenantHasNft({
       tenantId: argv.tenant,
       nftAddr: argv.addr,
@@ -713,7 +715,7 @@ const CmdTenantAddConsumers = async ({ argv }) => {
   console.log(`Account Addresses: ${argv.addrs}`);
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
     let res = await elvlv.TenantAddConsumers({
       groupId: argv.group_id,
       accountAddresses: argv.addrs,
@@ -731,7 +733,7 @@ const CmdTenantRemoveConsumer = async ({ argv }) => {
   console.log(`Account Address: ${argv.addr}`);
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
     let res = await elvlv.TenantRemoveConsumer({
       groupId: argv.group_id,
       accountAddress: argv.addr,
@@ -752,7 +754,7 @@ const CmdMarketplaceAddItem = async ({ argv }) => {
   console.log(`NFT For Sale: ${argv.forSale}`);
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
     const res = await marketplace.MarketplaceAddItem({
       nftObjectId: argv.object.startsWith("iq__") ? argv.object : undefined,
       nftObjectHash: argv.object.startsWith("hq__") ? argv.object : undefined,
@@ -776,7 +778,7 @@ const CmdMarketplaceAddItemBatch = async ({ argv }) => {
   console.log(`CSV file containing Object Names and IDs: ${argv.csv}`);
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     const res = await marketplace.MarketplaceAddItemBatch({
       marketplaceObjectId: argv.marketplace,
@@ -795,7 +797,7 @@ const CmdMarketplaceRemoveItem = async ({ argv }) => {
   console.log(`NFT Template Object ID: ${argv.object}`);
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
     const res = await marketplace.MarketplaceRemoveItem({
       nftObjectId: argv.object,
       marketplaceObjectId: argv.marketplace,
@@ -813,7 +815,7 @@ const CmdTenantHasConsumer = async ({ argv }) => {
   console.log(`Account Address: ${argv.addr}`);
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
     var res = await elvlv.TenantHasConsumer({
       groupId: argv.group_id,
       accountAddress: argv.addr,
@@ -832,7 +834,7 @@ const CmdStorefrontSectionAddItem = async ({ argv }) => {
   console.log(`Marketplace Storefront Section: ${argv.section}`);
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
     const res = await marketplace.StorefrontSectionAddItem({
       objectId: argv.marketplace,
       sku: argv.sku,
@@ -852,7 +854,7 @@ const CmdStorefrontSectionRemoveItem = async ({ argv }) => {
   console.log(`Object Write Token: ${argv.writeToken}`);
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
     const res = await marketplace.StorefrontSectionRemoveItem({
       objectId: argv.marketplace,
       sku: argv.sku,
@@ -871,7 +873,7 @@ const CmdNftSetTransferFee = async ({ argv }) => {
   console.log(`Fee: ${argv.fee}`);
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     res = await elvlv.NftSetTransferFee({
       address: argv.addr,
@@ -889,7 +891,7 @@ const CmdNftGetTransferFee = async ({ argv }) => {
   console.log(`NFT Contract Address: ${argv.addr}`);
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     res = await elvlv.NftGetTransferFee({ address: argv.addr });
 
@@ -921,7 +923,7 @@ const CmdNftRemoveRedeemableOffer = async ({ argv }) => {
   console.log(`Offer ID: ${argv.id}`);
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     res = await elvlv.NFTRemoveRedeemableOffer({ addr: argv.addr, 
       offerId:argv.id });
@@ -938,7 +940,7 @@ const CmdNftIsOfferActive = async ({ argv }) => {
   console.log(`Offer ID: ${argv.offer_id}`);
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     res = await elvlv.NFTIsOfferActive({ addr: argv.addr, 
       offerId:argv.offer_id });
@@ -956,7 +958,7 @@ const CmdNftIsOfferRedeemed = async ({ argv }) => {
   console.log(`Offer ID: ${argv.offer_id}`);
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     res = await elvlv.NFTIsOfferRedeemed({ addr: argv.addr,
       tokenId: argv.token_id,
@@ -976,7 +978,7 @@ const CmdNftRedeemOffer = async ({ argv }) => {
   console.log(`Offer ID: ${argv.offer_id}`);
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     let res = await elvlv.NFTRedeemOffer({ 
       addr: argv.addr,
@@ -1001,7 +1003,7 @@ const CmdASNftRedeemOffer = async ({ argv }) => {
 
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
 
     let res = await elvlv.ASNFTRedeemOffer({ 
       addr: argv.addr,
@@ -1024,7 +1026,7 @@ const CmdTenantProvision = async ({ argv }) => {
   console.log(`verbose: ${argv.verbose}`);
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
     let client = elvlv.client;
     let kmsId = ElvUtils.AddressToId({
       prefix: "ikms",
@@ -1052,7 +1054,7 @@ const CmdTenantAddConsumerGroup = async ({ argv }) => {
   console.log(`verbose: ${argv.verbose}`);
 
   try {
-    await Init();
+    await Init({debugLogging: argv.verbose});
     let client = elvlv.client;
     let tenantAddress = Utils.HashToAddress(argv.tenant);
     console.log(`Tenant Contract Address: ${tenantAddress}`);
@@ -1296,7 +1298,7 @@ yargs(hideBin(process.argv))
     alias: "v"
   })
   .command(
-    "nft_add_contract <library> <object> <tenant> [minthelper] [cap] [name] [symbol] [nftaddr] [hold]",
+    "nft_add_contract <library> <object> <tenant> [options]",
     "Add a new or existing NFT contract to an NFT Template object",
     (yargs) => {
       yargs
@@ -1313,11 +1315,11 @@ yargs(hideBin(process.argv))
           type: "string",
         })
         .option("minthelper", {
-          describe: "Mint helper address (hex)",
+          describe: "Mint helper address (hex). Default from tenant configuration.",
           type: "string",
         })
         .option("minter", {
-          describe: "Minter address (hex)",
+          describe: "Minter address (hex). Default from tenant configuration.",
           type: "string",
         })
         .option("cap", {
@@ -1334,6 +1336,10 @@ yargs(hideBin(process.argv))
         })
         .option("nftaddr", {
           describe: "NFT contract address (will not create a new one)",
+          type: "string",
+        })
+        .option("proxyaddr", {
+          describe: "Proxy Address (hex). Default from tenant configuration.",
           type: "string",
         })
         .option("hold", {


### PR DESCRIPTION
Modified tenant_show and nft_add_contract to use the authD tenant minter config
```
eg. nft_add_contract using authD minter config

./elv-live nft_add_contract ilibxxx iq__xxx itenYQbgk66W1BFEqWr95xPmHZEjmdF  --name test --symbol test --cap 10

eg. nft_add_contract override authD minter config

./elv-live nft_add_contract ilibxxx iq__xxx itenYQbgk66W1BFEqWr95xPmHZEjmdF  --name test --symbol test --cap 10 --verbose --minterhelper 0x7087F9434451eAff90F2Ac45daB758972883538E --proxyaddr 0x5557f80D0537E7bB439d919841e0eb9ed449e6BB --minter 0x5557f80D0537E7bB439d919841e0eb9ed449e6BB

```

check_minter and check_cauth options have been removed from tenant_show which checks for errors using the authD tenant_config now.
