### PR TITLE
remove consumers group query from tenant_show

### DIFF
--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -66,18 +66,8 @@ class EluvioLive {
       formatArguments: true,
     });
 
-    var tenant_consumer_address = await this.client.CallContractMethod({
-      contractAddress: tenantAddr,
-      abi: JSON.parse(abi),
-      methodName: "groupsMapping",
-      methodArgs: ["tenant_consumer", 0],
-      formatArguments: true,
-    });
-
     return {tenant_admin_address,
-      tenant_admin_id: ElvUtils.AddressToId({prefix:"igrp", address:tenant_admin_address}),
-      tenant_consumer_address,
-      tenant_consumer_id: ElvUtils.AddressToId({prefix:"igrp", address:tenant_consumer_address}),
+      tenant_admin_id: ElvUtils.AddressToId({prefix:"igrp", address:tenant_admin_address})
     };
   }
 


### PR DESCRIPTION
"We discontinued the consumer group feature - it was only there to allow finding NFTs for a user, and we no longer need that since we deployed the bc indexer"