### PR TITLE
redirect elv-live usage to stdout

### DIFF
--- a/elv-live
+++ b/elv-live
@@ -2,4 +2,4 @@
 
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-node $SOURCE_DIR/utilities/EluvioLiveCli.js $* 
+node $SOURCE_DIR/utilities/EluvioLiveCli.js $* 2>&1

--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -3190,7 +3190,7 @@ class EluvioLive {
   async NftPackSetDist({versionHash}) {
 
     let objectId = this.client.utils.DecodeVersionHash(versionHash).objectId;
-    let libraryId = await this.client.ContentObjectLibraryId({objectId})
+    let libraryId = await this.client.ContentObjectLibraryId({objectId});
 
     const df = "pack_dist." + versionHash + ".json";
     let distBuf = fs.readFileSync(df);

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -2196,12 +2196,12 @@ yargs(hideBin(process.argv))
           describe: "Tenant ID",
           type: "string",
         })
-        .option("csv", {
-          describe: "File path to output csv",
-          type: "string",
-        })
         .positional("owner", {
           describe: "Owner address (hex)",
+          type: "string",
+        })
+        .option("csv", {
+          describe: "File path to output csv",
           type: "string",
         });
     },

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -414,7 +414,7 @@ const CmdTenantBalanceOf = async ({ argv }) => {
 
     if (argv.csv && argv.csv != "") {
       console.log(`CSV: ${argv.csv}`);
-      let out = "contract,name,token,hold\n";
+      let out = "contract,token,hold,name\n";
       let json = res.nfts
       let contracts = Object.keys(json)
       for (let i = 0; i < contracts.length; i++) {
@@ -422,7 +422,7 @@ const CmdTenantBalanceOf = async ({ argv }) => {
         let nft = json[contract]
         for (let j = 0; j < nft.tokens.length; j++) {
             let token = nft.tokens[j]
-            out += `${contract},${nft.name},${token.tokenId},${token.hold}\n`
+            out += `${contract},${token.tokenId},${token.hold},${nft.name}\n`
         }
       }
       fs.writeFileSync(argv.csv, out);

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -415,14 +415,14 @@ const CmdTenantBalanceOf = async ({ argv }) => {
     if (argv.csv && argv.csv != "") {
       console.log(`CSV: ${argv.csv}`);
       let out = "contract,token,hold,name\n";
-      let json = res.nfts
-      let contracts = Object.keys(json)
+      let json = res.nfts;
+      let contracts = Object.keys(json);
       for (let i = 0; i < contracts.length; i++) {
-        let contract = contracts[i]
-        let nft = json[contract]
+        let contract = contracts[i];
+        let nft = json[contract];
         for (let j = 0; j < nft.tokens.length; j++) {
-            let token = nft.tokens[j]
-            out += `${contract},${token.tokenId},${token.hold},${nft.name}\n`
+            let token = nft.tokens[j];
+            out += `${contract},${token.tokenId},${token.hold},${nft.name}\n`;
         }
       }
       fs.writeFileSync(argv.csv, out);

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -425,7 +425,6 @@ const CmdTenantBalanceOf = async ({ argv }) => {
             out += `${contract},${nft.name},${token.tokenId},${token.hold}\n`
         }
       }
-      console.log(out)
       fs.writeFileSync(argv.csv, out);
     } else {
       console.log(yaml.dump(res));

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -2196,6 +2196,10 @@ yargs(hideBin(process.argv))
           describe: "Tenant ID",
           type: "string",
         })
+        .option("csv", {
+          describe: "File path to output csv",
+          type: "string",
+        })
         .positional("owner", {
           describe: "Owner address (hex)",
           type: "string",

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -412,7 +412,25 @@ const CmdTenantBalanceOf = async ({ argv }) => {
       maxNumber: argv.max_results,
     });
 
-    console.log(yaml.dump(res));
+    if (argv.csv && argv.csv != "") {
+      console.log(`CSV: ${argv.csv}`);
+      let out = "contract,name,token,hold\n";
+      let json = res.nfts
+      let contracts = Object.keys(json)
+      for (let i = 0; i < contracts.length; i++) {
+        let contract = contracts[i]
+        let nft = json[contract]
+        for (let j = 0; j < nft.tokens.length; j++) {
+            let token = nft.tokens[j]
+            out += `${contract},${nft.name},${token.tokenId},${token.hold}\n`
+        }
+      }
+      console.log(out)
+      fs.writeFileSync(argv.csv, out);
+    } else {
+      console.log(yaml.dump(res));
+    }
+
   } catch (e) {
     console.error("ERROR:", e);
   }


### PR DESCRIPTION
if its ok w/ everyone, let's redirect elv-live usage msgs to stdout not stderr. i think this is the only thing using stderr, our actual errors go to stdout already.

usage is too hard to grep otherwise.

(and throw in a csv handler for tenant_balance_of for easier parsing)