### PR TITLE
fix elv-live warning

### DIFF
--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -9,6 +9,14 @@ const yargs = require("yargs/yargs");
 const { hideBin } = require("yargs/helpers");
 const yaml = require("js-yaml");
 
+const originalEmit = process.emit;
+process.emit = function (name, data, ...args) {
+  if(name === `warning` && typeof data === `object` && data.name === `ExperimentalWarning`) {
+    return false;
+  }
+  return originalEmit.apply(process, arguments);
+};
+
 const CmdAccountCreate = async ({ argv }) => {
   console.log("Account Create\n");
   console.log(`funds: ${argv.funds}`);

--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -9,9 +9,9 @@ const yargs = require("yargs/yargs");
 const { hideBin } = require("yargs/helpers");
 const yaml = require("js-yaml");
 
-# hack that quiets this msg:
-#  node:87980) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
-#  (Use `node --trace-warnings ...` to show where the warning was created)
+// hack that quiets this msg:
+//  node:87980) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
+//  (Use `node --trace-warnings ...` to show where the warning was created)
 const originalEmit = process.emit;
 process.emit = function (name, data, ...args) {
   if(name === `warning` && typeof data === `object` && data.name === `ExperimentalWarning`) {

--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -9,6 +9,9 @@ const yargs = require("yargs/yargs");
 const { hideBin } = require("yargs/helpers");
 const yaml = require("js-yaml");
 
+# hack that quiets this msg:
+#  node:87980) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
+#  (Use `node --trace-warnings ...` to show where the warning was created)
 const originalEmit = process.emit;
 process.emit = function (name, data, ...args) {
   if(name === `warning` && typeof data === `object` && data.name === `ExperimentalWarning`) {

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -15,6 +15,9 @@ const fs = require("fs");
 const path = require("path");
 const prompt = require("prompt-sync")({ sigint: true });
 
+# hack that quiets this msg:
+#  node:87980) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
+#  (Use `node --trace-warnings ...` to show where the warning was created)
 const originalEmit = process.emit;
 process.emit = function (name, data, ...args) {
   if(name === `warning` && typeof data === `object` && data.name === `ExperimentalWarning`) {

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -15,6 +15,14 @@ const fs = require("fs");
 const path = require("path");
 const prompt = require("prompt-sync")({ sigint: true });
 
+const originalEmit = process.emit;
+process.emit = function (name, data, ...args) {
+  if(name === `warning` && typeof data === `object` && data.name === `ExperimentalWarning`) {
+    return false;
+  }
+  return originalEmit.apply(process, arguments);
+};
+
 let elvlv;
 let marketplace;
 

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -15,9 +15,9 @@ const fs = require("fs");
 const path = require("path");
 const prompt = require("prompt-sync")({ sigint: true });
 
-# hack that quiets this msg:
-#  node:87980) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
-#  (Use `node --trace-warnings ...` to show where the warning was created)
+// hack that quiets this msg:
+//  node:87980) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
+//  (Use `node --trace-warnings ...` to show where the warning was created)
 const originalEmit = process.emit;
 process.emit = function (name, data, ...args) {
   if(name === `warning` && typeof data === `object` && data.name === `ExperimentalWarning`) {

--- a/utilities/EluvioLiveCli.test.js
+++ b/utilities/EluvioLiveCli.test.js
@@ -7,6 +7,14 @@ const { Shuffler } = require("../src/Shuffler");
 const fs = require("fs");
 const path = require("path");
 
+const originalEmit = process.emit;
+process.emit = function (name, data, ...args) {
+  if(name === `warning` && typeof data === `object` && data.name === `ExperimentalWarning`) {
+    return false;
+  }
+  return originalEmit.apply(process, arguments);
+};
+
 function checkShuffled() {
   let f = Shuffler.shuffledPath(__dirname + "/../test/shuffle.in.txt");
   expect(fs.readFileSync(f, "utf8")).toEqual(

--- a/utilities/EluvioLiveCli.test.js
+++ b/utilities/EluvioLiveCli.test.js
@@ -7,14 +7,6 @@ const { Shuffler } = require("../src/Shuffler");
 const fs = require("fs");
 const path = require("path");
 
-const originalEmit = process.emit;
-process.emit = function (name, data, ...args) {
-  if(name === `warning` && typeof data === `object` && data.name === `ExperimentalWarning`) {
-    return false;
-  }
-  return originalEmit.apply(process, arguments);
-};
-
 function checkShuffled() {
   let f = Shuffler.shuffledPath(__dirname + "/../test/shuffle.in.txt");
   expect(fs.readFileSync(f, "utf8")).toEqual(


### PR DESCRIPTION
i'm tired of the 

```
(node:87980) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
```

looks bad, let's quiet it