### PR TITLE
Live stream insertion support

### DIFF
--- a/src/ElvFabric.js
+++ b/src/ElvFabric.js
@@ -251,9 +251,14 @@ class ElvFabric {
 
     let csvOut = "";
     for (const [id] of Object.entries(ids)) {
-      const meta = await this.getMeta({objectId: id, includeHash:true});
+      let row = "";
+      try {
+        const meta = await this.getMeta({objectId: id, includeHash:true});
 
-      let row = await ElvUtils.MakeCsv({fields, meta});
+        row = await ElvUtils.MakeCsv({fields, meta});
+      } catch (error) {
+        row = "ERROR: " + error.message;
+      }
       row = id + "," + row;
       csvOut = csvOut + row + "\n";
     }

--- a/src/LiveStream.js
+++ b/src/LiveStream.js
@@ -662,8 +662,8 @@ class EluvioLiveStream {
   }
 
   async Insertion({name, insertionTime, duration, targetHash, remove}) {
-    const audioAbrDuration = 2.005333
-    const videoAbrDuration = 2.002002
+    const audioAbrDuration = 2.005333;
+    const videoAbrDuration = 2.002002;
 
     let conf = await this.LoadConf({name});
     let libraryId = await this.client.ContentObjectLibraryId({objectId: conf.objectId});
@@ -744,7 +744,7 @@ class EluvioLiveStream {
       insertions = [
         ...insertions,
         newInsertion
-      ]
+      ];
     }
 
     // Store the new insertions in the write token

--- a/src/LiveStream.js
+++ b/src/LiveStream.js
@@ -150,6 +150,14 @@ class EluvioLiveStream {
         call: "live/status/" + tlro
       });
 
