### PR TITLE
Add wallet mapfile

### DIFF
--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -2499,9 +2499,10 @@ class EluvioLive {
    * @namedParams
    * @param {string} tenant - The Tenant ID
    * @param {integer} maxNumber - The address to mint to
+   * @param {integer} mapFile - Store addr->email mapping as CSV (optional)
    * @return {Promise<Object>} - The API Response containing list of Wallet Info
    */
-  async TenantWallets({ tenant, maxNumber = Number.MAX_SAFE_INTEGER }) {
+  async TenantWallets({ tenant, maxNumber = Number.MAX_SAFE_INTEGER, mapFile }) {
     if (maxNumber < 1) {
       maxNumber = Number.MAX_SAFE_INTEGER;
     }
@@ -2510,7 +2511,22 @@ class EluvioLive {
       path: urljoin("/tnt/wlt/", tenant),
       queryParams: { limit: maxNumber },
     });
-    return await res.json();
+
+    var j = await res.json();
+    var contents = j.contents;
+
+    if (mapFile) {
+      for (let i = 0; i < contents.length; i++ ) {
+        fs.appendFile(mapFile, contents[i].addr + "," + contents[i].ident + "\n",
+          err => {
+            if (err) {
+              throw err;
+            }
+          });
+      }
+    }
+
+    return await j;
   }
 
   /**

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -456,6 +456,7 @@ const CmdTenantWallets = async ({ argv }) => {
     let res = await elvlv.TenantWallets({
       tenant: argv.tenant,
       maxNumber: argv.max_results,
+      mapFile: argv.map_file
     });
 
     console.log(yaml.dump(res));
@@ -2109,6 +2110,10 @@ yargs(hideBin(process.argv))
         .option("max_results", {
           describe: "Show up to these many results (default 0 = unlimited)",
           type: "integer",
+        })
+        .option("map_file", {
+          describe: "Optional CSV file to store addr/email mapping",
+          type: "string",
         });
     },
     (argv) => {


### PR DESCRIPTION
Save an optional map file of addr to email when running tenant_wallets.

```
./elv-live tenant_wallets iten0123 --map_file my-emails.csv
```

I am thinking of adding option `--map_file` to nft_show and tenant_show and load emails from the map file to fill in the response (will be a separate PR).