### PR TITLE
Add Liverecording subcommand to elv-stream

### DIFF
--- a/src/LiveRecordingGenerator.js
+++ b/src/LiveRecordingGenerator.js
@@ -1,0 +1,106 @@
+const liveconfTemplate = require("./LiveRecordingTemplate");
+class LiveRecording {
+  constructor(probeData, nodeId, nodeUrl, calcAvSegDurations, overwriteOriginUrl) {
+    this.probeData = probeData;
+    this.nodeId = nodeId;
+    this.nodeUrl = nodeUrl;
+    this.calcAvSegDurations = calcAvSegDurations;
+    this.overwriteOriginUrl = overwriteOriginUrl;
+  }
+
+  probeKind() {
+    let fileNameSplit = this.probeData.format.filename.split(":");
+    return fileNameSplit[0];
+  }
+
+  getStreamDataForCodecType(codecType) {
+    let stream = null;
+    for (let index = 0; index < this.probeData.streams.length; index++) {
+      if (this.probeData.streams[index].codec_type == codecType) {
+        stream = this.probeData.streams[index];
+      }
+    }
+    return stream;
+  }
+
+  isFrameRateWhole() {
+    let videoStream = this.getStreamDataForCodecType("video");
+    let frameRate = videoStream.r_frame_rate.split("/");
+    return frameRate[1] == "1";
+  }
+
+  getForceKeyint() {
+    let videoStream = this.getStreamDataForCodecType("video");
+    let frameRate = videoStream.r_frame_rate.split("/");
+    let roundedFrameRate = Math.round(frameRate[0] / frameRate[1]);
+    if (roundedFrameRate > 30) {
+      return roundedFrameRate;
+    } else {
+      return roundedFrameRate * 2;
+    }
+  }
+
+  calcSegDuration() {
+    // I've only seen these two values. Herd coded for now...
+    if (this.isFrameRateWhole()) {
+      return "30";
+    }
+    return "30.03";
+  }
+
+  generateLiveConf() {
+    // gather required data
+    var conf = liveconfTemplate;
+    var fileName = this.overwriteOriginUrl || this.probeData.format.filename;
+    var audioStream = this.getStreamDataForCodecType("audio");
+    var sampleRate = parseInt(audioStream.sample_rate);
+    var segDuration = this.calcSegDuration();
+    var videoStream = this.getStreamDataForCodecType("video");
+    var sourceTimescale;
+    
+    // Fill in liveconf all formats have in common
+    conf.live_recording.fabric_config.ingress_node_api = this.nodeUrl || null;
+    conf.live_recording.fabric_config.ingress_node_id = this.nodeId || null;
+    conf.live_recording.recording_config.recording_params.description;
+    conf.live_recording.recording_config.recording_params.origin_url = fileName;
+    conf.live_recording.recording_config.recording_params.description = `Ingest stream ${fileName}`;
+    conf.live_recording.recording_config.recording_params.name = `Ingest stream ${fileName}`;
+    conf.live_recording.recording_config.recording_params.xc_params.audio_index[0] = audioStream.index;
+    conf.live_recording.recording_config.recording_params.xc_params.force_keyint = this.getForceKeyint();
+    conf.live_recording.recording_config.recording_params.xc_params.sample_rate = sampleRate;
+    conf.live_recording.recording_config.recording_params.xc_params.seg_duration = segDuration;
+    conf.live_recording.recording_config.recording_params.xc_params.enc_height = videoStream.height;
+    conf.live_recording.recording_config.recording_params.xc_params.enc_width = videoStream.width;
+
+    // Fill in specifics for protocol
+    switch (this.probeKind()) {
+      case "udp":
+        sourceTimescale = 90000;
+        conf.live_recording.recording_config.recording_params.source_timescale = sourceTimescale;
+        break;
+      case "rtmp":
+        sourceTimescale = 16000;
+        conf.live_recording.recording_config.recording_params.source_timescale = sourceTimescale;
+        conf.live_recording.recording_config.recording_params.xc_params.video_bitrate = parseInt(videoStream.bit_rate);
+        break;
+      case "hls":
+        console.log("HLS detected. Not yet implemented");
+        break;
+      default:
+        console.log("Something we do not support detected.");
+        break;
+    }
+
+    // Fill in AV segdurations if specified. 
+    if (this.calcAvSegDurations) {
+      conf.live_recording.recording_config.recording_params.xc_params.audio_seg_duration_ts = segDuration * sampleRate;
+      conf.live_recording.recording_config.recording_params.xc_params.video_seg_duration_ts = segDuration * sourceTimescale;
+    } else {
+      delete conf.live_recording.recording_config.recording_params.xc_params.audio_seg_duration_ts;
+      delete conf.live_recording.recording_config.recording_params.xc_params.video_seg_duration_ts;
+    }
+
+    return JSON.stringify(conf, null, 2);
+  }
+}
+module.exports = { LiveRecording };

--- a/src/LiveRecordingGenerator.js
+++ b/src/LiveRecordingGenerator.js
@@ -1,4 +1,5 @@
 const liveconfTemplate = require("./LiveRecordingTemplate");
