### PR TITLE
add --payee flag for payment_release cmd

### DIFF
--- a/src/ElvContracts.js
+++ b/src/ElvContracts.js
@@ -400,18 +400,25 @@ class ElvContracts {
   }
 
   /**
-   * Retrieve funds from payment splitter contract, as a payee
+   * Retrieve funds from payment splitter contract, as a payee or for payee address provided
    * @param {string} addr: address of the payment contract
    * @param {string} tokenContractAddress: address of the token contract (ERC20)
+   * @param {string} payeeAddress: address of the payee
    */
-  async PaymentRelease({ contractAddress, tokenContractAddress }){
+  async PaymentRelease({ addr, tokenContractAddress, payeeAddress }){
     const abistr = fs.readFileSync(
       path.resolve(__dirname, "../contracts/v4/Payment.abi")
     );
 
-    const payee = await this.client.signer.address;
+    let payee;
+    if (payeeAddress != "") {
+      payee = payeeAddress;
+    } else {
+      payee = await this.client.signer.address;
+    }
+
     const res = await this.client.CallContractMethod({
-      contractAddress: contractAddress,
+      contractAddress: addr,
       abi: JSON.parse(abistr),
       methodName: "release(address,address)",
       methodArgs: [

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -1402,11 +1402,13 @@ const CmdPaymentRelease = async ({ argv }) => {
     });
 
     res = await elvContract.PaymentRelease({
-      contractAddress: argv.addr,
-      tokenContractAddress: argv.token_addr
+      addr: argv.addr,
+      tokenContractAddress: argv.token_addr,
+      payeeAddress: argv.payee,
     });
 
     console.log("\n" + yaml.dump(await res));
+    console.log("Payment release successful.");
   } catch (e) {
     console.error("ERROR:", argv.verbose ? e : e.message);
   }
@@ -2948,7 +2950,7 @@ yargs(hideBin(process.argv))
 
   .command(
     "payment_release addr token_addr",
-    "Retrieve payment from payment splitter contract as a payee",
+    "Retrieve payment from payment splitter contract as a payee or for a payee using --payee flag.",
     (yargs) => {
       yargs
         .positional("addr", {
@@ -2958,6 +2960,11 @@ yargs(hideBin(process.argv))
         .positional("token_addr", {
           describe: "Address of the ERC20 token contract (hex)",
           type: "string"
+        })
+        .option("payee", {
+          describe: "payee address",
+          type: "string",
+          default: "",
         });
     },
     (argv) => {


### PR DESCRIPTION
If `--payee` flag is provided, the payee address is obtained from it or from the signer private key for payment_release cmd.
