### PR TITLE
Add elv-stream for live stream management

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ You'll need the latest current Nodejs and NPM (Node 17.5.0+ or npm 8.5.1+): http
 npm install
 ```
 
-Then:
+# Tools
+
+# EluvioLive CLI
+
+The EluvioLive CLI (`elv-live`) provides tenant, tokens and marketplace management commands.
 
 ```
 ./elv-live --help
@@ -26,7 +30,7 @@ Usage: elv-live <command>
 Commands:
   ...
 ```
-# Usage Examples
+## Usage Examples
 
 Environment variables required:
 
@@ -92,6 +96,7 @@ Properties > Library Info > Library Id
 Tenant Object Id *
 Properties > Eluvio LIVE Tenant > Object Id
 ```
+
 ## NFT commands
 
 Set up an NFT contract and associate it with an NFT Template object:
@@ -100,7 +105,7 @@ Set up an NFT contract and associate it with an NFT Template object:
 ./elv-live nft_add_contract  ilib3ErteXJcCoTapj2ZhEvMKWau6jET iq__QrxLAAJ8V1xbdPzGVMwjHTpoFKP itenYQbgk66W1BFEqWr95xPmHZEjmdF --minthelper 0x59e79eFE007F5208857a646Db5cBddA82261Ca81 --cap 100 --name "TEST NFT SERIES A" --symbol "TESTA"
 ```
 
-## NFT Build for generative images or videos
+### NFT Build for generative images or videos
 
 ./elv-live nft_build command assumes the nft_template object has been created and source images and videos have been ingested into the fabric such that image and embedded video urls have been generated and working.
 
@@ -146,3 +151,37 @@ NFT content object's value from /asset_metadata/nft if present.
 The required key 'attributes' is an array of objects {"trait_type": "", "value": ""}
 and is used to calculate trait rarity. If rarity is already present in the attribute,
 it will be used instead.
+
+# EluvioStream CLI
+
+```
+  export PRIVATE_KEY=0x...
+  ./elv-stream
+
+```
+
+The EluvioStream CLI provides commands for managing live streams.
+
+The general flow for managing a live stream is:
+
+1. Create and configure a live stream content object
+
+  This can be performed with the Fabric Browser
+
+2. Create a 'stream'
+
+  A live stream content object is only active once you create a 'stream'.
+
+3. Start the 'stream'
+
+  This is the process by which the stream is listening for input and is ready to stream.
+
+4. Stop or Reset the 'stream'
+
+  During streaming, you can stop (pause) or reset the stream which will discontinue playout until the stream is restarted.
+
+5. Terminate the stream
+
+  The stream is ended and can no longer be restarted.  You can create a new stream within
+  the same content object.
+

--- a/elv-stream
+++ b/elv-stream
@@ -1,0 +1,5 @@
+#! /usr/bin/env bash
+
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+node $SOURCE_DIR/utilities/EluvioLiveStreamCli.js $* 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "dot-object": "^2.1.4",
         "ethers": "^5.5.4",
         "fraction.js": "^4.1.1",
+        "got": "^11.8.6",
         "js-yaml": "^3.14.1",
         "keccak256": "^1.0.6",
         "prompt-sync": "^4.2.0",
@@ -2047,6 +2048,17 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/@sindresorhus/slugify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-1.1.2.tgz",
@@ -2103,6 +2115,17 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -2153,6 +2176,17 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
@@ -2188,6 +2222,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -2217,6 +2256,14 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "17.0.25",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.25.tgz",
@@ -2227,6 +2274,14 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.0.tgz",
       "integrity": "sha512-G/AdOadiZhnJp0jXCaBQU449W2h716OW/EoXeYkCytxKL06X1WCXB4DZpp8TpZ8eyIJVS1cw4lrlkkSYU21cDw==",
       "dev": true
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -2938,6 +2993,31 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
+      "integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -3078,6 +3158,17 @@
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/co": {
@@ -3337,6 +3428,31 @@
       "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
       "dev": true
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -3380,6 +3496,14 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dependencies": {
         "clone": "^1.0.2"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/define-properties": {
@@ -3612,6 +3736,14 @@
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -4462,6 +4594,20 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -4505,6 +4651,30 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
     "node_modules/graceful-fs": {
@@ -4627,6 +4797,11 @@
         "readable-stream": "^3.1.1"
       }
     },
+    "node_modules/http-cache-semantics": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
+    },
     "node_modules/http-proxy": {
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
@@ -4678,6 +4853,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -6837,6 +7024,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -6932,6 +7124,14 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
+      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
+      "dependencies": {
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/kind-of": {
@@ -7039,6 +7239,14 @@
       "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
       "dev": true
     },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -7138,6 +7346,14 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -7311,6 +7527,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -7430,6 +7657,14 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-limit": {
@@ -7820,6 +8055,15 @@
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
     },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -7841,6 +8085,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ramda": {
@@ -7960,6 +8215,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
+    },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
@@ -7997,6 +8257,17 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/revalidator": {
@@ -10657,6 +10928,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="
+    },
     "@sindresorhus/slugify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-1.1.2.tgz",
@@ -10698,6 +10974,14 @@
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "requires": {
+        "defer-to-connect": "^2.0.0"
       }
     },
     "@tootallnate/once": {
@@ -10747,6 +11031,17 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "requires": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
     "@types/eslint": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
@@ -10782,6 +11077,11 @@
         "@types/node": "*"
       }
     },
+    "@types/http-cache-semantics": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -10811,6 +11111,14 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
+    "@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
       "version": "17.0.25",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.25.tgz",
@@ -10821,6 +11129,14 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.0.tgz",
       "integrity": "sha512-G/AdOadiZhnJp0jXCaBQU449W2h716OW/EoXeYkCytxKL06X1WCXB4DZpp8TpZ8eyIJVS1cw4lrlkkSYU21cDw==",
       "dev": true
+    },
+    "@types/responselike": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/stack-utils": {
       "version": "2.0.1",
@@ -11388,6 +11704,25 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
+    "cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA=="
+    },
+    "cacheable-request": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
+      "integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      }
+    },
     "call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -11487,6 +11822,14 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+    },
+    "clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
     },
     "co": {
       "version": "4.6.0",
@@ -11707,6 +12050,21 @@
       "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
       "dev": true
     },
+    "decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "requires": {
+        "mimic-response": "^3.1.0"
+      },
+      "dependencies": {
+        "mimic-response": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+        }
+      }
+    },
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -11745,6 +12103,11 @@
       "requires": {
         "clone": "^1.0.2"
       }
+    },
+    "defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg=="
     },
     "define-properties": {
       "version": "1.1.4",
@@ -11935,6 +12298,14 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "enhanced-resolve": {
       "version": "5.9.3",
@@ -12556,6 +12927,14 @@
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true
     },
+    "get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "requires": {
+        "pump": "^3.0.0"
+      }
+    },
     "glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -12588,6 +12967,24 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+    },
+    "got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "requires": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      }
     },
     "graceful-fs": {
       "version": "4.2.10",
@@ -12682,6 +13079,11 @@
         "readable-stream": "^3.1.1"
       }
     },
+    "http-cache-semantics": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
+    },
     "http-proxy": {
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
@@ -12720,6 +13122,15 @@
         "portfinder": "^1.0.25",
         "secure-compare": "3.0.1",
         "union": "~0.5.0"
+      }
+    },
+    "http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "requires": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
       }
     },
     "https-proxy-agent": {
@@ -14316,6 +14727,11 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
+    "json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -14386,6 +14802,14 @@
             "ieee754": "^1.2.1"
           }
         }
+      }
+    },
+    "keyv": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
+      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
+      "requires": {
+        "json-buffer": "3.0.1"
       }
     },
     "kind-of": {
@@ -14472,6 +14896,11 @@
       "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
       "dev": true
     },
+    "lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -14542,6 +14971,11 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
+    },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -14686,6 +15120,11 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
+    "normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
+    },
     "npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -14773,6 +15212,11 @@
       "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
       "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
       "dev": true
+    },
+    "p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="
     },
     "p-limit": {
       "version": "2.3.0",
@@ -15081,6 +15525,15 @@
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
     },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -15094,6 +15547,11 @@
       "requires": {
         "side-channel": "^1.0.4"
       }
+    },
+    "quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
     },
     "ramda": {
       "version": "0.27.2",
@@ -15182,6 +15640,11 @@
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
     },
+    "resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
+    },
     "resolve-cwd": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
@@ -15210,6 +15673,14 @@
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz",
       "integrity": "sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==",
       "dev": true
+    },
+    "responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "requires": {
+        "lowercase-keys": "^2.0.0"
+      }
     },
     "revalidator": {
       "version": "0.1.8",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "dot-object": "^2.1.4",
     "ethers": "^5.5.4",
     "fraction.js": "^4.1.1",
+    "got": "^11.8.6",
     "js-yaml": "^3.14.1",
     "keccak256": "^1.0.6",
     "prompt-sync": "^4.2.0",

--- a/src/LiveObjectSetupStepOne.js
+++ b/src/LiveObjectSetupStepOne.js
@@ -133,10 +133,10 @@ const GenerateOffering = async ({
   const sourceStreams = [];
   const maxStreamIndex = Math.max(aStreamIndex, vStreamIndex);
 
-  for(let i = 0; i <= maxStreamIndex; i++) {
-    if(i === aStreamIndex) {
+  for (let i = 0; i <= maxStreamIndex; i++) {
+    if (i === aStreamIndex) {
       sourceStreams.push(sourceAudioStream);
-    } else if(i === vStreamIndex) {
+    } else if (i === vStreamIndex) {
       sourceStreams.push(sourceVideoStream);
     } else {
       sourceStreams.push(DUMMY_STREAM);
@@ -237,12 +237,12 @@ const GenerateOffering = async ({
     abrProfile
   });
 
-  if(createResponse.warnings.length > 0) {
+  if (createResponse.warnings.length > 0) {
     console.log("WARNINGS:");
     console.log(JSON.stringify(createResponse.warnings, null, 2));
   }
 
-  if(createResponse.errors.length > 0) {
+  if (createResponse.errors.length > 0) {
     console.log("ERRORS:");
     console.log(JSON.stringify(createResponse.errors, null, 2));
   }

--- a/src/LiveObjectSetupStepOne.js
+++ b/src/LiveObjectSetupStepOne.js
@@ -1,0 +1,294 @@
+/* eslint-disable no-console */
+
+/*
+
+Function to generate DRM keys and offering metadata for a live object
+
+EXAMPLE OF USE FROM WITHIN ANOTHER FILE:
+================================================
+
+const {GenerateOffering} = require("./LiveObjectSetupStepOne");
+
+const client = (...STANDARD CODE TO GENERATE INSTANCE OF CLIENT...);
+
+const streamUrl = "https://live-stream-source.com:PORT/PATH/FILENAME";
+
+const aBitRate = 128000;
+const aChannels = 2;
+const aSampleRate = 48000;
+const aStreamIndex = 1;
+const aTimeBase = "1/48000";
+const aChannelLayout = "stereo";
+
+const vBitRate = 9500000;
+const vHeight = 1080;
+const vStreamIndex = 0;
+const vWidth = 1920;
+const vDisplayAspectRatio = "16/9";
+const vFrameRate = "24";
+const vTimeBase = "1/12288";
+
+const abrProfile = require("path/to/abr/profile");
+
+const objectId = "qid";
+const libraryId = "lib_id";
+
+await GenerateOffering({
+    client,
+    libraryId,
+    objectId,
+    streamUrl,
+    abrProfile,
+    aBitRate, aChannels, aSampleRate, aStreamIndex,
+    aTimeBase,
+    aChannelLayout,
+    vBitRate, vHeight, vStreamIndex, vWidth,
+    vDisplayAspectRatio, vFrameRate, vTimeBase
+});
+
+*/
+
+
+// https://www.npmjs.com/package/fraction.js
+const Fraction = require("fraction.js");
+
+const DUMMY_DURATION = 1001; // should result in integer duration_ts values for both audio and video
+
+const GenerateOffering = async ({
+  client, // elvClient object
+  libraryId, objectId, // lib/object ID of new live object
+  streamUrl,  // live source URL
+  abrProfile, // JSON.parse(abr profile json file contents)
+  // audio info - integers
+  aBitRate, aChannels, aSampleRate, aStreamIndex,
+  // audio info - string containing fraction, e.g. "1/48000" (usually == 1/aSampleRate)
+  aTimeBase,
+  // audio info - string containing channel layout, e.g. "stereo"
+  aChannelLayout,
+  // video info - integers
+  vBitRate, vHeight, vStreamIndex, vWidth,
+  // video info - strings containing either integers or fractions, e.g. "16/9", "30", "1/30000"
+  vDisplayAspectRatio, vFrameRate, vTimeBase
+}) => {
+
+  // compute duration_ts
+  const aDurationTs = Fraction(aTimeBase).inverse().mul(DUMMY_DURATION).valueOf();
+  const vDurationTs = Fraction(vTimeBase).inverse().mul(DUMMY_DURATION).valueOf();
+
+  // construct /production_master/sources/STREAM_URL/streams
+
+  const sourceAudioStream = {
+    "bit_rate": aBitRate,
+    "channel_layout": aChannelLayout,
+    "channels": aChannels,
+    "codec_name": "aac",
+    "duration": DUMMY_DURATION,
+    "duration_ts": aDurationTs,
+    "frame_count": 0,
+    "language": "",
+    "max_bit_rate": aBitRate,
+    "sample_rate": aSampleRate,
+    "start_pts": 0,
+    "start_time": 0,
+    "time_base": aTimeBase,
+    "type": "StreamAudio"
+  };
+
+  const sourceVideoStream = {
+    "bit_rate": vBitRate,
+    "codec_name": "h264",
+    "display_aspect_ratio": vDisplayAspectRatio,
+    "duration": DUMMY_DURATION,
+    "duration_ts": vDurationTs,
+    "field_order": "progressive",
+    "frame_count": 0,
+    "frame_rate": vFrameRate,
+    "hdr": null,
+    "height": vHeight,
+    "language": "",
+    "max_bit_rate": vBitRate,
+    "sample_aspect_ratio": "1",
+    "start_pts": 0,
+    "start_time": 0,
+    "time_base": vTimeBase,
+    "type": "StreamVideo",
+    "width": vWidth
+  };
+
+  // placeholder stream to use if [aStreamIndex, vStreamIndex].sort() is not [0,1]
+  const DUMMY_STREAM = {
+    "bit_rate": 0,
+    "codec_name": "",
+    "duration": DUMMY_DURATION,
+    "duration_ts": 2500 * DUMMY_DURATION,
+    "frame_count": 1,
+    "language": "",
+    "max_bit_rate": 0,
+    "start_pts": 0,
+    "start_time": 0,
+    "time_base": "1/2500",
+    "type": "StreamData"
+  };
+
+  const sourceStreams = [];
+  const maxStreamIndex = Math.max(aStreamIndex, vStreamIndex);
+
+  for(let i = 0; i <= maxStreamIndex; i++) {
+    if(i === aStreamIndex) {
+      sourceStreams.push(sourceAudioStream);
+    } else if(i === vStreamIndex) {
+      sourceStreams.push(sourceVideoStream);
+    } else {
+      sourceStreams.push(DUMMY_STREAM);
+    }
+  }
+
+  // construct /production_master/sources
+  const sources = {
+    [streamUrl]: {
+      "container_format": {
+        "duration": DUMMY_DURATION,
+        "filename": streamUrl,
+        "format_name": "mov,mp4,m4a,3gp,3g2,mj2",
+        "start_time": 0
+      },
+      "streams": sourceStreams
+    }
+  };
+
+  // construct /production_master/variants
+  const variants = {
+    "default": {
+      "streams": {
+        "audio": {
+          "default_for_media_type": false,
+          "label": "",
+          "language": "",
+          "mapping_info": "",
+          "sources": [
+            {
+              "files_api_path": streamUrl,
+              "stream_index": aStreamIndex
+            }
+          ]
+        },
+        "video": {
+          "default_for_media_type": false,
+          "label": "",
+          "language": "",
+          "mapping_info": "",
+          "sources": [
+            {
+              "files_api_path": streamUrl,
+              "stream_index": vStreamIndex
+            }
+          ]
+        }
+      }
+    }
+  };
+
+  // construct /production_master
+  const production_master = {sources, variants};
+
+  // get existing metadata
+  console.log("Retrieving current metadata...");
+  let metadata = await client.ContentObjectMetadata({
+    libraryId,
+    objectId
+  });
+
+  // add /production_master to metadata
+  metadata.production_master = production_master;
+
+  // write back to object
+  console.log("Getting write token...");
+  let editResponse = await client.EditContentObject({
+    libraryId,
+    objectId
+  });
+  let writeToken = editResponse.write_token;
+  console.log(`New write token: ${writeToken}`);
+
+  console.log("Writing back metadata with /production_master added...");
+  await client.ReplaceMetadata({
+    libraryId,
+    metadata,
+    objectId,
+    writeToken
+  });
+
+  console.log("Finalizing...");
+  let finalizeResponse = await client.FinalizeContentObject({
+    libraryId,
+    objectId,
+    writeToken
+  });
+  let masterVersionHash = finalizeResponse.hash;
+  console.log(`Finalized, new version hash: ${masterVersionHash}`);
+
+  // Generate offering
+  const createResponse = await client.CreateABRMezzanine({
+    libraryId,
+    objectId,
+    masterVersionHash,
+    variant: "default",
+    offeringKey: "default",
+    abrProfile
+  });
+
+  if(createResponse.warnings.length > 0) {
+    console.log("WARNINGS:");
+    console.log(JSON.stringify(createResponse.warnings, null, 2));
+  }
+
+  if(createResponse.errors.length > 0) {
+    console.log("ERRORS:");
+    console.log(JSON.stringify(createResponse.errors, null, 2));
+  }
+
+  let versionHash = createResponse.hash;
+  console.log(`New version hash: ${versionHash}`);
+
+  // get new metadata
+  console.log("Retrieving revised metadata with offering...");
+  metadata = await client.ContentObjectMetadata({
+    libraryId,
+    versionHash
+  });
+
+  console.log("Moving /abr_mezzanine/offerings to /offerings and removing /abr_mezzanine...");
+  metadata.offerings = metadata.abr_mezzanine.offerings;
+  delete metadata.abr_mezzanine;
+
+  // add items to media_struct needed to use options.json handler
+  metadata.offerings.default.media_struct.duration_rat = `${DUMMY_DURATION}`;
+
+  // write back to object
+  console.log("Getting write token...");
+  editResponse = await client.EditContentObject({
+    libraryId,
+    objectId
+  });
+  writeToken = editResponse.write_token;
+  console.log(`New write token: ${writeToken}`);
+
+  console.log("Writing back metadata with /offerings...");
+  await client.ReplaceMetadata({
+    libraryId,
+    metadata,
+    objectId,
+    writeToken
+  });
+
+  console.log("Finalizing...");
+  finalizeResponse = await client.FinalizeContentObject({
+    libraryId,
+    objectId,
+    writeToken
+  });
+  let finalHash = finalizeResponse.hash;
+  console.log(`Finalized, new version hash: ${finalHash}`);
+};
+
+module.exports = {GenerateOffering};

--- a/src/LiveStream.js
+++ b/src/LiveStream.js
@@ -1,0 +1,871 @@
+/*
+ * Content Fabric live stream management
+ */
+
+const { ElvClient } = require("@eluvio/elv-client-js");
+const { Config } = require("./Config.js");
+
+const https = require("https");
+const got = require("got");
+
+const PRINT_DEBUG = true
+
+const streams = require('../liveconf.json');
+const channels = require('../channelsconf.json');
+
+const MakeTxLessToken = async({client, libraryId, objectId, versionHash}) => {
+  tok = await client.authClient.AuthorizationToken({libraryId, objectId,
+						    versionHash, channelAuth: false, noCache: true,
+						    noAuth: true});
+  return tok;
+}
+
+class EluvioLiveStream {
+
+  /**
+   * Instantiate the EluvioLiveStream
+   *
+   * @namedParams
+   * @param {string} configUrl - The Content Fabric configuration URL
+   * @return {EluvioLive} - New EluvioLive object connected to the specified content fabric and blockchain
+   */
+  constructor({ configUrl, debugLogging = false }) {
+    this.configUrl = configUrl || ElvClient.main;
+
+    this.debug = debugLogging;
+  }
+
+  async Init({}={}) {
+    this.client = await ElvClient.FromConfigurationUrl({
+      configUrl: this.configUrl,
+    });
+
+    let wallet = this.client.GenerateWallet();
+    let signer = wallet.AddAccount({
+      privateKey: process.env.PRIVATE_KEY,
+    });
+    this.client.SetSigner({ signer });
+    this.client.ToggleLogging(this.debug);
+  }
+
+  async StatusPrep({name}) {
+
+    // Pick the first object if name not specified
+    if (name == null) {
+      name = Object.keys(streams)[0];
+    }
+
+    const conf = streams[name];
+    if (conf == null) {
+      console.log("Bad name: ", name);
+      return
+    }
+
+    try {
+
+      // Set static token - avoid individual auth for separate channels/streams
+      let token = await MakeTxLessToken({client: this.client, libraryId: conf.libraryId});
+      this.client.SetStaticToken({token});
+
+    } catch (error) {
+      console.log("StatusPrep failed: ", error);
+      return null;
+    }
+
+  }
+
+  /*
+   * Retrive the status of the current live stream session
+   *
+   * States:
+   * - inactive
+   * - stopped
+   * - starting
+   * - running
+   * - stalled
+   * - terminated
+   */
+  async Status({client, name, stopLro = false}) {
+
+    const conf = streams[name];
+    if (conf == null) {
+      console.log("Bad name: ", name);
+      return
+    }
+
+    let status = {name: name};
+
+    try {
+
+      let libraryId = await this.client.ContentObjectLibraryId({objectId: conf.objectId});
+      status.library_id = libraryId;
+      status.object_id = conf.objectId;
+
+      let mainMeta = await this.client.ContentObjectMetadata({
+        libraryId: libraryId,
+        objectId: conf.objectId
+      });
+
+      let fabURI = mainMeta.live_recording.fabric_config.ingress_node_api;
+      this.client.SetNodes({fabricURIs: [fabURI]});
+      status.fabric_api = fabURI;
+      status.url = mainMeta.live_recording.recording_config.recording_params.origin_url;
+
+      let edgeWriteToken = mainMeta.live_recording.fabric_config.edge_write_token;
+
+      status.edge_write_token = edgeWriteToken;
+      let edgeMeta = await this.client.ContentObjectMetadata({
+        libraryId: libraryId,
+        objectId: conf.objectId,
+        writeToken: edgeWriteToken
+      });
+
+      // If a stream has never been started return state 'inactive'
+      if (!edgeMeta.live_recording.recordings || !edgeMeta.live_recording.recordings.recording_sequence) {
+        status.state = 'inactive';
+        return status;
+      }
+
+      let recordings = edgeMeta.live_recording.recordings;
+      status.recording_period_sequence = recordings.recording_sequence;
+
+      let period = recordings.live_offering[recordings.recording_sequence - 1];
+
+      let tlro = period.live_recording_handle;
+      status.tlro = tlro;
+
+      let sinceLastFinalize = Math.floor(new Date().getTime() / 1000) -
+      period.video_finalized_parts_info.last_finalization_time /1000000;
+
+      let recording_period = {
+        activation_time_epoch_sec: period.recording_start_time_epoch_sec,
+        start_time_epoch_sec: period.start_time_epoch_sec,
+        start_time_text: new Date(period.start_time_epoch_sec * 1000).toLocaleString(),
+        end_time_epoch_sec: period.end_time_epoch_sec,
+        end_time_text:  period.end_time_epoch_sec == 0 ? null : new Date(period.end_time_epoch_sec * 1000).toLocaleString(),
+        video_parts: period.video_finalized_parts_info.n_parts,
+        video_last_part_finalized_epoch_sec: period.video_finalized_parts_info.last_finalization_time / 1000000,
+        video_since_last_finalize_sec : sinceLastFinalize
+      };
+      status.recording_period = recording_period;
+
+      status.lro_status_url = await this.client.FabricUrl({
+        libraryId: libraryId,
+        objectId: conf.objectId,
+        writeToken: edgeWriteToken,
+        call: 'live/status/' + tlro
+      });
+
+      let state = "stopped";
+      let lroStatus = "";
+      try {
+        lroStatus = await got(status.lro_status_url);
+        state = JSON.parse(lroStatus.body).state;
+      } catch (error) {
+        console.log("LRO Status (failed): ", error.response.statusCode);
+      }
+      if (state == "running" && period.video_finalized_parts_info.last_finalization_time ==0) {
+        state = "starting";
+      } else if (state == "running" && sinceLastFinalize > 32.9) {
+        state = "stalled";
+      }
+      status.state = state;
+
+      if ((state == 'running' || state == 'stalled' || state == 'starting') && stopLro) {
+        lroStopUrl = await this.client.FabricUrl({
+        libraryId: libraryId,
+        objectId: conf.objectId,
+        writeToken: edgeWriteToken,
+        call: 'live/stop/' + tlro
+        });
+
+        try {
+          stop = await got(lroStopUrl);
+          console.log("LRO Stop: ", lroStatus.body);
+        } catch (error) {
+          console.log("LRO Stop (failed): ", error.response.statusCode);
+        }
+      }
+
+    } catch (error) {
+      console.error(error)
+    }
+
+    return status;
+  }
+
+ /*
+  * StartSession creates a new edge write token
+  */
+  async StartSession ({name}) {
+
+    console.log("START: ", name);
+    const conf = streams[name];
+    if (conf == null) {
+      console.log("Bad name: ", name);
+      return
+    }
+
+    let libraryId = await this.client.ContentObjectLibraryId({objectId: conf.objectId});
+
+    // Read live recording parameters - determine ingest node
+    let liveRecording = await this.client.ContentObjectMetadata({
+      libraryId: libraryId,
+      objectId: conf.objectId,
+      metadataSubtree: '/live_recording'
+    });
+
+    let fabURI = liveRecording.fabric_config.ingress_node_api;
+    this.client.SetNodes({fabricURIs: [fabURI]});
+
+    console.log("Node URI", fabURI, "ID", liveRecording.fabric_config.ingress_node_id);
+
+    let response = await this.client.EditContentObject({
+      libraryId: libraryId,
+      objectId: conf.objectId
+    })
+    const edgeToken = response.write_token
+    console.log("Edge token:", edgeToken)
+
+    /*
+    * Set the metadata, including the edge token.
+    */
+    response = await this.client.EditContentObject({
+      libraryId: libraryId,
+      objectId: conf.objectId
+    })
+    let writeToken = response.write_token
+
+    if (PRINT_DEBUG) console.log("MergeMetadata", libraryId, conf.objectId, writeToken)
+    await this.client.MergeMetadata({
+      libraryId: libraryId,
+      objectId: conf.objectId,
+      writeToken: writeToken,
+      metadata: {
+        live_recording: {
+          status: {
+            edge_write_token: edgeToken,
+            state: "active"  // indicates there is an active session (set to 'closed' when done)
+          },
+          fabric_config: {
+            edge_write_token: edgeToken
+          }
+        }
+      }
+    });
+
+    if (PRINT_DEBUG) console.log("FinalizeContentObject", libraryId, conf.objectId, writeToken)
+    response = await this.client.FinalizeContentObject({
+      libraryId: libraryId,
+      objectId: conf.objectId,
+      writeToken: writeToken
+    })
+    const objectHash = response.hash
+    console.log("Object hash:", objectHash);
+
+    if (PRINT_DEBUG) console.log("AuthorizationToken", libraryId, conf.objectId)
+    response = await this.client.authClient.AuthorizationToken({
+      libraryId: libraryId,
+      objectId: conf.objectId,
+      versionHash: "",
+      channelAuth: false,
+      noCache: true,
+      update: true,
+    });
+
+    const curlCmd = "curl -s -H \"$AUTH_HEADER\" "
+    const fabLibHashURI = fabURI + "/qlibs/" + libraryId + "/q/" + objectHash
+    const fabLibTokenURI = fabURI + "/qlibs/" + libraryId + "/q/" + edgeToken
+
+    console.log("\nSet Authorization header:\nexport AUTH_HEADER=\"" +
+      "Authorization: Bearer " + response + "\"")
+
+    console.log("\nInspect metadata:\n" +
+      curlCmd + fabLibHashURI + "/meta | jq")
+
+    console.log("\nInspect edge metadata:\n" +
+      curlCmd + fabLibTokenURI + "/meta | jq")
+
+    console.log("\nStart recording (returns HANDLE):\n" +
+      curlCmd + fabLibTokenURI + "/call/live/start | jq")
+
+    console.log("\nStop recording (use HANDLE from start):\n" +
+      curlCmd + fabLibTokenURI + "/call/live/stop/HANDLE")
+
+    console.log("\nPlayout options:\n" +
+      curlCmd + fabLibHashURI + "/rep/live/default/options.json | jq")
+
+    console.log("\nHLS playlist:\n" +
+      fabLibHashURI + "/rep/live/default/hls-sample-aes/playlist.m3u8?authorization=" + response)
+
+  }
+
+
+ /*
+  * Start, stop or reset a stream within the current session (current edge write token)
+  * The 'op' parameter can be:
+  * - 'start'
+  * - 'reset'  Stops current LRO recording and starts a new one.  Does not create a new edge write token
+  *            (just creates a new recording period in the existing edge write token)
+  * - 'stop'
+  * Returns stream status
+  */
+  async StartOrStopOrReset({name, op}) {
+
+    try {
+
+      console.log("Stream ", op, ": ", name);
+      let status = await this.Status({name});
+      console.log("STATUS: ", status);
+
+      if (status.state != 'terminated' && status.state != 'inactive') {
+        if (op == "start") {
+          return status;
+        }
+        console.log("STOPPING");
+        try {
+          await this.client.CallBitcodeMethod({
+            libraryId: status.library_id,
+            objectId: status.object_id,
+            writeToken: status.edge_write_token,
+            method: "/live/stop/" + status.tlro,
+            constant: false
+          });
+        } catch (error) {
+          // The /call/lro/stop API returns empty response
+          // console.log("LRO Stop (failed): ", error);
+        }
+
+        // Wait until LRO is terminated
+        let tries = 10;
+        while (status.state != 'terminated' && tries-- > 0) {
+          console.log("Wait to terminate - ", status.state);
+          await sleep(1000);
+            status = await this.Status({name});
+        }
+        console.log("Status after terminate - ", status.state);
+
+        if (tries <= 0) {
+          console.log("Failed to terminate");
+          return status;
+        }
+      }
+
+      if (op == "stop") {
+        return status;
+      }
+
+      console.log("STARTING");
+      try {
+        await this.client.CallBitcodeMethod({
+          libraryId: status.library_id,
+          objectId: status.object_id,
+          writeToken: status.edge_write_token,
+          method: "/live/start",
+          constant: false
+        });
+      } catch (error) {
+        console.log("LRO Start (failed): ", error);
+      }
+
+      // Wait until LRO is 'starting'
+      let tries = 10;
+      while (status.state != 'starting' && tries-- > 0) {
+        console.log("Wait to start - ", status.state);
+        await sleep(1000);
+        status = await this.Status({name});
+      }
+
+      console.log("Status after restart - ", status.state);
+      return status;
+
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  /*
+   * Stop the live stream session and close the edge write token.
+   * Not implemented fully
+   */
+  async StopSession({name}) {
+
+    try {
+
+      console.log("START: ", name);
+      const conf = streams[name];
+      if (conf == null) {
+        console.log("Bad name: ", name);
+        return
+      }
+
+      let libraryId = await this.client.ContentObjectLibraryId({objectId: conf.objectId});
+
+      let mainMeta = await this.client.ContentObjectMetadata({
+        libraryId: libraryId,
+        objectId: conf.objectId
+      });
+
+      let fabURI = mainMeta.live_recording.fabric_config.ingress_node_api;
+      this.client.SetNodes({fabricURIs: [fabURI]});
+
+      let edgeWriteToken = mainMeta.live_recording.fabric_config.edge_write_token;
+
+      let edgeMeta = await this.client.ContentObjectMetadata({
+        libraryId: libraryId,
+        objectId: conf.objectId,
+        writeToken: edgeWriteToken
+      });
+
+      // Stop the LRO if running
+      let status = await this.Status({name});
+      if (status.state != 'terminated') {
+        console.log("STOPPING");
+        try {
+          await this.client.CallBitcodeMethod({
+            libraryId: status.library_id,
+            objectId: status.object_id,
+            writeToken: status.edge_write_token,
+            method: "/live/stop/" + status.tlro,
+            constant: false
+          });
+        } catch (error) {
+          // The /call/lro/stop API returns empty response
+          // console.log("LRO Stop (failed): ", error);
+        }
+
+        // Wait until LRO is terminated
+        let tries = 10;
+        while (status.state != 'terminated' && tries-- > 0) {
+          console.log("Wait to terminate - ", status.state);
+          await sleep(1000);
+            status = await this.Status({name});
+        }
+        console.log("Status after terminate - ", status.state);
+
+        if (tries <= 0) {
+          console.log("Failed to terminate");
+          return status;
+        }
+      }
+
+      console.log("CONFIG:");
+      console.log("recording_start_time: ", edgeMeta.recording_start_time);
+      console.log("recording_stop_time:  ", edgeMeta.recording_stop_time);
+
+      // Set stop time
+      edgeMeta.recording_stop_time = Math.floor(new Date().getTime() / 1000);
+      console.log("AFTER");
+      console.log("recording_start_time: ", edgeMeta.recording_start_time);
+      console.log("recording_stop_time:  ", edgeMeta.recording_stop_time);
+
+      edgeMeta.live_recording.status = {state: "closed"};
+
+      let res = await this.client.ReplaceMetadata({
+        libraryId: libraryId,
+        objectId: conf.objectId,
+        writeToken: edgeWriteToken,
+        metadata: edgeMeta
+
+      });
+
+      return {
+        name: name,
+        edge_write_token: edgeWriteToken,
+        state: "closed"
+      }
+
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  async SetOfferingAndDRM({name}) {
+
+    console.log("INIT: ", name);
+    const conf = streams[name];
+    if (conf == null) {
+    console.log("Bad name: ", name);
+    return
+    }
+
+    const {GenerateOffering} = require("./LiveObjectSetupStepOne");
+
+    const aBitRate = 128000;
+    const aChannels = 2;
+    const aSampleRate = 48000;
+    const aStreamIndex = 1;
+    const aTimeBase = "1/48000";
+    const aChannelLayout = "stereo";
+
+    const vBitRate = 14000000;
+    const vHeight = 720;
+    const vStreamIndex = 0;
+    const vWidth = 1280;
+    const vDisplayAspectRatio = "16/9";
+    const vFrameRate = "30000/1001";
+    const vTimeBase = "1/30000"; // "1/16000";
+
+    const abrProfile = require("./abr_profile_live_drm.json");
+
+    let libraryId = await this.client.ContentObjectLibraryId({objectId: conf.objectId});
+    const objectId = conf.objectId;
+
+    try {
+
+      let mainMeta = await this.client.ContentObjectMetadata({
+        libraryId: libraryId,
+        objectId: conf.objectId
+      });
+
+      let fabURI = mainMeta.live_recording.fabric_config.ingress_node_api;
+      this.client.SetNodes({fabricURIs: [fabURI]});
+
+      let streamUrl = mainMeta.live_recording.recording_config.recording_params.origin_url;
+
+      await GenerateOffering({
+        client: this.client,
+        libraryId,
+        objectId,
+        streamUrl,
+        abrProfile,
+        aBitRate, aChannels, aSampleRate, aStreamIndex,
+        aTimeBase,
+        aChannelLayout,
+        vBitRate, vHeight, vStreamIndex, vWidth,
+        vDisplayAspectRatio, vFrameRate, vTimeBase
+      });
+
+      console.log("GenerateOffering - DONE");
+
+      return {
+        name,
+        object_id: objectId,
+        state: "initialized"
+      }
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+} // End class
+
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+const ChannelStatus = async ({client, name}) => {
+
+  let status = {name: name};
+
+  const conf = channels[name];
+  if (conf == null) {
+	console.log("Bad name: ", name);
+	return
+  }
+
+  try {
+
+    let meta = await client.ContentObjectMetadata({
+      libraryId: conf.libraryId,
+      objectId: conf.objectId
+    })
+
+	status.channel_title = meta.public.asset_metadata.title;
+	let source = meta.channel.offerings.default.items[0].source["/"];
+	let hash = source.split("/")[2];
+	status.stream_hash = hash;
+	latestHash = await client.LatestVersionHash({
+	  versionHash: hash
+	});
+	status.stream_latest_hash = latestHash;
+
+	if (hash != latestHash) {
+	  status.warnings = ["Stream version is not the latest"];
+	}
+
+	let channelFormatsUrl = await client.FabricUrl({
+      libraryId: conf.libraryId,
+      objectId: conf.objectId,
+	  rep: "channel/options.json"
+	});
+
+	try {
+	  let offerings = await got(channelFormatsUrl);
+	  status.offerings = JSON.parse(offerings.body);
+	} catch (error) {
+	  console.log(error);
+	  status.offerings_error = "Failed to retrieve channel offerings";
+	}
+
+	status.playout = await ChannelPlayout({client, libraryId: conf.libraryId, objectId: conf.objectId});
+
+  } catch (error) {
+    console.error(error)
+  }
+
+  return status;
+}
+
+/*
+ * Performs client-side playout operations - open the channel, read offerings,
+ * retrieve playlist and one video init segment.
+ */
+const ChannelPlayout = async({client, libraryId, objectId}) => {
+
+  let playout = {};
+
+  const offerings = await client.AvailableOfferings({
+	libraryId,
+	objectId,
+	handler: "channel",
+	linkPath: "/public/asset_metadata/offerings"
+  });
+
+  // Choosing offering 'default'
+  let offering = offerings.default;
+
+  const playoutOptions = await client.PlayoutOptions({
+	libraryId,
+	objectId,
+	offeringURI: offering.uri
+  });
+
+  const supportedDRM = 'fairplay';
+
+  // Retrieve master playlist
+  let masterPlaylistUrl = playoutOptions["hls"]["playoutMethods"]["fairplay"]["playoutUrl"];
+  playout.master_playlist_url = masterPlaylistUrl;
+  try {
+	let masterPlaylist =  await got(masterPlaylistUrl);
+	playout.master_playlist = "success"
+  } catch (error) {
+	playout.master_playlist = "fail";
+  }
+
+  let url = new URL(masterPlaylistUrl);
+  let p = url.pathname.split("/");
+
+  // Retrieve media playlist
+  p[p.length - 1] = "video/720@14000000/live.m3u8";
+  let pathMediaPlaylist = p.join("/");
+  url.pathname = pathMediaPlaylist;
+  let mediaPlaylistUrl = url.toString();
+  playout.media_playlist_url = mediaPlaylistUrl;
+  let mediaPlaylist;
+  try {
+	mediaPlaylist = await got(mediaPlaylistUrl);
+	playout.media_playlist = "success"
+  } catch (error) {
+	playout.media_playlist = "fail";
+  }
+
+  // Retrieve init segment
+  var regex = new RegExp("^#EXT-X-MAP:URI=\"init.m4s.(.*)\"$", "m");
+  var match = regex.exec(mediaPlaylist.body);
+  let initQueryParams;
+  if (match) {
+	initQueryParams = match[1];
+  }
+
+  p[p.length - 1] = "video/720@14000000/init.m4s";
+  let pathInit = p.join("/");
+  url.pathname = pathInit;
+  url.search=initQueryParams;
+  let initUrl = url.toString();
+  playout.init_segment_url = initUrl;
+/*
+  try {
+	let initSegment = await got(initUrl);
+	playout.init_segment = "success"
+  } catch (error) {
+	playout.init_segment = "fail";
+  }
+*/
+  return playout;
+}
+
+
+const Summary = async ({client}) => {
+
+  let summary = {};
+
+  try {
+	for (const [key, value] of Object.entries(streams)) {
+	  conf = streams[key];
+	  summary[key] = await Status({client, name: key, stopLro: false})
+	}
+
+  } catch (error) {
+    console.error(error)
+  }
+  return summary;
+}
+
+const ChannelSummary = async ({client}) => {
+
+  let summary = {};
+
+  try {
+	for (const [key, value] of Object.entries(channels)) {
+	  conf = channels[key];
+	  summary[key] = await ChannelStatus({client, name: key})
+	}
+
+  } catch (error) {
+    console.error(error)
+  }
+  return summary;
+}
+
+const ConfigStream = async () => {
+
+  const t = 1619850660;
+
+  try {
+    let client
+    if (conf.clientConf.configUrl) {
+      client = await ElvClient.FromConfigurationUrl({
+        configUrl: conf.clientConf.configUrl
+      })
+    } else {
+      client = new ElvClient(conf.clientConf)
+    }
+    const wallet = client.GenerateWallet()
+    const signer = wallet.AddAccount({ privateKey: conf.signerPrivateKey })
+    client.SetSigner({ signer })
+    const fabURI = client.fabricURIs[0]
+    console.log("Fabric URI: " + fabURI)
+    const ethURI = client.ethereumURIs[0]
+    console.log("Ethereum URI: " + ethURI)
+
+    client.ToggleLogging(false);
+
+    let mainMeta = await client.ContentObjectMetadata({
+      libraryId: conf.libraryId,
+      objectId: conf.objectId
+    })
+    console.log("Main meta:", mainMeta)
+
+    edgeWriteToken = mainMeta.edge_write_token;
+    console.log("Edge: ", edgeWriteToken);
+
+    let edgeMeta = await client.ContentObjectMetadata({
+      libraryId: conf.libraryId,
+      objectId: conf.objectId,
+      writeToken: edgeWriteToken
+    })
+    console.log("Edge meta:", edgeMeta)
+
+	//console.log("CONFIG: ", edgeMeta.live_recording_parameters.live_playout_config);
+	console.log("recording_start_time: ", edgeMeta.recording_start_time);
+	console.log("recording_stop_time:  ", edgeMeta.recording_stop_time);
+
+	// Set rebroadcast start
+	edgeMeta.live_recording_parameters.live_playout_config.rebroadcast_start_time_sec_epoch = t;
+
+    if (PRINT_DEBUG) console.log("MergeMetadata", conf.libraryId, conf.objectId, writeToken)
+    await client.MergeMetadata({
+      libraryId: conf.libraryId,
+      objectId: conf.objectId,
+      writeToken: edgeWriteToken,
+      metadata: {
+        "live_recording_parameters": {
+		  "live_playout_config" : edgeMeta.live_recording_parameters.live_playout_config
+		}
+	  }
+    });
+
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+async function EnsureAll() {
+  client = await StatusPrep({name: null});
+  let summary = await Summary({client});
+
+  var res = {
+	running: 0,
+	stalled: 0,
+	terminated: 0
+  };
+
+  try {
+	for (const [key, value] of Object.entries(summary)) {
+	  if (value.state == "stalled") {
+		console.log("Stream stalled: ", key, " - restarting");
+		console.log("todo ...");
+	  }
+	  res[value.state] = res[value.state] + 1;
+	}
+  } catch (error) {
+    console.error(error)
+  }
+
+  return res
+}
+
+async function Run() {
+
+  var client;
+
+  switch(command) {
+
+  case 'start':
+	StartStream({name});
+	break;
+
+  case 'status':
+	client = await StatusPrep({name});
+	let status = await Status({client, name, stopLro: false});
+	console.log(JSON.stringify(status, null, 4));
+	break;
+
+  case 'stop':
+	client = await UpdatePrep({name});
+	Status({client, name, stopLro: true});
+	break;
+
+  case 'summary':
+	client = await StatusPrep({name: null});
+	let summary = await Summary({client});
+	console.log(JSON.stringify(summary, null, 4));
+	break;
+
+  case 'init': // Set up DRM
+	SetOfferingAndDRM();
+	break;
+
+  case 'reset': // Stop and start LRO recording (same edge write token)
+	client = await StatusPrep({name});
+	let reset = await Reset({client, name, stopLro: false});
+	console.log(JSON.stringify(reset, null, 4));
+	break;
+
+  case 'channel':
+	client = await StatusPrep({name});
+	let channelStatus = await ChannelStatus({client, name});
+	console.log(JSON.stringify(channelStatus, null, 4));
+	break;
+
+  case 'channel_summary':
+	client = await StatusPrep({name});
+	let channelSummary = await ChannelSummary({client, name});
+	console.log(JSON.stringify(channelSummary, null, 4));
+	break;
+
+  case 'ensure_all': // Check all and restart stalled
+	let ensureSummary = await EnsureAll()
+	console.log(JSON.stringify(ensureSummary, null, 4));
+	break;
+
+  default:
+	console.log("Bad command: ", command)
+	break;
+
+  }
+}
+
+exports.EluvioLiveStream = EluvioLiveStream;

--- a/src/LiveStream.js
+++ b/src/LiveStream.js
@@ -565,11 +565,11 @@ class EluvioLiveStream {
 
   async LoadConf({name}) {
 
-    if (name.startsWith('iq__')) {
+    if (name.startsWith("iq__")) {
       return {
         name: name,
         objectId: name
-      }
+      };
     }
 
     // If name is not a QID, load liveconf.json
@@ -578,9 +578,9 @@ class EluvioLiveStream {
       streamsBuf = fs.readFileSync(
         path.resolve(__dirname, "../liveconf.json")
       );
-    } catch(error) {
-      console.log("Stream name must be a QID or a label in liveconf.json")
-      return {}
+    } catch (error) {
+      console.log("Stream name must be a QID or a label in liveconf.json");
+      return {};
     }
     const streams = JSON.parse(streamsBuf);
     const conf = streams[name];

--- a/src/LiveStream.js
+++ b/src/LiveStream.js
@@ -198,7 +198,7 @@ class EluvioLiveStream {
       return {
         state: status.state,
         error: "stream still active - must terminate first"
-      }
+      };
     }
 
     let objectId = status.object_id;
@@ -440,7 +440,7 @@ class EluvioLiveStream {
         return {
           state: "inactive",
           error: "no active streams - must create a stream first"
-        }
+        };
       }
       let edgeMeta = await this.client.ContentObjectMetadata({
         libraryId: libraryId,
@@ -506,7 +506,7 @@ class EluvioLiveStream {
         writeToken: edgeWriteToken,
         commitMessage: "Finalize live stream - stop time " + edgeMeta.recording_stop_time,
         publish: false // Don't publish this version because it is not currently useful
-      })
+      });
 
       return {
         name: name,
@@ -526,7 +526,7 @@ class EluvioLiveStream {
       return {
         state: status.state,
         error: "stream still active - must terminate first"
-      }
+      };
     }
 
     let objectId = status.object_id;
@@ -560,7 +560,7 @@ class EluvioLiveStream {
             "type": "ProtoHls"
           }
         }
-      }
+      };
     }
 
     let libraryId = await this.client.ContentObjectLibraryId({objectId});

--- a/src/LiveStream.js
+++ b/src/LiveStream.js
@@ -104,7 +104,14 @@ class EluvioLiveStream {
       });
 
       let fabURI = mainMeta.live_recording.fabric_config.ingress_node_api;
+
+      // Support both hostname and URL ingress_node_api
+      if (!fabURI.startsWith("http")) {
+        // Assume https
+        fabURI = "https://" + fabURI;
+      }
       this.client.SetNodes({fabricURIs: [fabURI]});
+
       status.fabric_api = fabURI;
       status.url = mainMeta.live_recording.recording_config.recording_params.origin_url;
 
@@ -213,6 +220,12 @@ class EluvioLiveStream {
     });
 
     let fabURI = liveRecording.fabric_config.ingress_node_api;
+    // Support both hostname and URL ingress_node_api
+    if (!fabURI.startsWith("http")) {
+      // Assume https
+      fabURI = "https://" + fabURI;
+    }
+
     this.client.SetNodes({fabricURIs: [fabURI]});
 
     console.log("Node URI", fabURI, "ID", liveRecording.fabric_config.ingress_node_id);
@@ -404,6 +417,12 @@ class EluvioLiveStream {
       });
 
       let fabURI = mainMeta.live_recording.fabric_config.ingress_node_api;
+      // Support both hostname and URL ingress_node_api
+      if (!fabURI.startsWith("http")) {
+        // Assume https
+        fabURI = "https://" + fabURI;
+      }
+
       this.client.SetNodes({fabricURIs: [fabURI]});
 
       let edgeWriteToken = mainMeta.live_recording.fabric_config.edge_write_token;
@@ -516,6 +535,12 @@ class EluvioLiveStream {
       });
 
       let fabURI = mainMeta.live_recording.fabric_config.ingress_node_api;
+      // Support both hostname and URL ingress_node_api
+      if (!fabURI.startsWith("http")) {
+        // Assume https
+        fabURI = "https://" + fabURI;
+      }
+
       this.client.SetNodes({fabricURIs: [fabURI]});
 
       let streamUrl = mainMeta.live_recording.recording_config.recording_params.origin_url;

--- a/src/LiveStream.js
+++ b/src/LiveStream.js
@@ -3,22 +3,19 @@
  */
 
 const { ElvClient } = require("@eluvio/elv-client-js");
-const { Config } = require("./Config.js");
-
-const https = require("https");
 const got = require("got");
 
-const PRINT_DEBUG = true
+const PRINT_DEBUG = true;
 
-const streams = require('../liveconf.json');
-const channels = require('../channelsconf.json');
+const streams = require("../liveconf.json");
+const channels = require("../channelsconf.json");
 
 const MakeTxLessToken = async({client, libraryId, objectId, versionHash}) => {
   tok = await client.authClient.AuthorizationToken({libraryId, objectId,
 						    versionHash, channelAuth: false, noCache: true,
 						    noAuth: true});
   return tok;
-}
+};
 
 class EluvioLiveStream {
 
@@ -35,7 +32,7 @@ class EluvioLiveStream {
     this.debug = debugLogging;
   }
 
-  async Init({}={}) {
+  async Init() {
     this.client = await ElvClient.FromConfigurationUrl({
       configUrl: this.configUrl,
     });
@@ -58,7 +55,7 @@ class EluvioLiveStream {
     const conf = streams[name];
     if (conf == null) {
       console.log("Bad name: ", name);
-      return
+      return;
     }
 
     try {
@@ -85,12 +82,12 @@ class EluvioLiveStream {
    * - stalled
    * - terminated
    */
-  async Status({client, name, stopLro = false}) {
+  async Status({name, stopLro = false}) {
 
     const conf = streams[name];
     if (conf == null) {
       console.log("Bad name: ", name);
-      return
+      return;
     }
 
     let status = {name: name};
@@ -122,7 +119,7 @@ class EluvioLiveStream {
 
       // If a stream has never been started return state 'inactive'
       if (!edgeMeta.live_recording.recordings || !edgeMeta.live_recording.recordings.recording_sequence) {
-        status.state = 'inactive';
+        status.state = "inactive";
         return status;
       }
 
@@ -153,7 +150,7 @@ class EluvioLiveStream {
         libraryId: libraryId,
         objectId: conf.objectId,
         writeToken: edgeWriteToken,
-        call: 'live/status/' + tlro
+        call: "live/status/" + tlro
       });
 
       let state = "stopped";
@@ -171,12 +168,12 @@ class EluvioLiveStream {
       }
       status.state = state;
 
-      if ((state == 'running' || state == 'stalled' || state == 'starting') && stopLro) {
+      if ((state == "running" || state == "stalled" || state == "starting") && stopLro) {
         lroStopUrl = await this.client.FabricUrl({
-        libraryId: libraryId,
-        objectId: conf.objectId,
-        writeToken: edgeWriteToken,
-        call: 'live/stop/' + tlro
+          libraryId: libraryId,
+          objectId: conf.objectId,
+          writeToken: edgeWriteToken,
+          call: "live/stop/" + tlro
         });
 
         try {
@@ -188,13 +185,13 @@ class EluvioLiveStream {
       }
 
     } catch (error) {
-      console.error(error)
+      console.error(error);
     }
 
     return status;
   }
 
- /*
+  /*
   * StartSession creates a new edge write token
   */
   async StartSession ({name}) {
@@ -203,7 +200,7 @@ class EluvioLiveStream {
     const conf = streams[name];
     if (conf == null) {
       console.log("Bad name: ", name);
-      return
+      return;
     }
 
     let libraryId = await this.client.ContentObjectLibraryId({objectId: conf.objectId});
@@ -212,7 +209,7 @@ class EluvioLiveStream {
     let liveRecording = await this.client.ContentObjectMetadata({
       libraryId: libraryId,
       objectId: conf.objectId,
-      metadataSubtree: '/live_recording'
+      metadataSubtree: "/live_recording"
     });
 
     let fabURI = liveRecording.fabric_config.ingress_node_api;
@@ -223,9 +220,9 @@ class EluvioLiveStream {
     let response = await this.client.EditContentObject({
       libraryId: libraryId,
       objectId: conf.objectId
-    })
-    const edgeToken = response.write_token
-    console.log("Edge token:", edgeToken)
+    });
+    const edgeToken = response.write_token;
+    console.log("Edge token:", edgeToken);
 
     /*
     * Set the metadata, including the edge token.
@@ -233,10 +230,10 @@ class EluvioLiveStream {
     response = await this.client.EditContentObject({
       libraryId: libraryId,
       objectId: conf.objectId
-    })
-    let writeToken = response.write_token
+    });
+    let writeToken = response.write_token;
 
-    if (PRINT_DEBUG) console.log("MergeMetadata", libraryId, conf.objectId, writeToken)
+    if (PRINT_DEBUG) console.log("MergeMetadata", libraryId, conf.objectId, writeToken);
     await this.client.MergeMetadata({
       libraryId: libraryId,
       objectId: conf.objectId,
@@ -254,16 +251,16 @@ class EluvioLiveStream {
       }
     });
 
-    if (PRINT_DEBUG) console.log("FinalizeContentObject", libraryId, conf.objectId, writeToken)
+    if (PRINT_DEBUG) console.log("FinalizeContentObject", libraryId, conf.objectId, writeToken);
     response = await this.client.FinalizeContentObject({
       libraryId: libraryId,
       objectId: conf.objectId,
       writeToken: writeToken
-    })
-    const objectHash = response.hash
+    });
+    const objectHash = response.hash;
     console.log("Object hash:", objectHash);
 
-    if (PRINT_DEBUG) console.log("AuthorizationToken", libraryId, conf.objectId)
+    if (PRINT_DEBUG) console.log("AuthorizationToken", libraryId, conf.objectId);
     response = await this.client.authClient.AuthorizationToken({
       libraryId: libraryId,
       objectId: conf.objectId,
@@ -273,35 +270,35 @@ class EluvioLiveStream {
       update: true,
     });
 
-    const curlCmd = "curl -s -H \"$AUTH_HEADER\" "
-    const fabLibHashURI = fabURI + "/qlibs/" + libraryId + "/q/" + objectHash
-    const fabLibTokenURI = fabURI + "/qlibs/" + libraryId + "/q/" + edgeToken
+    const curlCmd = "curl -s -H \"$AUTH_HEADER\" ";
+    const fabLibHashURI = fabURI + "/qlibs/" + libraryId + "/q/" + objectHash;
+    const fabLibTokenURI = fabURI + "/qlibs/" + libraryId + "/q/" + edgeToken;
 
     console.log("\nSet Authorization header:\nexport AUTH_HEADER=\"" +
-      "Authorization: Bearer " + response + "\"")
+      "Authorization: Bearer " + response + "\"");
 
     console.log("\nInspect metadata:\n" +
-      curlCmd + fabLibHashURI + "/meta | jq")
+      curlCmd + fabLibHashURI + "/meta | jq");
 
     console.log("\nInspect edge metadata:\n" +
-      curlCmd + fabLibTokenURI + "/meta | jq")
+      curlCmd + fabLibTokenURI + "/meta | jq");
 
     console.log("\nStart recording (returns HANDLE):\n" +
-      curlCmd + fabLibTokenURI + "/call/live/start | jq")
+      curlCmd + fabLibTokenURI + "/call/live/start | jq");
 
     console.log("\nStop recording (use HANDLE from start):\n" +
-      curlCmd + fabLibTokenURI + "/call/live/stop/HANDLE")
+      curlCmd + fabLibTokenURI + "/call/live/stop/HANDLE");
 
     console.log("\nPlayout options:\n" +
-      curlCmd + fabLibHashURI + "/rep/live/default/options.json | jq")
+      curlCmd + fabLibHashURI + "/rep/live/default/options.json | jq");
 
     console.log("\nHLS playlist:\n" +
-      fabLibHashURI + "/rep/live/default/hls-sample-aes/playlist.m3u8?authorization=" + response)
+      fabLibHashURI + "/rep/live/default/hls-sample-aes/playlist.m3u8?authorization=" + response);
 
   }
 
 
- /*
+  /*
   * Start, stop or reset a stream within the current session (current edge write token)
   * The 'op' parameter can be:
   * - 'start'
@@ -318,7 +315,7 @@ class EluvioLiveStream {
       let status = await this.Status({name});
       console.log("STATUS: ", status);
 
-      if (status.state != 'terminated' && status.state != 'inactive') {
+      if (status.state != "terminated" && status.state != "inactive") {
         if (op == "start") {
           return status;
         }
@@ -338,10 +335,10 @@ class EluvioLiveStream {
 
         // Wait until LRO is terminated
         let tries = 10;
-        while (status.state != 'terminated' && tries-- > 0) {
+        while (status.state != "terminated" && tries-- > 0) {
           console.log("Wait to terminate - ", status.state);
           await sleep(1000);
-            status = await this.Status({name});
+          status = await this.Status({name});
         }
         console.log("Status after terminate - ", status.state);
 
@@ -370,7 +367,7 @@ class EluvioLiveStream {
 
       // Wait until LRO is 'starting'
       let tries = 10;
-      while (status.state != 'starting' && tries-- > 0) {
+      while (status.state != "starting" && tries-- > 0) {
         console.log("Wait to start - ", status.state);
         await sleep(1000);
         status = await this.Status({name});
@@ -380,7 +377,7 @@ class EluvioLiveStream {
       return status;
 
     } catch (error) {
-      console.error(error)
+      console.error(error);
     }
   }
 
@@ -396,7 +393,7 @@ class EluvioLiveStream {
       const conf = streams[name];
       if (conf == null) {
         console.log("Bad name: ", name);
-        return
+        return;
       }
 
       let libraryId = await this.client.ContentObjectLibraryId({objectId: conf.objectId});
@@ -419,7 +416,7 @@ class EluvioLiveStream {
 
       // Stop the LRO if running
       let status = await this.Status({name});
-      if (status.state != 'terminated') {
+      if (status.state != "terminated") {
         console.log("STOPPING");
         try {
           await this.client.CallBitcodeMethod({
@@ -436,10 +433,10 @@ class EluvioLiveStream {
 
         // Wait until LRO is terminated
         let tries = 10;
-        while (status.state != 'terminated' && tries-- > 0) {
+        while (status.state != "terminated" && tries-- > 0) {
           console.log("Wait to terminate - ", status.state);
           await sleep(1000);
-            status = await this.Status({name});
+          status = await this.Status({name});
         }
         console.log("Status after terminate - ", status.state);
 
@@ -461,7 +458,7 @@ class EluvioLiveStream {
 
       edgeMeta.live_recording.status = {state: "closed"};
 
-      let res = await this.client.ReplaceMetadata({
+      await this.client.ReplaceMetadata({
         libraryId: libraryId,
         objectId: conf.objectId,
         writeToken: edgeWriteToken,
@@ -473,10 +470,10 @@ class EluvioLiveStream {
         name: name,
         edge_write_token: edgeWriteToken,
         state: "closed"
-      }
+      };
 
     } catch (error) {
-      console.error(error)
+      console.error(error);
     }
   }
 
@@ -485,8 +482,8 @@ class EluvioLiveStream {
     console.log("INIT: ", name);
     const conf = streams[name];
     if (conf == null) {
-    console.log("Bad name: ", name);
-    return
+      console.log("Bad name: ", name);
+      return;
     }
 
     const {GenerateOffering} = require("./LiveObjectSetupStepOne");
@@ -542,9 +539,9 @@ class EluvioLiveStream {
         name,
         object_id: objectId,
         state: "initialized"
-      }
+      };
     } catch (error) {
-      console.error(error)
+      console.error(error);
     }
   }
 
@@ -561,8 +558,8 @@ const ChannelStatus = async ({client, name}) => {
 
   const conf = channels[name];
   if (conf == null) {
-	console.log("Bad name: ", name);
-	return
+    console.log("Bad name: ", name);
+    return;
   }
 
   try {
@@ -570,43 +567,43 @@ const ChannelStatus = async ({client, name}) => {
     let meta = await client.ContentObjectMetadata({
       libraryId: conf.libraryId,
       objectId: conf.objectId
-    })
+    });
 
-	status.channel_title = meta.public.asset_metadata.title;
-	let source = meta.channel.offerings.default.items[0].source["/"];
-	let hash = source.split("/")[2];
-	status.stream_hash = hash;
-	latestHash = await client.LatestVersionHash({
+    status.channel_title = meta.public.asset_metadata.title;
+    let source = meta.channel.offerings.default.items[0].source["/"];
+    let hash = source.split("/")[2];
+    status.stream_hash = hash;
+    latestHash = await client.LatestVersionHash({
 	  versionHash: hash
-	});
-	status.stream_latest_hash = latestHash;
+    });
+    status.stream_latest_hash = latestHash;
 
-	if (hash != latestHash) {
+    if (hash != latestHash) {
 	  status.warnings = ["Stream version is not the latest"];
-	}
+    }
 
-	let channelFormatsUrl = await client.FabricUrl({
+    let channelFormatsUrl = await client.FabricUrl({
       libraryId: conf.libraryId,
       objectId: conf.objectId,
 	  rep: "channel/options.json"
-	});
+    });
 
-	try {
+    try {
 	  let offerings = await got(channelFormatsUrl);
 	  status.offerings = JSON.parse(offerings.body);
-	} catch (error) {
+    } catch (error) {
 	  console.log(error);
 	  status.offerings_error = "Failed to retrieve channel offerings";
-	}
+    }
 
-	status.playout = await ChannelPlayout({client, libraryId: conf.libraryId, objectId: conf.objectId});
+    status.playout = await ChannelPlayout({client, libraryId: conf.libraryId, objectId: conf.objectId});
 
   } catch (error) {
-    console.error(error)
+    console.error(error);
   }
 
   return status;
-}
+};
 
 /*
  * Performs client-side playout operations - open the channel, read offerings,
@@ -617,31 +614,29 @@ const ChannelPlayout = async({client, libraryId, objectId}) => {
   let playout = {};
 
   const offerings = await client.AvailableOfferings({
-	libraryId,
-	objectId,
-	handler: "channel",
-	linkPath: "/public/asset_metadata/offerings"
+    libraryId,
+    objectId,
+    handler: "channel",
+    linkPath: "/public/asset_metadata/offerings"
   });
 
   // Choosing offering 'default'
   let offering = offerings.default;
 
   const playoutOptions = await client.PlayoutOptions({
-	libraryId,
-	objectId,
-	offeringURI: offering.uri
+    libraryId,
+    objectId,
+    offeringURI: offering.uri
   });
-
-  const supportedDRM = 'fairplay';
 
   // Retrieve master playlist
   let masterPlaylistUrl = playoutOptions["hls"]["playoutMethods"]["fairplay"]["playoutUrl"];
   playout.master_playlist_url = masterPlaylistUrl;
   try {
-	let masterPlaylist =  await got(masterPlaylistUrl);
-	playout.master_playlist = "success"
+    //let masterPlaylist =  await got(masterPlaylistUrl);
+    playout.master_playlist = "success";
   } catch (error) {
-	playout.master_playlist = "fail";
+    playout.master_playlist = "fail";
   }
 
   let url = new URL(masterPlaylistUrl);
@@ -655,10 +650,10 @@ const ChannelPlayout = async({client, libraryId, objectId}) => {
   playout.media_playlist_url = mediaPlaylistUrl;
   let mediaPlaylist;
   try {
-	mediaPlaylist = await got(mediaPlaylistUrl);
-	playout.media_playlist = "success"
+    mediaPlaylist = await got(mediaPlaylistUrl);
+    playout.media_playlist = "success";
   } catch (error) {
-	playout.media_playlist = "fail";
+    playout.media_playlist = "fail";
   }
 
   // Retrieve init segment
@@ -666,7 +661,7 @@ const ChannelPlayout = async({client, libraryId, objectId}) => {
   var match = regex.exec(mediaPlaylist.body);
   let initQueryParams;
   if (match) {
-	initQueryParams = match[1];
+    initQueryParams = match[1];
   }
 
   p[p.length - 1] = "video/720@14000000/init.m4s";
@@ -675,7 +670,7 @@ const ChannelPlayout = async({client, libraryId, objectId}) => {
   url.search=initQueryParams;
   let initUrl = url.toString();
   playout.init_segment_url = initUrl;
-/*
+  /*
   try {
 	let initSegment = await got(initUrl);
 	playout.init_segment = "success"
@@ -684,7 +679,7 @@ const ChannelPlayout = async({client, libraryId, objectId}) => {
   }
 */
   return playout;
-}
+};
 
 
 const Summary = async ({client}) => {
@@ -692,61 +687,61 @@ const Summary = async ({client}) => {
   let summary = {};
 
   try {
-	for (const [key, value] of Object.entries(streams)) {
+    for (const [key] of Object.entries(streams)) {
 	  conf = streams[key];
-	  summary[key] = await Status({client, name: key, stopLro: false})
-	}
+	  summary[key] = await Status({client, name: key, stopLro: false});
+    }
 
   } catch (error) {
-    console.error(error)
+    console.error(error);
   }
   return summary;
-}
+};
 
 const ChannelSummary = async ({client}) => {
 
   let summary = {};
 
   try {
-	for (const [key, value] of Object.entries(channels)) {
+    for (const [key] of Object.entries(channels)) {
 	  conf = channels[key];
-	  summary[key] = await ChannelStatus({client, name: key})
-	}
+	  summary[key] = await ChannelStatus({client, name: key});
+    }
 
   } catch (error) {
-    console.error(error)
+    console.error(error);
   }
   return summary;
-}
+};
 
 const ConfigStream = async () => {
 
   const t = 1619850660;
 
   try {
-    let client
+    let client;
     if (conf.clientConf.configUrl) {
       client = await ElvClient.FromConfigurationUrl({
         configUrl: conf.clientConf.configUrl
-      })
+      });
     } else {
-      client = new ElvClient(conf.clientConf)
+      client = new ElvClient(conf.clientConf);
     }
-    const wallet = client.GenerateWallet()
-    const signer = wallet.AddAccount({ privateKey: conf.signerPrivateKey })
-    client.SetSigner({ signer })
-    const fabURI = client.fabricURIs[0]
-    console.log("Fabric URI: " + fabURI)
-    const ethURI = client.ethereumURIs[0]
-    console.log("Ethereum URI: " + ethURI)
+    const wallet = client.GenerateWallet();
+    const signer = wallet.AddAccount({ privateKey: conf.signerPrivateKey });
+    client.SetSigner({ signer });
+    const fabURI = client.fabricURIs[0];
+    console.log("Fabric URI: " + fabURI);
+    const ethURI = client.ethereumURIs[0];
+    console.log("Ethereum URI: " + ethURI);
 
     client.ToggleLogging(false);
 
     let mainMeta = await client.ContentObjectMetadata({
       libraryId: conf.libraryId,
       objectId: conf.objectId
-    })
-    console.log("Main meta:", mainMeta)
+    });
+    console.log("Main meta:", mainMeta);
 
     edgeWriteToken = mainMeta.edge_write_token;
     console.log("Edge: ", edgeWriteToken);
@@ -755,17 +750,17 @@ const ConfigStream = async () => {
       libraryId: conf.libraryId,
       objectId: conf.objectId,
       writeToken: edgeWriteToken
-    })
-    console.log("Edge meta:", edgeMeta)
+    });
+    console.log("Edge meta:", edgeMeta);
 
-	//console.log("CONFIG: ", edgeMeta.live_recording_parameters.live_playout_config);
-	console.log("recording_start_time: ", edgeMeta.recording_start_time);
-	console.log("recording_stop_time:  ", edgeMeta.recording_stop_time);
+    //console.log("CONFIG: ", edgeMeta.live_recording_parameters.live_playout_config);
+    console.log("recording_start_time: ", edgeMeta.recording_start_time);
+    console.log("recording_stop_time:  ", edgeMeta.recording_stop_time);
 
-	// Set rebroadcast start
-	edgeMeta.live_recording_parameters.live_playout_config.rebroadcast_start_time_sec_epoch = t;
+    // Set rebroadcast start
+    edgeMeta.live_recording_parameters.live_playout_config.rebroadcast_start_time_sec_epoch = t;
 
-    if (PRINT_DEBUG) console.log("MergeMetadata", conf.libraryId, conf.objectId, writeToken)
+    if (PRINT_DEBUG) console.log("MergeMetadata", conf.libraryId, conf.objectId, writeToken);
     await client.MergeMetadata({
       libraryId: conf.libraryId,
       objectId: conf.objectId,
@@ -773,99 +768,111 @@ const ConfigStream = async () => {
       metadata: {
         "live_recording_parameters": {
 		  "live_playout_config" : edgeMeta.live_recording_parameters.live_playout_config
-		}
+        }
 	  }
     });
 
   } catch (error) {
-    console.error(error)
+    console.error(error);
   }
-}
+};
 
 async function EnsureAll() {
   client = await StatusPrep({name: null});
   let summary = await Summary({client});
 
   var res = {
-	running: 0,
-	stalled: 0,
-	terminated: 0
+    running: 0,
+    stalled: 0,
+    terminated: 0
   };
 
   try {
-	for (const [key, value] of Object.entries(summary)) {
+    for (const [key, value] of Object.entries(summary)) {
 	  if (value.state == "stalled") {
-		console.log("Stream stalled: ", key, " - restarting");
-		console.log("todo ...");
+        console.log("Stream stalled: ", key, " - restarting");
+        console.log("todo ...");
 	  }
 	  res[value.state] = res[value.state] + 1;
-	}
+    }
   } catch (error) {
-    console.error(error)
+    console.error(error);
   }
 
-  return res
+  return res;
 }
 
+/*
+ * Original Run() function - kept for reference
+ */
 async function Run() {
 
   var client;
 
-  switch(command) {
+  switch (command) {
 
-  case 'start':
-	StartStream({name});
-	break;
+    case "start":
+      StartStream({name});
+      break;
 
-  case 'status':
-	client = await StatusPrep({name});
-	let status = await Status({client, name, stopLro: false});
-	console.log(JSON.stringify(status, null, 4));
-	break;
+    case "status":
+      client = await StatusPrep({name});
+      let status = await Status({client, name, stopLro: false});
+      console.log(JSON.stringify(status, null, 4));
+      break;
 
-  case 'stop':
-	client = await UpdatePrep({name});
-	Status({client, name, stopLro: true});
-	break;
+    case "stop":
+      client = await UpdatePrep({name});
+      Status({client, name, stopLro: true});
+      break;
 
-  case 'summary':
-	client = await StatusPrep({name: null});
-	let summary = await Summary({client});
-	console.log(JSON.stringify(summary, null, 4));
-	break;
+    case "summary":
+      client = await StatusPrep({name: null});
+      let summary = await Summary({client});
+      console.log(JSON.stringify(summary, null, 4));
+      break;
 
-  case 'init': // Set up DRM
-	SetOfferingAndDRM();
-	break;
+    case "init": // Set up DRM
+      SetOfferingAndDRM();
+      break;
 
-  case 'reset': // Stop and start LRO recording (same edge write token)
-	client = await StatusPrep({name});
-	let reset = await Reset({client, name, stopLro: false});
-	console.log(JSON.stringify(reset, null, 4));
-	break;
+    case "reset": // Stop and start LRO recording (same edge write token)
+      client = await StatusPrep({name});
+      let reset = await Reset({client, name, stopLro: false});
+      console.log(JSON.stringify(reset, null, 4));
+      break;
 
-  case 'channel':
-	client = await StatusPrep({name});
-	let channelStatus = await ChannelStatus({client, name});
-	console.log(JSON.stringify(channelStatus, null, 4));
-	break;
+    case "channel":
+      client = await StatusPrep({name});
+      let channelStatus = await ChannelStatus({client, name});
+      console.log(JSON.stringify(channelStatus, null, 4));
+      break;
 
-  case 'channel_summary':
-	client = await StatusPrep({name});
-	let channelSummary = await ChannelSummary({client, name});
-	console.log(JSON.stringify(channelSummary, null, 4));
-	break;
+    case "channel_summary":
+      client = await StatusPrep({name});
+      let channelSummary = await ChannelSummary({client, name});
+      console.log(JSON.stringify(channelSummary, null, 4));
+      break;
 
-  case 'ensure_all': // Check all and restart stalled
-	let ensureSummary = await EnsureAll()
-	console.log(JSON.stringify(ensureSummary, null, 4));
-	break;
+    case "ensure_all": // Check all and restart stalled
+      let ensureSummary = await EnsureAll();
+      console.log(JSON.stringify(ensureSummary, null, 4));
+      break;
 
-  default:
-	console.log("Bad command: ", command)
-	break;
+    case "future_use_config":
+      ConfigStream();
+      break;
+
+    default:
+      console.log("Bad command: ", command);
+      break;
 
   }
 }
+
+if (useOldRunFunction) {
+  Run();
+}
+
 
 exports.EluvioLiveStream = EluvioLiveStream;

--- a/src/LiveStream.js
+++ b/src/LiveStream.js
@@ -870,6 +870,7 @@ async function Run() {
   }
 }
 
+const useOldRunFunction = false;
 if (useOldRunFunction) {
   Run();
 }

--- a/src/abr_profile_live_drm.json
+++ b/src/abr_profile_live_drm.json
@@ -1,0 +1,1906 @@
+{
+  "drm_optional": false,
+  "store_clear": false,
+  "ladder_specs": {
+    "{\"media_type\":\"audio\",\"channels\":1}": {
+      "rung_specs": [
+        {
+          "bit_rate": 128000,
+          "media_type": "audio",
+          "pregenerate": true
+        }
+      ]
+    },
+    "{\"media_type\":\"audio\",\"channels\":2}": {
+      "rung_specs": [
+        {
+          "bit_rate": 128000,
+          "media_type": "audio",
+          "pregenerate": true
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":273,\"aspect_ratio_width\":640}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2538
+        },
+        {
+          "bit_rate": 6000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1692
+        },
+        {
+          "bit_rate": 2640000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1270
+        },
+        {
+          "bit_rate": 1450000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1016
+        },
+        {
+          "bit_rate": 1070000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        },
+        {
+          "bit_rate": 690000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        }
+
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":267,\"aspect_ratio_width\":640}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2538
+        },
+        {
+          "bit_rate": 6000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1692
+        },
+        {
+          "bit_rate": 2640000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1270
+        },
+        {
+          "bit_rate": 1450000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1016
+        },
+        {
+          "bit_rate": 1070000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        },
+        {
+          "bit_rate": 690000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":729,\"aspect_ratio_width\":1280}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":1,\"aspect_ratio_width\":2}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2160
+        },
+        {
+          "bit_rate": 5000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1440
+        },
+        {
+          "bit_rate": 2250000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1200000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 864
+        },
+        {
+          "bit_rate": 910000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 720
+        },
+        {
+          "bit_rate": 580000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 720
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":67,\"aspect_ratio_width\":120}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":539,\"aspect_ratio_width\":960}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":11,\"aspect_ratio_width\":15}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":11,\"aspect_ratio_width\":20}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":12296,\"aspect_ratio_width\":21851}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":131072,\"aspect_ratio_width\":192165}": {
+      "rung_specs": [
+        {
+          "bit_rate": 5500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1620
+        },
+        {
+          "bit_rate": 2400000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1400000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 810
+        },
+        {
+          "bit_rate": 900000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 648
+        },
+        {
+          "bit_rate": 680000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 440000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":135,\"aspect_ratio_width\":176}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":135,\"aspect_ratio_width\":316}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2528
+        },
+        {
+          "bit_rate": 6000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1692
+        },
+        {
+          "bit_rate": 2640000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1270
+        },
+        {
+          "bit_rate": 1450000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1016
+        },
+        {
+          "bit_rate": 1070000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        },
+        {
+          "bit_rate": 690000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":135,\"aspect_ratio_width\":76}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1920,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1080
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 1280,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 720
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 960,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 768,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 432
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":16,\"aspect_ratio_width\":9}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1920,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1080
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 1280,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 720
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 960,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 768,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 432
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":17,\"aspect_ratio_width\":40}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2538
+        },
+        {
+          "bit_rate": 6000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1692
+        },
+        {
+          "bit_rate": 2640000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1270
+        },
+        {
+          "bit_rate": 1450000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1016
+        },
+        {
+          "bit_rate": 1070000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        },
+        {
+          "bit_rate": 690000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":173,\"aspect_ratio_width\":320}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1036,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4700000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1334
+        },
+        {
+          "bit_rate": 2080000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1000
+        },
+        {
+          "bit_rate": 1145000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 800
+        },
+        {
+          "bit_rate": 843000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        },
+        {
+          "bit_rate": 541000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":2,\"aspect_ratio_width\":3}": {
+      "rung_specs": [
+        {
+          "bit_rate": 5500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1620
+        },
+        {
+          "bit_rate": 2400000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1400000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 810
+        },
+        {
+          "bit_rate": 900000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 648
+        },
+        {
+          "bit_rate": 680000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 440000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":20,\"aspect_ratio_width\":27}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":240,\"aspect_ratio_width\":427}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":243,\"aspect_ratio_width\":320}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":259,\"aspect_ratio_width\":480}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1036,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4700000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1334
+        },
+        {
+          "bit_rate": 2080000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1000
+        },
+        {
+          "bit_rate": 1145000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 800
+        },
+        {
+          "bit_rate": 843000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        },
+        {
+          "bit_rate": 541000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":262144,\"aspect_ratio_width\":319905}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1280
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 853
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 512
+        },
+        {
+          "bit_rate": 540000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 426
+        },
+        {
+          "bit_rate": 350000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 426
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":27,\"aspect_ratio_width\":32}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1280
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 853
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 512
+        },
+        {
+          "bit_rate": 540000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 426
+        },
+        {
+          "bit_rate": 350000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 426
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":27,\"aspect_ratio_width\":40}": {
+      "rung_specs": [
+        {
+          "bit_rate": 5500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1620
+        },
+        {
+          "bit_rate": 2400000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1400000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 810
+        },
+        {
+          "bit_rate": 900000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 648
+        },
+        {
+          "bit_rate": 680000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 440000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":297,\"aspect_ratio_width\":400}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":3,\"aspect_ratio_width\":4}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":30,\"aspect_ratio_width\":53}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":40,\"aspect_ratio_width\":71}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":429,\"aspect_ratio_width\":1024}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2538
+        },
+        {
+          "bit_rate": 6000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1692
+        },
+        {
+          "bit_rate": 2640000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1270
+        },
+        {
+          "bit_rate": 1450000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1016
+        },
+        {
+          "bit_rate": 1070000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        },
+        {
+          "bit_rate": 690000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":466577,\"aspect_ratio_width\":912058}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1036,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4700000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1334
+        },
+        {
+          "bit_rate": 2080000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1000
+        },
+        {
+          "bit_rate": 1145000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 800
+        },
+        {
+          "bit_rate": 843000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        },
+        {
+          "bit_rate": 541000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":480,\"aspect_ratio_width\":853}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":486,\"aspect_ratio_width\":853}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":5,\"aspect_ratio_width\":12}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2538
+        },
+        {
+          "bit_rate": 6000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1692
+        },
+        {
+          "bit_rate": 2640000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1270
+        },
+        {
+          "bit_rate": 1450000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1016
+        },
+        {
+          "bit_rate": 1070000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        },
+        {
+          "bit_rate": 690000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":582543,\"aspect_ratio_width\":776720}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":639,\"aspect_ratio_width\":889}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":65536,\"aspect_ratio_width\":87381}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":81,\"aspect_ratio_width\":128}": {
+      "rung_specs": [
+        {
+          "bit_rate": 5500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1620
+        },
+        {
+          "bit_rate": 2400000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1400000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 810
+        },
+        {
+          "bit_rate": 900000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 648
+        },
+        {
+          "bit_rate": 680000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 440000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":8192,\"aspect_ratio_width\":12015}": {
+      "rung_specs": [
+        {
+          "bit_rate": 5500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1620
+        },
+        {
+          "bit_rate": 2400000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1400000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 810
+        },
+        {
+          "bit_rate": 900000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 648
+        },
+        {
+          "bit_rate": 680000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 440000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":891,\"aspect_ratio_width\":1600}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":9,\"aspect_ratio_width\":16}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    }
+  },
+  "playout_formats": {
+    "hls-fairplay": {
+      "drm": {
+        "enc_scheme_name": "cbcs",
+        "license_servers": [],
+        "type": "DrmFairplay"
+      },
+      "protocol": {
+        "type": "ProtoHls"
+      }
+    },
+    "hls-sample-aes": {
+      "drm": {
+        "enc_scheme_name": "cbcs",
+        "type": "DrmSampleAes"
+      },
+      "protocol": {
+        "type": "ProtoHls"
+      }
+    },
+    "hls-aes128": {
+      "drm": {
+        "enc_scheme_name": "aes-128",
+        "type": "DrmAes128"
+      },
+      "protocol": {
+        "type": "ProtoHls"
+      }
+    }
+  },
+  "segment_specs": {
+    "audio": {
+      "segs_per_chunk": 15,
+      "target_dur": 2
+    },
+    "video": {
+      "segs_per_chunk": 15,
+      "target_dur": 2
+    }
+  }
+}
+

--- a/utilities/EluvioLiveStreamCli.js
+++ b/utilities/EluvioLiveStreamCli.js
@@ -1,0 +1,226 @@
+const { EluvioLiveStream } = require("../src/LiveStream.js");
+const { Config } = require("../src/Config.js");
+
+const yargs = require("yargs/yargs");
+const { hideBin } = require("yargs/helpers");
+const yaml = require("js-yaml");
+
+// hack that quiets this msg:
+//  node:87980) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
+//  (Use `node --trace-warnings ...` to show where the warning was created)
+const originalEmit = process.emit;
+process.emit = function (name, data, ...args) {
+  if(name === `warning` && typeof data === `object` && data.name === `ExperimentalWarning`) {
+    return false;
+  }
+  return originalEmit.apply(process, arguments);
+};
+
+const CmdInit = async ({ argv }) => {
+  try {
+    let elvStream = new EluvioLiveStream({
+      configUrl: Config.networks[Config.net],
+      debugLogging: argv.verbose
+    });
+
+    await elvStream.Init({
+      privateKey: process.env.PRIVATE_KEY,
+    });
+
+    let status = await elvStream.SetOfferingAndDRM({name: argv.stream});
+    console.log(yaml.dump(status));
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
+const CmdSessionStart = async ({ argv }) => {
+  try {
+    let elvStream = new EluvioLiveStream({
+      configUrl: Config.networks[Config.net],
+      debugLogging: argv.verbose
+    });
+
+    await elvStream.Init({
+      privateKey: process.env.PRIVATE_KEY,
+    });
+
+    let status = await elvStream.StartSession({name: argv.stream});
+    console.log(yaml.dump(status));
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
+const CmdSessionStop = async ({ argv }) => {
+  try {
+    let elvStream = new EluvioLiveStream({
+      configUrl: Config.networks[Config.net],
+      debugLogging: argv.verbose
+    });
+
+    await elvStream.Init({
+      privateKey: process.env.PRIVATE_KEY,
+    });
+
+    let status = await elvStream.StopSession({name: argv.stream});
+    console.log(yaml.dump(status));
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
+const CmdStreamStatus = async ({ argv }) => {
+  try {
+    let elvStream = new EluvioLiveStream({
+      configUrl: Config.networks[Config.net],
+      debugLogging: argv.verbose
+    });
+
+    await elvStream.Init({
+      privateKey: process.env.PRIVATE_KEY,
+    });
+
+    let status = await elvStream.Status({name: argv.stream, stopLro: false});
+    console.log(yaml.dump(status));
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
+// Executes stream start, stop or reset
+const CmdStreamOp = async ({ argv, op }) => {
+  try {
+    let elvStream = new EluvioLiveStream({
+      configUrl: Config.networks[Config.net],
+      debugLogging: argv.verbose
+    });
+
+    await elvStream.Init({
+      privateKey: process.env.PRIVATE_KEY,
+    });
+
+    let status = await elvStream.StartOrStopOrReset({name: argv.stream, op, stopLro: false});
+    console.log(yaml.dump(status));
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
+yargs(hideBin(process.argv))
+  .option("verbose", {
+    describe: "Verbose mode",
+    type: "boolean",
+    alias: "v"
+  })
+  .command(
+    "init <stream>",
+    "Initialize media and DRM configuration for the object.",
+    (yargs) => {
+      yargs
+        .positional("stream", {
+          describe:
+            "Stream name or QID (content ID)",
+          type: "string",
+        })
+    },
+    (argv) => {
+      CmdInit({ argv });
+    }
+  )
+  .command(
+    "session_start <stream>",
+    "Create a new live stream session.",
+    (yargs) => {
+      yargs
+        .positional("stream", {
+          describe:
+            "Stream name or QID (content ID)",
+          type: "string",
+        })
+    },
+    (argv) => {
+      CmdSessionStart({ argv });
+    }
+  )
+  .command(
+    "session_stop <stream>",
+    "End the current live stream session.",
+    (yargs) => {
+      yargs
+        .positional("stream", {
+          describe:
+            "Stream name or QID (content ID)",
+          type: "string",
+        })
+    },
+    (argv) => {
+      CmdSessionStop({ argv });
+    }
+  )
+  .command(
+    "start <stream>",
+    "Start or resume current live stream session if not running.",
+    (yargs) => {
+      yargs
+        .positional("stream", {
+          describe:
+            "Stream name or QID (content ID)",
+          type: "string",
+        })
+    },
+    (argv) => {
+      CmdStreamOp({ argv, op: "start" });
+    }
+  )
+  .command(
+    "status <stream>",
+    "Status of the currently active live stream session",
+    (yargs) => {
+      yargs
+        .positional("stream", {
+          describe:
+            "Stream name or QID (content ID)",
+          type: "string",
+        })
+    },
+    (argv) => {
+      CmdStreamStatus({ argv });
+    }
+  )
+  .command(
+    "reset <stream>",
+    "Reset the currently active live stream session",
+    (yargs) => {
+      yargs
+        .positional("stream", {
+          describe:
+            "Stream name or QID (content ID)",
+          type: "string",
+        })
+    },
+    (argv) => {
+      CmdStreamOp({ argv, op: "reset" });
+    }
+  )
+  .command(
+    "stop <stream>",
+    "Pauses the currently active live stream session",
+    (yargs) => {
+      yargs
+        .positional("stream", {
+          describe:
+            "Stream name or QID (content ID)",
+          type: "string",
+        })
+    },
+    (argv) => {
+      CmdStreamOp({ argv, op: "stop" });
+    }
+  )
+
+  .strict()
+  .help()
+  .usage("Eluvio Live Stream CLI\n\nUsage: elv-stream <command>")
+  .scriptName("")
+  .demandCommand(1).argv;

--- a/utilities/EluvioLiveStreamCli.js
+++ b/utilities/EluvioLiveStreamCli.js
@@ -29,7 +29,8 @@ const CmdInit = async ({ argv }) => {
 
     let status = await elvStream.SetOfferingAndDRM({
       name: argv.stream,
-      drm: argv.drm
+      drm: argv.drm,
+      format: argv.format
     });
     console.log(yaml.dump(status));
   } catch (e) {
@@ -134,6 +135,11 @@ yargs(hideBin(process.argv))
           describe:
             "Specify if playout should be DRM protected (default: false)",
           type: "boolean",
+        })
+        .option("format", {
+          describe:
+            "Specify the list of playout formats and DRM to support, comma-separated (hls-clear, hls-aes128, hls-sample-aes, hls-fairplay)",
+          type: "string",
         })
 
       },

--- a/utilities/EluvioLiveStreamCli.js
+++ b/utilities/EluvioLiveStreamCli.js
@@ -27,14 +27,17 @@ const CmdInit = async ({ argv }) => {
       privateKey: process.env.PRIVATE_KEY,
     });
 
-    let status = await elvStream.SetOfferingAndDRM({name: argv.stream});
+    let status = await elvStream.SetOfferingAndDRM({
+      name: argv.stream,
+      drm: argv.drm
+    });
     console.log(yaml.dump(status));
   } catch (e) {
     console.error("ERROR:", e);
   }
 };
 
-const CmdStreamStart = async ({ argv }) => {
+const CmdStreamCreate = async ({ argv }) => {
   try {
     let elvStream = new EluvioLiveStream({
       configUrl: Config.networks[Config.net],
@@ -45,7 +48,7 @@ const CmdStreamStart = async ({ argv }) => {
       privateKey: process.env.PRIVATE_KEY,
     });
 
-    let status = await elvStream.StreamStart({
+    let status = await elvStream.StreamCreate({
       name: argv.stream,
       start: argv.start,
       show_curl: argv.show_curl
@@ -127,7 +130,13 @@ yargs(hideBin(process.argv))
             "Stream name or QID (content ID)",
           type: "string",
         })
-    },
+        .option("drm", {
+          describe:
+            "Specify if playout should be DRM protected (default: false)",
+          type: "boolean",
+        })
+
+      },
     (argv) => {
       CmdInit({ argv });
     }
@@ -154,7 +163,7 @@ yargs(hideBin(process.argv))
         })
     },
     (argv) => {
-      CmdStreamStart({ argv });
+      CmdStreamCreate({ argv });
     }
   )
   .command(

--- a/utilities/EluvioLiveStreamCli.js
+++ b/utilities/EluvioLiveStreamCli.js
@@ -30,7 +30,7 @@ const CmdInit = async ({ argv }) => {
     let status = await elvStream.SetOfferingAndDRM({
       name: argv.stream,
       drm: argv.drm,
-      format: argv.format
+      format: argv.formats
     });
     console.log(yaml.dump(status));
   } catch (e) {
@@ -136,7 +136,7 @@ yargs(hideBin(process.argv))
             "Specify if playout should be DRM protected (default: false)",
           type: "boolean",
         })
-        .option("format", {
+        .option("formats", {
           describe:
             "Specify the list of playout formats and DRM to support, comma-separated (hls-clear, hls-aes128, hls-sample-aes, hls-fairplay)",
           type: "string",

--- a/utilities/EluvioLiveStreamCli.js
+++ b/utilities/EluvioLiveStreamCli.js
@@ -34,7 +34,7 @@ const CmdInit = async ({ argv }) => {
   }
 };
 
-const CmdSessionStart = async ({ argv }) => {
+const CmdStreamStart = async ({ argv }) => {
   try {
     let elvStream = new EluvioLiveStream({
       configUrl: Config.networks[Config.net],
@@ -45,14 +45,18 @@ const CmdSessionStart = async ({ argv }) => {
       privateKey: process.env.PRIVATE_KEY,
     });
 
-    let status = await elvStream.StartSession({name: argv.stream});
+    let status = await elvStream.StreamStart({
+      name: argv.stream,
+      start: argv.start,
+      show_curl: argv.show_curl
+    });
     console.log(yaml.dump(status));
   } catch (e) {
     console.error("ERROR:", e);
   }
 };
 
-const CmdSessionStop = async ({ argv }) => {
+const CmdStreamTerminate = async ({ argv }) => {
   try {
     let elvStream = new EluvioLiveStream({
       configUrl: Config.networks[Config.net],
@@ -115,7 +119,7 @@ yargs(hideBin(process.argv))
   })
   .command(
     "init <stream>",
-    "Initialize media and DRM configuration for the object.",
+    "Initialize media and DRM configuration for the stream object.",
     (yargs) => {
       yargs
         .positional("stream", {
@@ -129,8 +133,8 @@ yargs(hideBin(process.argv))
     }
   )
   .command(
-    "session_start <stream>",
-    "Create a new live stream session.",
+    "create <stream>",
+    "Create a new live stream for this stream object.",
     (yargs) => {
       yargs
         .positional("stream", {
@@ -138,14 +142,24 @@ yargs(hideBin(process.argv))
             "Stream name or QID (content ID)",
           type: "string",
         })
+        .option("start", {
+          describe:
+            "Optionally start the the new stream (equivalent to calling 'start')",
+          type: "boolean",
+        })
+        .option("show_curl", {
+          describe:
+            "Show 'curl' commands for inspecting metadata, LRO status, etc.",
+          type: "boolean",
+        })
     },
     (argv) => {
-      CmdSessionStart({ argv });
+      CmdStreamStart({ argv });
     }
   )
   .command(
-    "session_stop <stream>",
-    "End the current live stream session.",
+    "terminate <stream>",
+    "End the current live stream for this object.",
     (yargs) => {
       yargs
         .positional("stream", {
@@ -155,12 +169,12 @@ yargs(hideBin(process.argv))
         })
     },
     (argv) => {
-      CmdSessionStop({ argv });
+      CmdStreamTerminate({ argv });
     }
   )
   .command(
     "start <stream>",
-    "Start or resume current live stream session if not running.",
+    "Start or resume current live stream if not running.",
     (yargs) => {
       yargs
         .positional("stream", {
@@ -175,7 +189,7 @@ yargs(hideBin(process.argv))
   )
   .command(
     "status <stream>",
-    "Status of the currently active live stream session",
+    "Status of the currently active live stream.",
     (yargs) => {
       yargs
         .positional("stream", {
@@ -190,7 +204,7 @@ yargs(hideBin(process.argv))
   )
   .command(
     "reset <stream>",
-    "Reset the currently active live stream session",
+    "Reset the currently active live stream.",
     (yargs) => {
       yargs
         .positional("stream", {
@@ -205,7 +219,7 @@ yargs(hideBin(process.argv))
   )
   .command(
     "stop <stream>",
-    "Pauses the currently active live stream session",
+    "Pauses the currently active live stream.",
     (yargs) => {
       yargs
         .positional("stream", {


### PR DESCRIPTION


```
./elv-stream
Eluvio Live Stream CLI

Usage: elv-stream <command>

Commands:
  init <stream>       Initialize media and DRM configuration for the stream
                      object.
  create <stream>     Create a new live stream for this stream object.
  terminate <stream>  End the current live stream for this object.
  start <stream>      Start or resume current live stream if not running.
  status <stream>     Status of the currently active live stream.
  reset <stream>      Reset the currently active live stream.
  stop <stream>       Pauses the currently active live stream.

Options:
      --version  Show version number                                   [boolean]
  -v, --verbose  Verbose mode                                          [boolean]
      --help     Show help                                             [boolean]
```