+
 class LiveRecording {
   constructor(probeData, nodeId, nodeUrl, calcAvSegDurations, overwriteOriginUrl) {
     this.probeData = probeData;

--- a/src/LiveRecordingTemplate.js
+++ b/src/LiveRecordingTemplate.js
@@ -1,0 +1,104 @@
+module.exports = {
+  live_recording: {
+    fabric_config: {
+      ingress_node_api: "",
+      ingress_node_id: ""
+    },
+    playout_config: {
+      rebroadcast_start_time_sec_epoch: 0,
+      vod_enabled: false
+    },
+    recording_config: {
+      recording_params: {
+        description: "",
+        ladder_specs: [
+          {
+            bit_rate: 14000000,
+            codecs: "avc1.640028,mp4a.40.2",
+            height: 2160,
+            media_type: 1,
+            representation: "2160@14000000",
+            stream_name: "video",
+            width: 3840
+          },
+          {
+            bit_rate: 9500000,
+            codecs: "avc1.640028,mp4a.40.2",
+            height: 1080,
+            media_type: 1,
+            representation: "1080@9500000",
+            stream_name: "video",
+            width: 1920
+          },
+          {
+            bit_rate: 4500000,
+            codecs: "avc1.640028,mp4a.40.2",
+            height: 720,
+            media_type: 1,
+            representation: "720@4500000",
+            stream_name: "video",
+            width: 1280
+          },
+          {
+            bit_rate: 520000,
+            codecs: "avc1.640028,mp4a.40.2",
+            height: 360,
+            media_type: 1,
+            representation: "360@520000",
+            stream_name: "video",
+            width: 640
+          },
+          {
+            bit_rate: 128000,
+            channels: 2,
+            codecs: "mp4a.40.2",
+            media_type: 2,
+            representation: "stereo@128000",
+            stream_name: "audio"
+          }
+        ],
+        listen: true,
+        live_delay_nano: 2000000000,
+        max_duration_sec: -1,
+        name: "",
+        origin_url: "",
+        part_ttl: 2592000,
+        playout_type: "live",
+        source_timescale: null,
+        xc_params: {
+          audio_bitrate: 128000,
+          audio_index: [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+          ],
+          audio_seg_duration_ts: null,
+          ecodec: "libx264",
+          ecodec2: "aac",
+          enc_height: 2160,
+          enc_width: 3840,
+          filter_descriptor: "",
+          force_keyint: null,
+          format: "fmp4-segment",
+          listen: true,
+          n_audio: 1,
+          preset: "faster",
+          sample_rate: 48000,
+          seg_duration: null,
+          skip_decoding: false,
+          start_segment_str: "1",
+          stream_id: -1,
+          sync_audio_to_stream_id: -1,
+          video_bitrate: null,
+          video_seg_duration_ts: null,
+          xc_type: 3
+        }
+      }
+    }
+  }
+};

--- a/utilities/EluvioLiveStreamCli.js
+++ b/utilities/EluvioLiveStreamCli.js
@@ -118,12 +118,15 @@ const CmdStreamOp = async ({ argv, op }) => {
 };
 
 const CreateLiveRecording = async ({ argv }) => {
-  let { probeFile, nodeUrl, nodeId, calcAvSegDurations, overwriteOriginUrl} = argv;
-  let rawdata = fs.readFileSync(probeFile);
-  let probe = JSON.parse(rawdata);
-
-  lc = new LiveRecording(probe, nodeId, nodeUrl, calcAvSegDurations, overwriteOriginUrl);
-  console.log(lc.generateLiveConf());
+  try {
+    let { probeFile, nodeUrl, nodeId, calcAvSegDurations, overwriteOriginUrl} = argv;
+    let rawdata = fs.readFileSync(probeFile);
+    let probe = JSON.parse(rawdata);
+    lc = new LiveRecording(probe, nodeId, nodeUrl, calcAvSegDurations, overwriteOriginUrl);
+    console.log(lc.generateLiveConf());
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
 };
 
 yargs(hideBin(process.argv))

--- a/utilities/EluvioLiveStreamCli.js
+++ b/utilities/EluvioLiveStreamCli.js
@@ -156,7 +156,7 @@ yargs(hideBin(process.argv))
           type: "string",
         })
 
-    },
+      },
     (argv) => {
       CmdInit({ argv });
     }


### PR DESCRIPTION
I added a subcommand and its logic to elv-stream. This subcommand takes in a ffprobe json file as input and outputs live recording metadata for the stream. I also tested the other elv-stream commands to make sure nothing is broken. 

Some final edits might be needed to the live recording but its a good basis for starting. Sometimes it might be ready as is!

```bash
❯ ./elv-stream liverecording --help
 liverecording [args]

Generates live recording object metadata using a source probe

Options:
      --version             Show version number                        [boolean]
  -v, --verbose             Verbose mode                               [boolean]
      --help                Show help                                  [boolean]
  -p, --probeFile           Path to file containing ffprobe data in json format
                                                             [string] [required]
  -n, --nodeUrl             Optional node, example:
                            https://host-76-74-34-195.contentfabric.io  [string]
  -i, --nodeId              Optional node id, example:
                            inod2dPELDTh44bbBDU7rdH7zGTThRKd            [string]
  -c, --calcAvSegDurations  Have the tool automatically calculate and use
                            audio_seg_duration_ts and video_seg_duration_ts
                                                      [boolean] [default: false]
  -d, --overwriteOriginUrl  Manually provide rtmp or udp origin url rather than
                            use the url provided in the probe
                                                        [string] [default: null]
```

Example run (this is an rtmp probe of big buck bunny)
```
❯ ./elv-stream liverecording -p ./tmp/bbb_4k_60fps_ts.json  -n https://host-76-74-28-233.contentfabric.io -i inod3P5oPk4azq8eYUiSh4JYKpRmMoQg
{
  "live_recording": {
    "fabric_config": {
      "ingress_node_api": "https://host-76-74-28-233.contentfabric.io",
      "ingress_node_id": "inod3P5oPk4azq8eYUiSh4JYKpRmMoQg"
    },
...
```
