### PR TITLE
speed up --show_owners via authd api

### DIFF
--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -1361,7 +1361,6 @@ class EluvioLive {
           queryParams: { limit: maxShowOwners },
         });
         res = await res.json();
-        console.log("res", res);
 
         nftInfo.tokens = res.contents;
       } catch (e) {

--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -1197,7 +1197,7 @@ class EluvioLive {
    * @param {string} minter - Warn if this is not the owner of the mint helper contract (hex)
    * @param {string} proxyAddr - proxy owner address
    * @param {integer} showOwners - Enumerate all token owners using a fast indexed query. Only used if tokenId is undefined.
-   * @param {integer} showOwnersViaContract - Enumerate all token info up to showOwners amount. Only used if tokenId is undefined.
+   * @param {integer} showOwnersViaContract - Enumerate all token info up to the given amount. Only used if tokenId is undefined.
    * @param {integer} tokenId - The token ID to show info for. This will take precedence over showOwners
    * @return {Promise<Object>} - An object containing NFT info, including 'warnings'
    */

--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -44,7 +44,6 @@ class EluvioLive {
     });
 
     if (asUrl) {
-      console.log("Setting AS URL to", asUrl);
       // elv-client-js strips the path and only stores the host - save it here
       this.asUrlPath = url.parse(asUrl).path;
       this.client.SetNodes({
@@ -53,7 +52,6 @@ class EluvioLive {
         ]
       });
     } else {
-      console.log("Using default AS URL");
       this.asUrlPath = "as";
     }
 

--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -1362,7 +1362,7 @@ class EluvioLive {
 
         nftInfo.tokens = res.contents;
       } catch (e) {
-        warns.push("Failed to get token owners: " + addr);
+        warns.push("Failed to get token owners: " + addr + " - " + e);
       }
 
       for (var i = 0; i < maxShowOwners && i < nftInfo.totalSupply; i++) {

--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -44,6 +44,7 @@ class EluvioLive {
     });
 
     if (asUrl) {
+      console.log("Setting AS URL to", asUrl);
       // elv-client-js strips the path and only stores the host - save it here
       this.asUrlPath = url.parse(asUrl).path;
       this.client.SetNodes({
@@ -52,6 +53,7 @@ class EluvioLive {
         ]
       });
     } else {
+      console.log("Using default AS URL");
       this.asUrlPath = "as";
     }
 
@@ -107,7 +109,7 @@ class EluvioLive {
     body.request_type = requestType;
     body.contract_address = contractAddress;
     body.tokens = [];
-  
+
     switch (requestType) {
       case "batch":
         if (!csv) {
@@ -157,8 +159,8 @@ class EluvioLive {
 
     let res = await this.PostServiceRequest({
       path: urljoin("/tnt/nft/stu", tenantId),  // /tnt/nft/stu/:tid/
-      body, 
-      host 
+      body,
+      host
     });
 
     let tenantConfigResult = await res.json();
@@ -1196,11 +1198,12 @@ class EluvioLive {
    * @param {string} mintHelper - Warn if this is not a minter for the NFT contract (hex)
    * @param {string} minter - Warn if this is not the owner of the mint helper contract (hex)
    * @param {string} proxyAddr - proxy owner address
-   * @param {integer} showOwners - Also enumerate all token info up to showOwners amount. Only used if tokenId is undefined.
+   * @param {integer} showOwners - Enumerate all token owners using a fast indexed query. Only used if tokenId is undefined.
+   * @param {integer} showOwnersViaContract - Enumerate all token info up to showOwners amount. Only used if tokenId is undefined.
    * @param {integer} tokenId - The token ID to show info for. This will take precedence over showOwners
    * @return {Promise<Object>} - An object containing NFT info, including 'warnings'
    */
-  async NftShow({ addr, mintHelper, minterAddr, proxyAddr, showOwners, tokenId }) {
+  async NftShow({ addr, mintHelper, minterAddr, proxyAddr, showOwners, showOwnersViaContract, tokenId }) {
     const abi = fs.readFileSync(
       path.resolve(__dirname, "../contracts/v3/ElvTradableLocal.abi")
     );
@@ -1347,9 +1350,64 @@ class EluvioLive {
       }
 
     } else if (showOwners && showOwners > 0) {
-      var maxShowOwners = showOwners;
+      // prefer this fast one to the contract code, let for reference below
+      const maxShowOwners = showOwners;
+      nftInfo.tokens = [];
+
+      try {
+        const url = urljoin("/nft/owners/", addr);
+        let res = await this.GetServiceRequest({
+          path: url,
+          queryParams: { limit: maxShowOwners },
+        });
+        res = await res.json();
+        console.log("res", res);
+
+        nftInfo.tokens = res.contents;
+      } catch (e) {
+        warns.push("Failed to get token owners: " + addr);
+      }
 
       for (var i = 0; i < maxShowOwners && i < nftInfo.totalSupply; i++) {
+        try {
+          // adapt to format:
+          // hold -> holdSecs
+          nftInfo.tokens[i].holdSecs = nftInfo.tokens[i].hold;
+          // add holdEnd
+          const timestamp = nftInfo.tokens[i].hold;
+          nftInfo.tokens[i].holdEnd = new Date(timestamp * 1000);
+          // token_id -> tokenId
+          nftInfo.tokens[i].tokenId = "" + nftInfo.tokens[i].token_id;
+          // token_uri -> tokenURI
+          nftInfo.tokens[i].tokenURI = nftInfo.tokens[i].token_uri;
+          // token_owner -> owner
+          nftInfo.tokens[i].owner = nftInfo.tokens[i].token_owner;
+          // ordinal int -> string
+          nftInfo.tokens[i].ordinal = "" + nftInfo.tokens[i].ordinal;
+
+          delete nftInfo.tokens[i].block;
+          delete nftInfo.tokens[i].created;
+          delete nftInfo.tokens[i].contract_name;
+          delete nftInfo.tokens[i].contract_addr;
+          delete nftInfo.tokens[i].hold;
+          delete nftInfo.tokens[i].token_id;
+          delete nftInfo.tokens[i].token_id_str;
+          delete nftInfo.tokens[i].token_owner;
+          delete nftInfo.tokens[i].token_uri;
+        } catch (e) {
+          warns.push("Failed to re-process token ID (index: " + i + "): " + addr);
+          continue;
+        }
+
+        if (i == 0) {
+          nftInfo.firstTokenUri = nftInfo.tokens[i].tokenURI;
+        }
+      }
+
+    } else if (showOwnersViaContract && showOwnersViaContract > 0) {
+      var maxShowOwners = showOwnersViaContract;
+
+      for (i = 0; i < maxShowOwners && i < nftInfo.totalSupply; i++) {
         nftInfo.tokens[i] = {};
 
         try {
@@ -1805,7 +1863,7 @@ class EluvioLive {
     let account = new ElvAccount({configUrl:this.configUrl, debugLogging: this.debug});
     account.InitWithClient({elvClient: this.client});
     var policyFormat = await ElvUtils.parseAndSignPolicy({policyString, data, configUrl:this.configUrl, elvAccount:account});
-    
+
     if (this.debug){
       console.log("Policy format: ", policyFormat);
     }

--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -1350,7 +1350,7 @@ class EluvioLive {
       }
 
     } else if (showOwners && showOwners > 0) {
-      // prefer this fast one to the contract code, let for reference below
+      // prefer this fast one to the contract code, which is left for reference below
       const maxShowOwners = showOwners;
       nftInfo.tokens = [];
 

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -41,7 +41,7 @@ const Init = async ({debugLogging = false, asUrl}={}) => {
   await elvlv.Init({ debugLogging, asUrl });
 
   marketplace = new Marketplace(config);
-  await marketplace.Init({ debugLogging });
+  await marketplace.Init({ debugLogging, asUrl });
 };
 
 const CmdTenantAuthToken = async ({ argv }) => {
@@ -201,6 +201,7 @@ const CmdNftShow = async ({ argv }) => {
   console.log("addr ", argv.addr);
   console.log("check_minter ", argv.check_minter);
   console.log("show_owners ", argv.show_owners);
+  console.log("show_owners_via_contract ", argv.show_owners_via_contract);
   console.log("token_id ", argv.token_id);
   try {
     await Init({ debugLogging: argv.verbose, asUrl: argv.as_url });
@@ -209,6 +210,7 @@ const CmdNftShow = async ({ argv }) => {
       addr: argv.addr,
       mintHelper: argv.check_minter,
       showOwners: argv.show_owners,
+      showOwnersViaContract: argv.show_owners_via_contract,
       tokenId: argv.token_id
     });
 
@@ -1834,7 +1836,11 @@ yargs(hideBin(process.argv))
           describe: "Check that all NFTs use this mint helper",
         })
         .option("show_owners", {
-          describe: "Show up to these many owners (default 0). Only used when token_id is not specified.",
+          describe: "Show up to these many owners (default 0), loaded from an index. Only used when token_id is not specified.",
+          type: "integer",
+        })
+        .option("show_owners_via_contract", {
+          describe: "Show up to these many owners (default 0), parsed directly from the contract. Only used when token_id is not specified.",
           type: "integer",
         })
         .option("token_id", {


### PR DESCRIPTION
fixes https://github.com/eluv-io/elv-live-js/issues/136

sample output:
```
$ ./elv-live nft_show 0x4b2e8e711fb223096c3c16d0a9e3d7b835fb5aaa --show_owners 2
NFT - show
addr  0x4b2e8e711fb223096c3c16d0a9e3d7b835fb5aaa
check_minter  undefined
show_owners  2
show_owners_via_contract  undefined
token_id  undefined
Network: demov3
name: GOAT-NFT-TEST-URI
owner: '0x761f45287Ea364DB6b216bd655910430afA3e839'
symbol: GOAT-NFT-TEST-URI
totalSupply: 32
transferFee: 0
minted: 44
cap: 100
proxy: '0xFd612AF562108610e456c51B2c40a1053e8aed33'
proxyInfo:
  owner: '0x25D7D6e2Dc74FD56A4eacfd842B68eCF73B91f9D'
defHoldSecs: '604800'
tokens:
  - ordinal: '43'
    holdSecs: 1691525593
    holdEnd: 2023-08-08T20:13:13.000Z
    tokenId: '44'
    tokenURI: >-
      https://demov3.net955210.contentfabric.io/s/demov3/q/hq__AqmrLPerNTtkQ62jGYSJyhoNEkvQWGCp6MxTsDstoQzGp4eqjvmfLUE1kKLaXoK5uFbfFHsUoH/meta/public/nft
    owner: '0xb516b92fe8f422555f0d04ef139c6a68fe57af08'
  - ordinal: '42'
    holdSecs: 1691525354
    holdEnd: 2023-08-08T20:09:14.000Z
    tokenId: '43'
    tokenURI: >-
      https://demov3.net955210.contentfabric.io/s/demov3/q/hq__AqmrLPerNTtkQ62jGYSJyhoNEkvQWGCp6MxTsDstoQzGp4eqjvmfLUE1kKLaXoK5uFbfFHsUoH/meta/public/nft
    owner: '0xb516b92fe8f422555f0d04ef139c6a68fe57af08'
firstTokenUri: >-
  https://demov3.net955210.contentfabric.io/s/demov3/q/hq__AqmrLPerNTtkQ62jGYSJyhoNEkvQWGCp6MxTsDstoQzGp4eqjvmfLUE1kKLaXoK5uFbfFHsUoH/meta/public/nft
warns: []
```



new usage:
```
 nft_show <addr> [options]

Show info on this NFT

Positionals:
  addr  NFT address (hex)                                    [string] [required]

Options:
      --version                   Show version number                  [boolean]
  -v, --verbose                   Verbose mode                         [boolean]
      --as_url                    Alternate authority service URL (include
                                  '/as/' route if necessary)            [string]
      --help                      Show help                            [boolean]
      --check_minter              Check that all NFTs use this mint helper
      --show_owners               Show up to these many owners (default 0),
                                  loaded from an index. Only used when token_id
                                  is not specified.
      --show_owners_via_contract  Show up to these many owners (default 0),
                                  parsed directly from the contract. Only used
                                  when token_id is not specified.
      --token_id                  External token ID. This will take precedence
                                  over show_owners.                     [string]
```
