### PR TITLE
Implement content object policy functions

### DIFF
--- a/common_policies/site_policy.yaml
+++ b/common_policies/site_policy.yaml
@@ -1,0 +1,197 @@
+name: Site Policy With Broadcaster Audience Rules
+type: ast
+expr:
+  rule: main
+rules:
+
+  # --- Site access rules ------------------------------------------------------
+
+  # !a or !b or !c  ==> not(a and b and c)
+  # !a and !b and !c  ==> not(a or b or c)
+
+  # if isEntryPoint {
+  #   if ...
+  # } else {
+  #   return true
+  # }
+
+  #  (isEntryPoint and (....)) or (!isEntryPoint and (...))
+  #
+  #  main:
+  #    if:
+  #      condition:
+  #        and:
+  #          - true
+  #          - true
+  #      then:
+  #        - true
+  #      else: true
+
+  main:
+    and:
+      - rule: permittedTitles
+      - or:
+          - rule: publicContent
+          - rule: isContentDecrypt
+
+  permittedTitles:
+    in:
+      - env: call/resource_id
+      - - iq__XXX
+        - iq__YYY
+
+  isContentDecrypt:
+    and:
+      - in:
+          - env: api_call/action
+          - - q.read.part.read
+            - q.read.decrypt
+      - fn.ids.Equivalent:
+          - env: api_call/subject
+          - env: api_call/node_id
+
+  publicContent: # as if title was accessed with a "state-channel token" for the title
+    or:
+      - and:
+          - env: call/is_entry_point
+          - or:
+              - rule: isBcRead
+              - rule: isPublicMeta
+          - not:
+              or:
+                - rule: isEncryptedData
+                - rule: isCryptRead
+                - in:
+                    - env: api_call/action
+                    - - q.read.versions
+                      - q.read.decrypt
+      - not:
+          env: call/is_entry_point
+
+  isBcRead:
+    eq:
+      - env: api_call/action
+      - q.read.bccall
+  isPublicMeta:
+    and:
+      - eq:
+          - env: api_call/action
+          - q.read.meta
+      - or:
+          - fn.strings.StartsWith:
+              - env: api_call/meta_path
+              - /public
+          - not:
+              env: call/is_entry_point
+  isEncryptedData:
+    and:
+      - in:
+          - env: api_call/action
+          - - q.read.part.read
+            - q.read.files.read
+      - env: call/is_encrypted_data
+  isCryptRead:
+    and:
+      - in:
+          - env: api_call/action
+          - q.read.crypt
+      - env: call/is_entry_point
+      - eq:
+          - env: call/grant
+          - read-crypt
+
+  #	if ep.Action.isIn(Actions.QReadBcCall()) {
+  #		return nil
+  #	}
+  #	if ep.Action.isIn(Actions.QReadMeta()) && !pathIn(ep.MetaPath, publicQMetaPath) {
+  #		return e("reason", "illegal metadata path: "+ep.MetaPath)
+  #	}
+  #	if ep.Action.isIn(Actions.QReadPartRead(), Actions.QReadFilesRead()) &&
+  #		ep.isEncryptedData() {
+  #		return e("reason", "access to encrypted data")
+  #	}
+  #	if ep.Action.isIn(Actions.QReadVersions(), Actions.QReadDecrypt()) {
+  #		return e("reason", "invalid action "+ep.Action)
+  #	}
+  #	if ep.Action.isIn(Actions.QReadCrypt()) && ep.Grant != auth.Grants.ReadCrypt {
+  #		return e("reason", fmt.Sprintf("invalid action %s for grant %s", ep.Action, ep.Grant))
+  #	}
+
+  # --- Broadcaster audience rules -----------------------------------------------------
+
+  # action rules
+  broadcaster/policy/any.phone/blackout:
+    extra:
+      lastUpdated: 2016-10-21T15:04:40Z
+    rule: broadcaster/audience/any.phone
+    # action: urn:scte:224:action:blackout
+  broadcaster/policy/fl.all/blackout:
+    extra:
+      lastUpdated: 2016-10-21T15:04:40Z
+    rule: broadcaster/audience/fl.all
+    # action: urn:scte:224:action:blackout
+  broadcaster/policy/any.all/blackout:
+    extra:
+      lastUpdated: 2016-10-21T15:04:40Z
+    rule: broadcaster/audience/any.all
+    # action: urn:scte:224:action:blackout
+
+  # audience rules
+  broadcaster/audience/any.phone:
+    extra:
+      description: Users anywhere and on a phone
+      lastUpdated: 2016-10-21T15:04:40Z
+    and:
+      - rule: "broadcaster/audience/location/any"
+      - rule: "broadcaster/audience/device/phone"
+  broadcaster/audience/fl.all:
+    extra:
+      description: Users in florida
+      lastUpdated: 2016-10-21T15:04:40Z
+    and:
+      - rule: "broadcaster/audience/location/fl"
+      - rule: "broadcaster/audience/device/all"
+  broadcaster/audience/any.all:
+    extra:
+      description: Users anywhere and on all devices
+      lastUpdated: 2016-10-21T15:04:40Z
+    and:
+      - rule: broadcaster/audience/location/any
+      - rule: broadcaster/audience/device/all
+
+  # location rules
+  broadcaster/audience/location/any:
+    extra:
+      description: No geo restrictions
+      lastUpdated: 2016-10-21T15:04:40Z
+    and:
+      - true
+  broadcaster/audience/location/fl:
+    extra:
+      description: Audience in Florida
+      lastUpdated: 2016-10-21T15:04:40Z
+    or:
+      - in:
+          - env: token/ctx/usr/location
+          - - "32003"
+            - "32004"
+
+  # device rules
+  broadcaster/audience/device/phone:
+    extra:
+      description: Audience using phones
+      lastUpdated: 2016-10-21T15:04:40Z
+    equal:
+      - env: token/ctx/usr/device
+      - Phone
+  broadcaster/audience/device/all:
+    extra:
+      description: Audience using any device
+      lastUpdated: 2016-10-21T15:04:40Z
+    and:
+      - true
+
+  # --- Extra test rules -----------------------------------------------------
+
+  testEvalContextFunctionRule:
+    func: testCtxFunction

