### PR TITLE
nft permissions - validate owner

### DIFF
--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -1554,6 +1554,11 @@ class EluvioLive {
       privateKey: process.env.PRIVATE_KEY
     });
 
+    // Policy can only be set by object owner
+    const objectOwner = await this.client.authClient.Owner({id: objectId});
+    if (objectOwner.toLowerCase() != this.client.signer.address.toLowerCase()) {
+      throw Error("Policy must be set by object owner " + objectOwner);
+    }
 
     //Set Policy
     const policyString = fs.readFileSync(

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -1156,7 +1156,7 @@ const CmdNFTSetPolicyPermissions = async ({ argv }) => {
 
     console.log("\n" + yaml.dump(res));
   } catch (e) {
-    console.error("ERROR:", e);
+    console.error("ERROR:", argv.verbose ? e : e.message);
   }
 };
 


### PR DESCRIPTION
policy failures are confusing if you're in the content managers group -- let's explicitly fail with a warning if this occurs