+      status.insertions = [];
+      if (edgeMeta.live_recording.playout_config.interleaves != undefined) {
+        let insertions = edgeMeta.live_recording.playout_config.interleaves;
+        for (let i = 0; i < insertions.length; i ++) {
+          status.insertions[i] = {insertion_time: insertions[i].insertion_time, target: insertions[i].playout};
+        }
+      }
+
       let state = "stopped";
       let lroStatus = "";
       try {
@@ -497,7 +505,6 @@ class EluvioLiveStream {
         objectId: objectId,
         writeToken: edgeWriteToken,
         metadata: edgeMeta
-
       });
 
       await this.client.FinalizeContentObject({
@@ -653,6 +660,107 @@ class EluvioLiveStream {
       console.error(error);
     }
   }
+
+  async Insertion({name, insertionTime, duration, targetHash, remove}) {
+    const audioAbrDuration = 2.005333
+    const videoAbrDuration = 2.002002
+
+    let conf = await this.LoadConf({name});
+    let libraryId = await this.client.ContentObjectLibraryId({objectId: conf.objectId});
+    let objectId = conf.objectId;
+
+    let mainMeta = await this.client.ContentObjectMetadata({
+      libraryId: libraryId,
+      objectId: conf.objectId
+    });
+
+    let fabURI = mainMeta.live_recording.fabric_config.ingress_node_api;
+
+    // Support both hostname and URL ingress_node_api
+    if (!fabURI.startsWith("http")) {
+      // Assume https
+      fabURI = "https://" + fabURI;
+    }
+    this.client.SetNodes({fabricURIs: [fabURI]});
+    let edgeWriteToken = mainMeta.live_recording.fabric_config.edge_write_token;
+
+    let edgeMeta = await this.client.ContentObjectMetadata({
+      libraryId: libraryId,
+      objectId: conf.objectId,
+      writeToken: edgeWriteToken
+    });
+
+    let res = {};
+    let insertions = [];
+    if (edgeMeta.live_recording.playout_config.interleaves != undefined) {
+      insertions = edgeMeta.live_recording.playout_config.interleaves;
+    }
+
+    // Assume insertions are sorted by insertion time
+    let errs = [];
+    let currentTime = -1;
+    let insertionDone = false;
+    let newInsertion = {
+      insertion_time: insertionTime,
+      duration: duration,
+      audio_abr_duration: audioAbrDuration,
+      video_abr_duration: videoAbrDuration,
+      playout: "/qfab/" + targetHash + "/rep/playout"  // TO FIX - should be a link
+    };
+
+    for (let i = 0; i < insertions.length; i ++) {
+      if (insertions[i].insertion_time <= currentTime) {
+        // Bad insertion - must be later than current time
+        append(errs, "Bad insertion - time:", insertions[i].insertion_time);
+      }
+      if (remove) {
+        if (insertions[i].insertion_time == insertionTime) {
+          insertions.splice(i, 1);
+          break;
+        }
+      } else {
+        if (insertions[i].insertion_time > insertionTime) {
+          if (i > 0) {
+            insertions = [
+              ...insertions.slice[0, i],
+              newInsertion,
+              ...insertions.splice(i)
+            ];
+          } else {
+            insertions = [
+              newInsertion,
+              ...insertions.splice(i)
+            ];
+          }
+          insertionDone = true;
+          break;
+        }
+      }
+    }
+
+    if (!remove && !insertionDone) {
+      // Add to the end of the insertions list
+      console.log("Add insertion at the end");
+      insertions = [
+        ...insertions,
+        newInsertion
+      ]
+    }
+
+    // Store the new insertions in the write token
+    await this.client.ReplaceMetadata({
+      libraryId: libraryId,
+      objectId: objectId,
+      writeToken: edgeWriteToken,
+      metadataSubtree: "/live_recording/playout_config/interleaves",
+      metadata: insertions
+    });
+
+    res.errors = errs;
+    res.insertions = insertions;
+    return res;
+  }
+
 
   async LoadConf({name}) {
 

--- a/utilities/EluvioLiveStreamCli.js
+++ b/utilities/EluvioLiveStreamCli.js
@@ -283,12 +283,12 @@ yargs(hideBin(process.argv))
         })
         .positional("time", {
           describe:
-            "Insertion time (seconds with 6 decimals)",
+            "Insertion time relative to stream start (seconds with 6 decimal precision)",
           type: "float",
         })
         .positional("duration", {
           describe:
-            "Duration (seconds with 6 decimals)",
+            "Duration (seconds with 6 decimal precision)",
           type: "float",
         })
         .positional("target_hash", {

--- a/utilities/EluvioLiveStreamCli.js
+++ b/utilities/EluvioLiveStreamCli.js
@@ -115,6 +115,30 @@ const CmdStreamOp = async ({ argv, op }) => {
   }
 };
 
+const CmdStreamInsertion = async ({ argv }) => {
+  try {
+    let elvStream = new EluvioLiveStream({
+      configUrl: Config.networks[Config.net],
+      debugLogging: argv.verbose
+    });
+
+    await elvStream.Init({
+      privateKey: process.env.PRIVATE_KEY,
+    });
+
+    let status = await elvStream.Insertion({
+      name: argv.stream,
+      insertionTime: argv.time,
+      duration: argv.duration,
+      targetHash: argv.target_hash,
+      remove: argv.remove
+    });
+    console.log(yaml.dump(status));
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
 yargs(hideBin(process.argv))
   .option("verbose", {
     describe: "Verbose mode",
@@ -245,6 +269,42 @@ yargs(hideBin(process.argv))
     },
     (argv) => {
       CmdStreamOp({ argv, op: "stop" });
+    }
+  )
+  .command(
+    "insertion <stream> <time> <duration> <target_hash>",
+    "Pauses the currently active live stream.",
+    (yargs) => {
+      yargs
+        .positional("stream", {
+          describe:
+            "Stream name or QID (content ID)",
+          type: "string",
+        })
+        .positional("time", {
+          describe:
+            "Insertion time (seconds with 6 decimals)",
+          type: "float",
+        })
+        .positional("duration", {
+          describe:
+            "Duration (seconds with 6 decimals)",
+          type: "float",
+        })
+        .positional("target_hash", {
+          describe:
+            "Target content object hash (playable)",
+          type: "string",
+        })
+        .option("remove", {
+          describe:
+            "Flag indicating the insertion is to be deleted",
+          type: "bool",
+        })
+
+    },
+    (argv) => {
+      CmdStreamInsertion({ argv });
     }
   )
 


### PR DESCRIPTION
Support for the new live stream capability - ad/content insertion.

- `status` reports list of insertions
- new command `insertion` can be used to add or remove an existing insertion from a live stream (write token)

```
./elv-stream insertion
 insertion <stream> <time> <duration> <target_hash>

Pauses the currently active live stream.

Positionals:
  stream       Stream name or QID (content ID)               [string] [required]
  time         Insertion time relative to stream start (seconds with 6 decimal
               precision)                                             [required]
  duration     Duration (seconds with 6 decimal precision)            [required]
  target_hash  Target content object hash (playable)         [string] [required]

Options:
      --version  Show version number                                   [boolean]
  -v, --verbose  Verbose mode                                          [boolean]
      --help     Show help                                             [boolean]
      --remove   Flag indicating the insertion is to be deleted```