### PR TITLE
Add NFT token URI update by hash

### DIFF
--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -107,7 +107,7 @@ class EluvioLive {
     body.request_type = requestType;
     body.contract_address = contractAddress;
     body.tokens = [];
-  
+
     switch (requestType) {
       case "batch":
         if (!csv) {
@@ -157,8 +157,8 @@ class EluvioLive {
 
     let res = await this.PostServiceRequest({
       path: urljoin("/tnt/nft/stu", tenantId),  // /tnt/nft/stu/:tid/
-      body, 
-      host 
+      body,
+      host
     });
 
     let tenantConfigResult = await res.json();
@@ -168,6 +168,97 @@ class EluvioLive {
     return tenantConfigResult;
 
   }
+
+  /**
+   * Update all token URIs for a given contract to the new hash provided as argument.
+   *
+   * @namedParams
+   * @param {string} tenantId - Tenant ID (iten format)
+   * @param {string} contractAddress - The NFT contract address
+   * @param {string} hash - The new NFT template object hash
+   * @param {bool} dryRun - Dry run flag (default 'true')
+   * @return {Promise<Object>} - An object containing operation result
+   */
+  async TenantUpdateTokenURI({ tenantId, contractAddress, hash, dryRun = true }) {
+    const abi = fs.readFileSync(
+      path.resolve(__dirname, "../contracts/v3/ElvTradableLocal.abi")
+    );
+
+    let nftInfo = {
+      tokens: [],
+      warns: []
+    };
+
+    let body = {
+      request_type: "batch",
+      contract_address:contractAddress,
+      tokens: []
+    };
+
+    try {
+      const totalSupply = await this.client.CallContractMethod({
+        contractAddress,
+        abi: JSON.parse(abi),
+        methodName: "totalSupply",
+        formatArguments: true,
+      });
+      nftInfo.totalSupply = Number(totalSupply);
+      } catch (e) {
+        console.log("Failed to retrieve supply", e);
+        return;
+    }
+
+    // Retrieve the list of owners
+    for (var i = 0; i < nftInfo.totalSupply; i ++) {
+      nftInfo.tokens[i] = {};
+      try {
+        let tokenId = await this.client.CallContractMethod({
+          contractAddress,
+          abi: JSON.parse(abi),
+          methodName: "tokenByIndex",
+          methodArgs: [i],
+          formatArguments: true,
+        });
+        nftInfo.tokens[i].tokenId = tokenId.toString();
+
+        nftInfo.tokens[i].tokenUri = await this.client.CallContractMethod({
+          contractAddress,
+          abi: JSON.parse(abi),
+          methodName: "tokenURI",
+          methodArgs: [tokenId],
+          formatArguments: true,
+        });
+
+        nftInfo.tokens[i].newTokenUri = await ElvUtils.UpdateFabricUrl({url: nftInfo.tokens[i].tokenUri, newHash: hash});
+
+        body.tokens.push({
+          "token_id": Number(tokenId),
+          "token_id_str": tokenId.toString(),
+          "token_uri": nftInfo.tokens[i].newTokenUri
+        });
+
+      } catch (e) {
+        console.log("Failed to get token ID/URI (index: " + i + "): " + contractAddress, e);
+        continue;
+      }
+    }
+
+    if (dryRun == true) {
+      console.log("DRY RUN - RETURNING REQUEST ODY");
+      return body;
+    }
+
+    console.log("REQUEST BODY", body);
+    let res = await this.PostServiceRequest({
+      path: urljoin("/tnt/nft/stu", tenantId),  // /tnt/nft/stu/:tid/
+      body
+    });
+
+    let tenantConfigResult = await res.json();
+
+    return tenantConfigResult;
+  }
+
 
   /**
    * Show info about this tenant.

--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -203,9 +203,9 @@ class EluvioLive {
         formatArguments: true,
       });
       nftInfo.totalSupply = Number(totalSupply);
-      } catch (e) {
-        console.log("Failed to retrieve supply", e);
-        return;
+    } catch (e) {
+      console.log("Failed to retrieve supply", e);
+      return;
     }
 
     // Retrieve the list of owners
@@ -243,8 +243,8 @@ class EluvioLive {
       }
     }
 
-    if (dryRun == true) {
-      console.log("DRY RUN - RETURNING REQUEST ODY");
+    if (dryRun) {
+      console.log("DRY RUN - RETURNING REQUEST BODY");
       return body;
     }
 

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -170,8 +170,8 @@ class ElvUtils {
     // Find pattern '/q/hq__...'
     let s = p.split("/");
     for (var i = 0; i < s.length; i ++) {
-      if (s[i] == 'q') {
-        if (s[i+1].startsWith('hq__')) {
+      if (s[i] == "q") {
+        if (s[i+1].startsWith("hq__")) {
           s[i+1] = newHash;
           break;
         }

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -156,6 +156,31 @@ class ElvUtils {
     return false;
   }
 
+  /**
+   * Parse a fabric URL of format 'http(s)://host/.../q/hq__.../...' and replace the object hash
+   * with the newly provided one.
+   *
+   * @param {string} url
+   * @param {string} newHash Format 'hq__...'
+   */
+  static async UpdateFabricUrl({url, newHash}) {
+    let u = new URL(url);
+    let p = u.pathname;
+
+    // Find pattern '/q/hq__...'
+    let s = p.split("/");
+    for (var i = 0; i < s.length; i ++) {
+      if (s[i] == 'q') {
+        if (s[i+1].startsWith('hq__')) {
+          s[i+1] = newHash;
+          break;
+        }
+      }
+    }
+    u.pathname = s.join("/");
+    return u.href;
+  }
+
 }
 
 

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -2261,7 +2261,7 @@ yargs(hideBin(process.argv))
         .option("dry_run", {
           describe:
             "Default 'true'",
-          type: "bool",
+          type: "boolean",
         })
     },
     (argv) => {

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -378,6 +378,28 @@ const CmdTenantSetTokenURI = async ({ argv }) => {
   }
 };
 
+const CmdTenantUpdateTokenURI = async ({ argv }) => {
+  console.log("Contract address", argv.addr);
+  console.log("Hash", argv.hash);
+  console.log("Dry run", argv.dry_run);
+
+  try {
+    await Init({debugLogging: argv.verbose, asUrl: argv.as_url});
+
+    let res = await elvlv.TenantUpdateTokenURI({
+      tenantId: argv.tenant,
+      contractAddress: argv.addr,
+      hash: argv.hash,
+      dryRun: argv.dry_run
+    });
+
+    console.log(res);
+
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
 
 const CmdSiteShow = async ({ argv }) => {
   console.log("Site - show", argv.object);
@@ -2219,6 +2241,33 @@ yargs(hideBin(process.argv))
     }
   )
 
+  .command(
+    "tenant_update_token_uri <tenant> <addr> <hash> [options]",
+    "Reset the token URI(s) for tenant NFT contract(s)",
+    (yargs) => {
+      yargs
+        .positional("tenant", {
+          describe: "Tenant ID",
+          type: "string",
+        })
+        .positional("addr", {
+          describe: "NFT contract address",
+          type: "string",
+        })
+        .positional("hash", {
+          describe: 'New NFT template object hash',
+          type: "string",
+        })
+        .option("dry_run", {
+          describe:
+            "Default 'true'",
+          type: "bool",
+        })
+    },
+    (argv) => {
+      CmdTenantUpdateTokenURI({ argv });
+    }
+  )
 
   .command(
     "tenant_balance_of <tenant> <owner>",


### PR DESCRIPTION
New command to simplify updating generative NFTs (where each token may have a different URI).
The new command just takes a new hash (`hq__`) and retrieves all the current token URIs, updates just the hash, and sets them back.

By default it runs in `dry_run` mode and just prints out the new hashes that it would set.  So you must specify `--dry_run false` to get it to set the URIs.

Usage:

```bash
./elv-live tenant_update_token_uri
 tenant_update_token_uri <tenant> <addr> <hash> [options]

Reset the token URI(s) for tenant NFT contract(s)

Positionals:
  tenant  Tenant ID                                          [string] [required]
  addr    NFT contract address                               [string] [required]
  hash    New NFT template object hash                       [string] [required]

Options:
      --version  Show version number                                   [boolean]
  -v, --verbose  Verbose mode                                          [boolean]
      --as_url   Alternate authority service URL (include '/as/' route if
                 necessary)                                             [string]
      --help     Show help                                             [boolean]
      --dry_run  Default 'true'                                        [boolean]
```

Example:

```bash
./elv-live tenant_update_token_uri iten4TXq2en3qtu3JREnE5tSLRf9zLod  0xb914ad493a0a4fe5a899dc21b66a509bcf8f1ed9 hq__LUSGZREUAjYHRqz8mDxFDBX94M4UyyCTKx732gt82KdnauuSx5TadVXu3zDAmARQeCuMtDxLWr
```