### PR TITLE
Remove inserting rarity calculations for nftMakeGenerative

### DIFF
--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -2214,9 +2214,10 @@ class EluvioLive {
    * @param {string} hash - NFT Template hash
    * @param {string} imagePath - Local file path to the image
    * @param {Object} attrs - Extra attributes for this token
+   * @param {Object} rarity - Stats for each trait and value
    * @return {Promise<Object>} - The public/nfts JSON array element
    */
-  async NftMakeGenerative({ assetMetadata, hash, nftMeta}) {
+  async NftMakeGenerative({ assetMetadata, hash, nftMeta, rarity, insertRarity = false }) {
     const m = assetMetadata;
     var pnft = {};
 
@@ -2265,6 +2266,19 @@ class EluvioLive {
       },
     ];
 
+    if (insertRarity) {
+      // Insert rarity if doesn't exist
+      for (const i in nftMeta.attributes) {
+        if (nftMeta.attributes[i].rarity !== undefined){
+          continue;
+        }
+        if (rarity && rarity[nftMeta.attributes[i].trait_type]) {
+          let r = rarity[nftMeta.attributes[i].trait_type];
+          nftMeta.attributes[i].rarity =
+            r[nftMeta.attributes[i].value] + "/" + total_supply;
+        }
+      }
+    }
     pnft.attributes = pnft.attributes.concat(nftMeta.attributes);
 
     return pnft;
@@ -2332,12 +2346,13 @@ class EluvioLive {
       // Generative NFT - build an nft array
 
       // Read image and attributes info from directory
-      let { nftMetas } = await this.readNftDir({ nftDir });
+      let { nftMetas, rarity } = await this.readNftDir({ nftDir });
       for (const nftMeta of nftMetas) {
         pnft = await this.NftMakeGenerative({
           assetMetadata: m,
           hash,
-          nftMeta
+          nftMeta,
+          rarity,
         });
         pnfts.push(pnft);
       }

--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -2214,10 +2214,9 @@ class EluvioLive {
    * @param {string} hash - NFT Template hash
    * @param {string} imagePath - Local file path to the image
    * @param {Object} attrs - Extra attributes for this token
-   * @param {Object} rarity - Stats for each trait and value
    * @return {Promise<Object>} - The public/nfts JSON array element
    */
-  async NftMakeGenerative({ assetMetadata, hash, nftMeta, rarity }) {
+  async NftMakeGenerative({ assetMetadata, hash, nftMeta}) {
     const m = assetMetadata;
     var pnft = {};
 
@@ -2266,17 +2265,6 @@ class EluvioLive {
       },
     ];
 
-    // Insert rarity if doesn't exist
-    for (const i in nftMeta.attributes) {
-      if (nftMeta.attributes[i].rarity !== undefined){
-        continue;
-      }
-      if (rarity && rarity[nftMeta.attributes[i].trait_type]) {
-        let r = rarity[nftMeta.attributes[i].trait_type];
-        nftMeta.attributes[i].rarity =
-          r[nftMeta.attributes[i].value] + "/" + total_supply;
-      }
-    }
     pnft.attributes = pnft.attributes.concat(nftMeta.attributes);
 
     return pnft;
@@ -2344,13 +2332,12 @@ class EluvioLive {
       // Generative NFT - build an nft array
 
       // Read image and attributes info from directory
-      let { nftMetas, rarity } = await this.readNftDir({ nftDir });
+      let { nftMetas } = await this.readNftDir({ nftDir });
       for (const nftMeta of nftMetas) {
         pnft = await this.NftMakeGenerative({
           assetMetadata: m,
           hash,
-          nftMeta,
-          rarity,
+          nftMeta
         });
         pnfts.push(pnft);
       }


### PR DESCRIPTION
Implement Sam's request to remove rarity calculations and use the provided attributes from the json files as is.
ie. Attributes without a "rarity" will be merged as is.

