### PR TITLE
Remove need for tenant name in tenant_provision, use contract name

### DIFF
--- a/src/Provision.js
+++ b/src/Provision.js
@@ -2,6 +2,7 @@
 const fs = require("fs");
 const path = require("path");
 const { ElvUtils } = require("../src/Utils");
+const Utils = require("@eluvio/elv-client-js/src/Utils.js");
 
 const TYPE_LIVE_DROP_EVENT_SITE = "Eluvio LIVE Drop Event Site";
 const TYPE_LIVE_TENANT = "Eluvio LIVE Tenant";
@@ -61,13 +62,26 @@ const SetObjectPermissions = async (client, objectId, tenantAdmins, contentAdmin
   await Promise.all(promises);
 };
 
-const InitializeTenant = async ({client, kmsId, tenantName, tenantId, debug=false}) => {
+const InitializeTenant = async ({client, kmsId, tenantId, debug=false}) => {
   let tenantAdminId = await client.userProfileClient.TenantId();
   let tenantAdminSigner = client.signer;
 
   if (!tenantAdminId){
     throw Error("No tenant admin group set for account.");
   }
+
+  const tenantAddr = Utils.HashToAddress(tenantId);
+  const abi = fs.readFileSync(
+    path.resolve(__dirname, "../contracts/v3/BaseTenantSpace.abi")
+  );
+
+  const tenantName = await client.CallContractMethod({
+    contractAddress: tenantAddr,
+    abi: JSON.parse(abi),
+    methodName: "name",
+    methodArgs: [],
+    formatArguments: true,
+  });
 
   let tenantAdminGroupAddress = client.utils.HashToAddress(tenantAdminId);
 

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -1010,7 +1010,6 @@ const CmdASNftRedeemOffer = async ({ argv }) => {
 const CmdTenantProvision = async ({ argv }) => {
   console.log("Tenant Provision");
   console.log(`Tenant ID: ${argv.tenant}`);
-  console.log(`Tenant Name: ${argv.tenant_name}`);
   console.log(`verbose: ${argv.verbose}`);
 
   try {
@@ -1025,7 +1024,6 @@ const CmdTenantProvision = async ({ argv }) => {
     res = await InitializeTenant({
       client,
       kmsId,
-      tenantName: argv.tenant_name,
       tenantId: argv.tenant,
       debug: true
     });
@@ -2315,15 +2313,11 @@ yargs(hideBin(process.argv))
   )
 
   .command(
-    "tenant_provision <tenant> <tenant_name>",
+    "tenant_provision <tenant>",
     "Provisions a new tenant account with standard media libraries and content types. Note this account must be created using space_tenant_create.",
     (yargs) => {
       yargs.positional("tenant", {
         describe: "Tenant ID",
-        type: "string",
-      });
-      yargs.positional("tenant_name", {
-        describe: "Name of the tenant (without the elv-admin postfix). Used to create access groups name",
         type: "string",
       });
     },


### PR DESCRIPTION
Now we can just do:
`./elv-live tenant_provision itenXXX`