### PR TITLE
Add payment totals

### DIFF
--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -849,7 +849,7 @@ class EluvioLive {
    * @return {Promise<Object>} - New contract address
    */
   async NftSetTransferProxy({ addr, proxyAddr }) {
-    if (proxyAddr == null || proxyAddr.length() == 0) {
+    if (proxyAddr == null || proxyAddr.length == 0) {
       proxyAddr = await this.CreateNftTransferProxy({});
     }
 

--- a/src/ElvContracts.js
+++ b/src/ElvContracts.js
@@ -374,7 +374,7 @@ class ElvContracts {
         });
         payees[payeeAddr].releasable = Ethers.utils.formatUnits(releasable, decimals);
 
-        let payeeTotal = Ethers.BigNumber.from(released)
+        let payeeTotal = Ethers.BigNumber.from(released);
         payeeTotal = payeeTotal.add(Ethers.BigNumber.from(releasable));
         payees[payeeAddr].total = Ethers.utils.formatUnits(payeeTotal, decimals);
         total = total.add(payeeTotal);

--- a/src/ElvContracts.js
+++ b/src/ElvContracts.js
@@ -305,7 +305,7 @@ class ElvContracts {
       path.resolve(__dirname, "../contracts/v4/Payment.abi")
     );
     const abistrToken = fs.readFileSync(
-      path.resolve(__dirname, "../contracts/v4/IERC20.abi")
+      path.resolve(__dirname, "../contracts/v4/ElvToken.abi")
     );
 
     const decimals = await this.client.CallContractMethod({
@@ -331,6 +331,7 @@ class ElvContracts {
       formatArguments: true,
     });
 
+    var total = Ethers.BigNumber.from(0);
     var payees = {};
 
     // Number of stakeholders is not available - try up to 10
@@ -373,6 +374,10 @@ class ElvContracts {
         });
         payees[payeeAddr].releasable = Ethers.utils.formatUnits(releasable, decimals);
 
+        let payeeTotal = Ethers.BigNumber.from(released)
+        payeeTotal = payeeTotal.add(Ethers.BigNumber.from(releasable));
+        payees[payeeAddr].total = Ethers.utils.formatUnits(payeeTotal, decimals);
+        total = total.add(payeeTotal);
 
       } catch (e) {
         // Stop here when we reach the end of the payee list
@@ -388,6 +393,7 @@ class ElvContracts {
       contract_address: contractAddress,
       shares: Ethers.BigNumber.from(totalShares._hex).toNumber(),
       released: Ethers.utils.formatUnits(totalReleased, decimals),
+      total: Ethers.utils.formatUnits(total, decimals),
       payees
     };
 


### PR DESCRIPTION
Bonus fix:
- NFT proxy command had a syntax error - length()
- use token ABI instead of IERC20 for decimals function

New output:

```

contract_address: '0x9d57f1d811bf5d24ad1d9dbcf1ae8229335c419c'
shares: 100
released: '0.9'
total: '1643.0'
payees:
  '0x1B50E06d8C1fB546c95655Ce5d49014249f5De46':
    shares: 20
    released: '0.0'
    releasable: '328.6'
    total: '328.6'
  '0x96880b592a4C8E9483807F321448Db2121136e50':
    shares: 20
    released: '0.0'
    releasable: '328.6'
    total: '328.6'
  '0xC05e0274158442B7d595E5AC6D483d18DF8fc93e':
    shares: 30
    released: '0.0'
    releasable: '492.9'
    total: '492.9'
  '0x165B828643eB0fA8A7C6b15330670106169941cc':
    shares: 30
    released: '0.9'
    releasable: '492.0'
    total: '492.9'
```