--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -1565,26 +1565,8 @@ class EluvioLive {
 
     let account = new ElvAccount({configUrl:this.configUrl, debugLogging: this.debug});
     account.InitWithClient({elvClient: this.client});
-    let signer = (await account.Show())["userId"];
 
-    let auth_policy =  {
-      id:"",
-      description:"",
-      type:"epl-ast",
-      version:"1.0",
-      body: policyString
-    };
-
-    let encoded = `${auth_policy.type}|${auth_policy.version}|${auth_policy.body}|`;
-
-    let signature = await this.client.Sign(encoded);
-    auth_policy.signer = signer;
-    auth_policy.signature = signature;
-
-
-    let policyFormat = {
-      auth_policy
-    };
+    let policyFormat = await ElvUtils.parseAndSignPolicy({policyString, configUrl:this.configUrl, elvAccount:account});
 
     if (this.debug){
       console.log("Policy Value To Set: ", policyFormat);

--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -1527,6 +1527,7 @@ class EluvioLive {
 
   /**
    * Sets the nft policy and permissions for a given object
+   * throws error if something goes wrong.
    *
    * @namedParams
    * @param {string} objectId - The NFT object ID
@@ -1578,8 +1579,12 @@ class EluvioLive {
       value: JSON.stringify(policyFormat)
     });
 
+    if (!ElvUtils.isTransactionSuccess(res)) {
+      throw res;
+    }
+
     if (!clearAddresses && addresses.length == 0) {
-      return {policyResponse: res};
+      return;
     }
 
     if (clearAddresses){
@@ -1603,8 +1608,10 @@ class EluvioLive {
     if (this.debug){
       console.log("Set Policy response: ", res);
     }
-    return {policyResponse: res, permissionsResponse: res2};
 
+    if (!ElvUtils.isTransactionSuccess(res)) {
+      throw res2;
+    }
   }
 
   /**
@@ -1703,7 +1710,7 @@ class EluvioLive {
     }
 
     // Set policy in object metadata
-    await elvFabric.setMeta({objectId,meta:policyFormat});
+    await elvFabric.setMeta({objectId,meta:policyFormat, merge:true});
 
     let contractResp = await this.ContentSetPolicyDelegate({objectId,delegateId:objectId});
     return contractResp;
@@ -1803,7 +1810,7 @@ class EluvioLive {
       value: ""
     });
 
-    return {deleteDelegateResp};
+    return deleteDelegateResp;
   }
 
   /**

--- a/src/ElvAccount.js
+++ b/src/ElvAccount.js
@@ -12,7 +12,7 @@ class ElvAccount {
    * @namedParams
    * @param {string} configUrl - The Content Fabric configuration URL
    * @param {string} mainObjectId - The top-level Eluvio Live object ID
-   * @return {ElvSpace} - New ElvSpace object connected to the specified content fabric and blockchain
+   * @return {ElvSpace} - New ElvAccount object connected to the specified content fabric and blockchain
    */
   constructor({ configUrl, debugLogging = false }) {
     this.configUrl = configUrl;

--- a/src/ElvFabric.js
+++ b/src/ElvFabric.js
@@ -49,8 +49,9 @@ class ElvFabric {
    * Set content metadata for an object
    * @param {string} objectId
    * @param {object} meta Metadata tree to merge into the object
+   * @param {boolean} merge Merge == true will merge instead of replace
    */
-  async setMeta({objectId, meta}) {
+  async setMeta({objectId, meta, merge=false}) {
     if (this.debug){
       console.log("Set Meta", objectId, "meta", JSON.stringify(meta));
     }
@@ -66,13 +67,23 @@ class ElvFabric {
       objectId
     });
 
-    await this.client.ReplaceMetadata({
-      libraryId,
-      objectId,
-      writeToken: editResponse.write_token,
-      metadata: meta,
-      metadataSubtree: "/"
-    });
+    if (!merge) {
+      await this.client.ReplaceMetadata({
+        libraryId,
+        objectId,
+        writeToken: editResponse.write_token,
+        metadata: meta,
+        metadataSubtree: "/"
+      });
+    } else {
+      await this.client.MergeMetadata({
+        libraryId,
+        objectId,
+        writeToken: editResponse.write_token,
+        metadata: meta,
+        metadataSubtree: "/"
+      });
+    }
 
     await this.client.FinalizeContentObject({
       libraryId,

--- a/src/ElvFabric.js
+++ b/src/ElvFabric.js
@@ -51,9 +51,16 @@ class ElvFabric {
    * @param {object} meta Metadata tree to merge into the object
    */
   async setMeta({objectId, meta}) {
-    console.log("Set Meta", objectId, "meta", JSON.stringify(meta)); // PENDING debug log
+    if (this.debug){
+      console.log("Set Meta", objectId, "meta", JSON.stringify(meta));
+    }
 
     const libraryId = await this.client.ContentObjectLibraryId({objectId});
+
+    if (this.debug){
+      console.log("Library ID Found ", libraryId);
+    }
+
     const editResponse = await this.client.EditContentObject({
       libraryId,
       objectId
@@ -75,7 +82,7 @@ class ElvFabric {
   }
 
   /**
-   * Set content metadata for an object
+   * Get content metadata for an object
    * @param {string} objectId
    */
   async getMeta({objectId, select, includeHash=false}) {

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -117,6 +117,33 @@ class ElvUtils {
     return row;
   }
 
+  static async parseAndSignPolicy({policyString, description="", data="", elvAccount}){
+    
+    let signer = (await elvAccount.Show())["userId"];
+
+    let auth_policy =  {
+      id:"",
+      description,
+      type:"epl-ast",
+      version:"1.0",
+      body: policyString,
+      data
+    };
+
+    let encoded = `${auth_policy.type}|${auth_policy.version}|${auth_policy.body}|${data}`;
+
+    let signature = await elvAccount.client.Sign(encoded);
+    auth_policy.signer = signer;
+    auth_policy.signature = signature;
+
+
+    let policyFormat = {
+      auth_policy
+    };
+
+    return policyFormat;
+  }
+
 }
 
 

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -117,7 +117,7 @@ class ElvUtils {
     return row;
   }
 
-  static async parseAndSignPolicy({policyString, description="", data="", elvAccount}){
+  static async parseAndSignPolicy({policyString, description="", data=null, elvAccount}){
     
     let signer = (await elvAccount.Show())["userId"];
 
@@ -130,7 +130,13 @@ class ElvUtils {
       data
     };
 
-    let encoded = `${auth_policy.type}|${auth_policy.version}|${auth_policy.body}|${data}`;
+    let encoded = `${auth_policy.type}|${auth_policy.version}|${auth_policy.body}|`;
+
+    if (data != null) {
+      data = {"/": "./" + path.join("meta",data)};
+      auth_policy["data"] = data;
+      encoded = encoded + `${data}`;
+    }
 
     let signature = await elvAccount.client.Sign(encoded);
     auth_policy.signer = signer;
@@ -142,6 +148,13 @@ class ElvUtils {
     };
 
     return policyFormat;
+  }
+
+  static isTransactionSuccess(tx){
+    if (tx.logs && tx.logs.length != 0){
+      return true;
+    }
+    return false;
   }
 
 }

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -118,7 +118,7 @@ class ElvUtils {
   }
 
   static async parseAndSignPolicy({policyString, description="", data=null, elvAccount}){
-    
+
     let signer = (await elvAccount.Show())["userId"];
 
     let auth_policy =  {
@@ -133,15 +133,14 @@ class ElvUtils {
     let encoded = `${auth_policy.type}|${auth_policy.version}|${auth_policy.body}|`;
 
     if (data != null) {
-      let link  = {"/": "./" + path.join("meta",data)};
-      auth_policy["data"] = link;
-      encoded = encoded + `${data}`;
+      let link  = "./" + path.join("meta",data);
+      auth_policy["data"] = {"/" : link};
+      encoded = encoded + `${link}`;
     }
 
     let signature = await elvAccount.client.Sign(encoded);
     auth_policy.signer = signer;
     auth_policy.signature = signature;
-
 
     let policyFormat = {
       auth_policy

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -133,8 +133,8 @@ class ElvUtils {
     let encoded = `${auth_policy.type}|${auth_policy.version}|${auth_policy.body}|`;
 
     if (data != null) {
-      data = {"/": "./" + path.join("meta",data)};
-      auth_policy["data"] = data;
+      let link  = {"/": "./" + path.join("meta",data)};
+      auth_policy["data"] = link;
       encoded = encoded + `${data}`;
     }
 

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -1465,6 +1465,81 @@ const CmdTokenCreate = async ({ argv }) => {
   }
 };
 
+const CmdContentSetPolicy  = async ({ argv }) => {
+  console.log("Content Set Policy");
+  console.log(`Object: ${argv.object}`);
+  console.log(`Policy Path: ${argv.policy_path}`);
+  console.log(`Data: ${argv.data}`);
+
+  try {
+    await Init({ debugLogging: argv.verbose });
+
+    res = await elvlv.ContentSetPolicy({
+      objectId: argv.object,
+      policyPath: argv.policy_path,
+      data: argv.data
+    });
+
+    console.log("\n" + yaml.dump(res));
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
+const CmdContentSetPolicyDelegate  = async ({ argv }) => {
+  console.log("Content Set Policy Delegate");
+  console.log(`Object: ${argv.object}`);
+  console.log(`Policy Path: ${argv.delegate}`);
+  console.log(`Data: ${argv.data}`);
+
+  try {
+    await Init({ debugLogging: argv.verbose });
+
+    res = await elvlv.ContentSetPolicyDelegate({
+      objectId: argv.object,
+      delegateId: argv.delegate
+    });
+
+    console.log("\n" + yaml.dump(res));
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
+const CmdContentGetPolicy  = async ({ argv }) => {
+  console.log("Content Get Policy");
+  console.log(`Object: ${argv.object}`);
+
+  try {
+    await Init({ debugLogging: argv.verbose });
+
+    res = await elvlv.ContentGetPolicy({
+      objectId: argv.object
+    });
+
+    console.log("\n" + yaml.dump(res));
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
+const CmdContentClearPolicy = async ({ argv }) => {
+  console.log("Content Clear Policy");
+  console.log(`Object: ${argv.object}`);
+
+  try {
+    await Init({ debugLogging: argv.verbose });
+
+    res = await elvlv.ContentClearPolicy({
+      objectId: argv.object
+    });
+
+    console.log("\n" + yaml.dump(res));
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
 yargs(hideBin(process.argv))
   .option("verbose", {
     describe: "Verbose mode",
@@ -2922,6 +2997,78 @@ yargs(hideBin(process.argv))
     },
     (argv) => {
       CmdTokenCreate({ argv });
+    }
+  )
+
+  .command(
+    "content_set_policy <object> <policy_path> [data]",
+    "Set the policy on an existing content object. This also sets the delegate on the object contract to itself.",
+    (yargs) => {
+      yargs
+        .positional("object", {
+          describe: "ID of the content object",
+          type: "string",
+        })
+        .positional("policy_path", {
+          describe: "Path to the content object policy file (eg. policy.yaml)",
+          type: "string",
+        })
+        .option("data", {
+          describe: "Metadata path within the policy object to link to",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdContentSetPolicy({ argv });
+    }
+  )
+
+  .command(
+    "content_set_policy_delegate <object> <delegate>",
+    "Set the policy delegate on the object contract.",
+    (yargs) => {
+      yargs
+        .positional("object", {
+          describe: "ID of the content object",
+          type: "string",
+        })
+        .positional("delegate", {
+          describe: "ID of the content object policy delegate",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdContentSetPolicyDelegate({ argv });
+    }
+  )
+
+  .command(
+    "content_get_policy <object>",
+    "Get the content object policy from the object metadata and the delegate from the object's contract meta",
+    (yargs) => {
+      yargs
+        .positional("object", {
+          describe: "ID of the content object",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdContentGetPolicy({ argv });
+    }
+  )
+
+  .command(
+    "content_clear_policy <object>",
+    "Remove content object policy from the object metadata and the delegate from the object's contract meta",
+    (yargs) => {
+      yargs
+        .positional("object", {
+          describe: "ID of the content object",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdContentClearPolicy({ argv });
     }
   )
 

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -1154,7 +1154,7 @@ const CmdNFTSetPolicyPermissions = async ({ argv }) => {
       clearAddresses: argv.clear
     });
 
-    console.log("\n" + yaml.dump(res));
+    console.log("Success!");
   } catch (e) {
     console.error("ERROR:", argv.verbose ? e : e.message);
   }
@@ -1480,7 +1480,12 @@ const CmdContentSetPolicy  = async ({ argv }) => {
       data: argv.data
     });
 
-    console.log("\n" + yaml.dump(res));
+    if (ElvUtils.isTransactionSuccess(res)){
+      console.log("Success!");
+    } else {
+      console.log("Transaction Error: ", yaml.dump(res));
+    }
+
   } catch (e) {
     console.error("ERROR:", e);
   }
@@ -1500,7 +1505,11 @@ const CmdContentSetPolicyDelegate  = async ({ argv }) => {
       delegateId: argv.delegate
     });
 
-    console.log("\n" + yaml.dump(res));
+    if (ElvUtils.isTransactionSuccess(res)){
+      console.log("Success!");
+    } else {
+      console.log("Transaction Error: ", yaml.dump(res));
+    }
   } catch (e) {
     console.error("ERROR:", e);
   }
@@ -1534,7 +1543,11 @@ const CmdContentClearPolicy = async ({ argv }) => {
       objectId: argv.object
     });
 
-    console.log("\n" + yaml.dump(res));
+    if (ElvUtils.isTransactionSuccess(res)){
+      console.log("Success!");
+    } else {
+      console.log("Transaction Error: ", yaml.dump(res));
+    }
   } catch (e) {
     console.error("ERROR:", e);
   }


### PR DESCRIPTION
```
  content_set_policy <object>               Set the policy on an existing
  <policy_path> [data]                      content object. This also sets the
                                            delegate on the object contract to
                                            itself.
  content_set_policy_delegate <object>      Set the policy delegate on the
  <delegate>                                object contract.
  content_get_policy <object>               Get the content object policy from
                                            the object metadata and the delegate
                                            from the object's contract meta
  content_clear_policy <object>             Remove content object policy from
                                            the object metadata and the delegate
                                            from the object's contract meta
```