### PR TITLE
Add support for tenant authd tickets generation

### DIFF
--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -2311,7 +2311,7 @@ class EluvioLive {
     }
     let ts = Date.now();
     body.ts = ts;
-    
+
     let token = "";
     if ( useFabricToken ) {
       token = await this.client.CreateFabricToken({
@@ -2326,7 +2326,7 @@ class EluvioLive {
     }
 
     let res;
-    
+
     if (host !== undefined) {
       this.client.SetNodes({
         authServiceURIs:[
@@ -2457,6 +2457,35 @@ class EluvioLive {
     });
     return await res.json();
   }
+
+  /**
+   * Generate tickets (NTP) as a tenant.
+   *
+   * @namedParams
+   * @param {string} tenant - The Tenant ID
+   * @param {string} otp - The OTP ID
+   * @param {integer} quantity - Number of tickets to generate
+   * @return {Promise<Object>} - Tickets API Response Object
+   */
+  async TenantTicketsGenerate({ tenant, otp, host, quantity = 1 }) {
+    let now = Date.now();
+
+    let body = {
+      tickets: {
+        quantity: quantity,
+      },
+      ts: now
+    };
+
+    let res = await this.PostServiceRequest({
+      path: urljoin("/tnt/tix", tenant, otp),
+      host,
+      body,
+    });
+    return await res.json();
+
+  }
+
 
   /**
    * Get the list of Tenant marketplaces/sites from the Main Live Object

--- a/src/ElvTenant.js
+++ b/src/ElvTenant.js
@@ -122,15 +122,6 @@ class ElvTenant {
       formatArguments: true,
     });
 
-    // Tenant consumer group (should be deprecated)
-    tenant.consumerGroup = await this.client.CallContractMethod({
-      contractAddress: tenantAddr,
-      abi: JSON.parse(abi),
-      methodName: "groupsMapping",
-      methodArgs: ["tenant_consumer", 0],
-      formatArguments: true,
-    });
-
     // Fabric object information
     tenant.fabric_object_visibility = await this.client.CallContractMethod({
       contractAddress: tenantAddr,

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -353,6 +353,30 @@ const CmdShuffle = async ({ argv }) => {
   }
 };
 
+const CmdTenantTicektsGenerate = async ({ argv }) => {
+  console.log(
+    "Tenant tickets generation",
+    argv.tenant,
+    argv.otp,
+    argv.quantity
+  );
+
+  try {
+    await Init({debugLogging: argv.verbose});
+
+    let res = await elvlv.TenantTicketsGenerate({
+      tenant: argv.tenant,
+      otp: argv.otp,
+      quantity: argv.quantity,
+      host: argv.host
+    });
+
+    console.log("Tickets: ", res);
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
 const CmdTenantMint = async ({ argv }) => {
   console.log(
     "Tenant mint",
@@ -1311,6 +1335,10 @@ yargs(hideBin(process.argv))
     type: "boolean",
     alias: "v"
   })
+  .option("host", {
+    describe: "Alternate URL endpoint",
+    type: "string"
+  })
   .command(
     "nft_add_contract <tenant> <object> <cap> <name> <symbol> [options]",
     "Add a new or existing NFT contract to an NFT Template object",
@@ -1866,6 +1894,29 @@ yargs(hideBin(process.argv))
     },
     (argv) => {
       CmdShuffle({ argv });
+    }
+  )
+
+  .command(
+    "tenant_tickets_generate <tenant> <otp>",
+    "Generate tickets for a given tenant OTP ID",
+    (yargs) => {
+      yargs
+        .positional("tenant", {
+          describe: "Tenant ID",
+          type: "string",
+        })
+        .positional("otp", {
+          describe: "OTP ID (including prefix)",
+          type: "string",
+        })
+        .option("quantity", {
+          describe: "Specify how many to generate (default 1)",
+          type: "integer",
+        });
+    },
+    (argv) => {
+      CmdTenantTicektsGenerate({ argv });
     }
   )
 

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -353,7 +353,7 @@ const CmdShuffle = async ({ argv }) => {
   }
 };
 
-const CmdTenantTicektsGenerate = async ({ argv }) => {
+const CmdTenantTicketsGenerate = async ({ argv }) => {
   console.log(
     "Tenant tickets generation",
     argv.tenant,
@@ -1916,7 +1916,7 @@ yargs(hideBin(process.argv))
         });
     },
     (argv) => {
-      CmdTenantTicektsGenerate({ argv });
+      CmdTenantTicketsGenerate({ argv });
     }
   )
 


### PR DESCRIPTION
Uses new elvauthd API to generate tickets as a tenant, using a tenant ID and a previously generated OTP ID.

Bonus:
- removed the tenant consumer group query which no longer exists for new tenants (and breaks `tenant_info`)
