### PR TITLE
Enhance time spec for stream insertions

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -1,16 +1,18 @@
-const net = "main"; // Set to "main"  "demov3" "test"
+const net = "main"; // Set to "main"  "demov3" "test" "dev"
 
 const networks = {
   main: "https://main.net955305.contentfabric.io",
   demo: "https://demov3.net955210.contentfabric.io",
   demov3: "https://demov3.net955210.contentfabric.io",
   test: "https://test.net955205.contentfabric.io/config",
+  dev: "http://127.0.0.1:8008/config"
 };
 
 const mainObjects = {
   main: "iq__suqRJUt2vmXsyiWS5ZaSGwtFU9R",
   demov3: "iq__2gkNh8CCZqFFnoRpEUmz7P3PaBQG",
   test: "NOT YET SET UP",
+  dev: "NOT YET SET UP"
 };
 
 const consts = {
@@ -39,6 +41,8 @@ const consts = {
     spaceAddress: "0x8e5935ca87ad11779e3aec4adcb48a5cb7c2abb4",
     claimerAddress: "0xdB9241496785241f0727D3f2BbB12a5B75dEb3E9",
   },
+  dev: {
+  }
 };
 
 exports.Config = { net, networks, mainObjects, consts };

--- a/src/LiveStream.js
+++ b/src/LiveStream.js
@@ -73,7 +73,7 @@ class EluvioLiveStream {
    * - stalled - stream is running but source feed is no longer received
    * - terminated - stream is terminated (must create a new one to restart)
    */
-  async Status({name, stopLro = false}) {
+  async Status({name, stopLro = false, showParams = false}) {
 
     let conf = await this.LoadConf({name});
 
@@ -164,6 +164,10 @@ class EluvioLiveStream {
             insertion_time_local: new Date(insertionTimeSinceEpoch * 1000).toLocaleString(),
             target: insertions[i].playout};
         }
+      }
+
+      if (showParams) {
+        status.recording_paramse = edgeMeta.live_recording.recording_config.recording_params;
       }
 
       let state = "stopped";
@@ -679,7 +683,7 @@ class EluvioLiveStream {
   // - remove - flag to remove the insertion at that exact 'time' (instead of adding)
   async Insertion({name, insertionTime, sinceStart, duration, targetHash, remove}) {
     const audioAbrDuration = 2.005333;
-    const videoAbrDuration = 2.002002;
+    const videoAbrDuration = 2.002000;
 
     let conf = await this.LoadConf({name});
     let libraryId = await this.client.ContentObjectLibraryId({objectId: conf.objectId});
@@ -715,7 +719,7 @@ class EluvioLiveStream {
     // Find stream start time (from the most recent recording section)
     let recordings = edgeMeta.live_recording.recordings;
     let period = recordings.live_offering[recordings.recording_sequence - 1];
-    let streamStartTime = period.start_time_epoch_sec
+    let streamStartTime = period.start_time_epoch_sec;
 
     if (!sinceStart) {
       insertionTime = insertionTime - streamStartTime;

--- a/src/LiveStream.js
+++ b/src/LiveStream.js
@@ -157,7 +157,12 @@ class EluvioLiveStream {
       if (edgeMeta.live_recording.playout_config.interleaves != undefined) {
         let insertions = edgeMeta.live_recording.playout_config.interleaves;
         for (let i = 0; i < insertions.length; i ++) {
-          status.insertions[i] = {insertion_time: insertions[i].insertion_time, target: insertions[i].playout};
+          let insertionTimeSinceEpoch = recording_period.start_time_epoch_sec + insertions[i].insertion_time;
+          status.insertions[i] = {
+            insertion_time_since_start: insertions[i].insertion_time,
+            insertion_time: new Date(insertionTimeSinceEpoch * 1000).toISOString(),
+            insertion_time_local: new Date(insertionTimeSinceEpoch * 1000).toLocaleString(),
+            target: insertions[i].playout};
         }
       }
 
@@ -384,6 +389,7 @@ class EluvioLiveStream {
       }
 
       console.log("STARTING");
+
       try {
         await this.client.CallBitcodeMethod({
           libraryId: status.library_id,
@@ -664,7 +670,14 @@ class EluvioLiveStream {
     }
   }
 
-  async Insertion({name, insertionTime, duration, targetHash, remove}) {
+  // Add a content insertion entry
+  // Parameters:
+  // - insertionTime - seconds (float)
+  // - sinceStart - true if time specified since stream start, false if since epoch
+  // - duration - seconds (float, deafault 20.0)
+  // - targetHash -  playable
+  // - remove - flag to remove the insertion at that exact 'time' (instead of adding)
+  async Insertion({name, insertionTime, sinceStart, duration, targetHash, remove}) {
     const audioAbrDuration = 2.005333;
     const videoAbrDuration = 2.002002;
 
@@ -697,6 +710,19 @@ class EluvioLiveStream {
     let insertions = [];
     if (edgeMeta.live_recording.playout_config.interleaves != undefined) {
       insertions = edgeMeta.live_recording.playout_config.interleaves;
+    }
+
+    // Find stream start time (from the most recent recording section)
+    let recordings = edgeMeta.live_recording.recordings;
+    let period = recordings.live_offering[recordings.recording_sequence - 1];
+    let streamStartTime = period.start_time_epoch_sec
+
+    if (!sinceStart) {
+      insertionTime = insertionTime - streamStartTime;
+    }
+
+    if (duration == undefined) {
+      duration = 20;  // Default duration
     }
 
     // Assume insertions are sorted by insertion time

--- a/utilities/EluvioLiveStreamCli.js
+++ b/utilities/EluvioLiveStreamCli.js
@@ -89,7 +89,7 @@ const CmdStreamStatus = async ({ argv }) => {
       privateKey: process.env.PRIVATE_KEY,
     });
 
-    let status = await elvStream.Status({name: argv.stream, stopLro: false});
+    let status = await elvStream.Status({name: argv.stream, stopLro: false, showParams: argv.show_params});
     console.log(yaml.dump(status));
   } catch (e) {
     console.error("ERROR:", e);
@@ -261,6 +261,11 @@ yargs(hideBin(process.argv))
           describe:
             "Stream name or QID (content ID)",
           type: "string",
+        })
+        .option("show_params", {
+          describe:
+            "Show recording parameters (can be large)",
+          type: "bool",
         })
     },
     (argv) => {


### PR DESCRIPTION
Quick enhancement for the ./elv-stream insertion

Now insertion time can be specified as follows:

(a)  Seconds (float) since stream start

`120.050`

(b)  Seconds from now  (same as above but use `--from_now` flag)

`60.000 --from_now`

(c)  Wall time (absolute) using this ISO format  (can have milliseconds; always UTC!)

`2023-06-06T06:05:00.700Z` 

Example (the most common example for testing):

```
/elv-stream insertion iq__rNTPXZR6hiCrCHPCSidkjZtNsdb  120 hq__8iY9aVTRNsM6hXobZGFCp1u5bTijKvJ5kEQUr6ZV6SpZbUhjDBKfsbfWN9ui6B1poXwSK6RRCa --duration 25
```