### PR TITLE
Add global option for alternate auth services URL

### DIFF
--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -35,10 +35,19 @@ class EluvioLive {
     this.debug = false;
   }
 
-  async Init({debugLogging = false}={}) {
+  async Init({debugLogging = false, asUrl}={}) {
     this.client = await ElvClient.FromConfigurationUrl({
       configUrl: this.configUrl,
     });
+
+    if (asUrl) {
+      this.client.SetNodes({
+        authServiceURIs:[
+          asUrl
+        ]
+      });
+    }
+
     let wallet = this.client.GenerateWallet();
     let signer = wallet.AddAccount({
       privateKey: process.env.PRIVATE_KEY,

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -30,7 +30,7 @@ process.emit = function (name, data, ...args) {
 let elvlv;
 let marketplace;
 
-const Init = async ({debugLogging = false}={}) => {
+const Init = async ({debugLogging = false, asUrl}={}) => {
   console.log("Network: " + Config.net);
 
   const config = {
@@ -38,7 +38,7 @@ const Init = async ({debugLogging = false}={}) => {
     mainObjectId: Config.mainObjects[Config.net],
   };
   elvlv = new EluvioLive(config);
-  await elvlv.Init({ debugLogging });
+  await elvlv.Init({ debugLogging, asUrl });
 
   marketplace = new Marketplace(config);
   await marketplace.Init({ debugLogging });
@@ -520,9 +520,10 @@ const CmdTenantPrimarySales = async ({ argv }) => {
   );
   console.log(`Offset: ${argv.offset}`);
   console.log(`CSV: ${argv.csv}`);
+  console.log("All argv", argv);
 
   try {
-    await Init({debugLogging: argv.verbose});
+    await Init({debugLogging: argv.verbose, asUrl: argv.as_url});
 
     let res = await elvlv.TenantPrimarySales({
       tenant: argv.tenant,
@@ -1561,6 +1562,10 @@ yargs(hideBin(process.argv))
   })
   .option("host", {
     describe: "Alternate URL endpoint",
+    type: "string"
+  })
+  .option("as_url", {
+    describe: "Alternate authority service URL (include '/as/' route if necessary)",
     type: "string"
   })
   .command(

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -520,7 +520,6 @@ const CmdTenantPrimarySales = async ({ argv }) => {
   );
   console.log(`Offset: ${argv.offset}`);
   console.log(`CSV: ${argv.csv}`);
-  console.log("All argv", argv);
 
   try {
     await Init({debugLogging: argv.verbose, asUrl: argv.as_url});


### PR DESCRIPTION
There already is a `--host` global option as well as several command-specific instances but it doesn't work 'globally'.

There is a complication with respect to the `/as` prefix - in this case the `--as_url` command takes a URL including `/as` (if applicable - for local instances simply don't add `/as`).
