### PR TITLE
add --csv option to tenant_wallets (#125)

### DIFF
--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -2685,6 +2685,11 @@ class EluvioLive {
   async TenantMint({ tenant, marketplace, sku, addr, quantity = 1 }) {
     let now = Date.now();
 
+    /* body can optionally include:
+     * - ident: ""
+     * - email: ""
+     * - cust_name: ""
+     */
     let body = {
       trans_id: "",
       tickets: null,
@@ -2695,9 +2700,6 @@ class EluvioLive {
           quant: quantity,
         },
       ],
-      ident: "minter@tenant.com",
-      email: "minter@tenant.com",
-      cust_name: "minter@tenant.com",
       ts: now,
       extra: {
         elv_addr: addr,


### PR DESCRIPTION
also: Remove unnecessary tenant mint arguments - email, ident, cust_name