### PR TITLE
Print stream urls when calling status

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,7 @@
   },
   "extends": ["eslint:recommended", "prettier"],
   "parserOptions": {
-    "ecmaVersion": 2018
+    "ecmaVersion": 2020
   },
   "settings": {
     "html/html-extensions": [".tmpl"],

--- a/src/LiveStream.js
+++ b/src/LiveStream.js
@@ -905,6 +905,67 @@ class EluvioLiveStream {
     return info;
   }
 
+  /*
+   * Get hls related playout and embed urls for a given stream. 
+   */
+  async MonitorStream({name}) {
+    let playout_urls = {};
+    try {
+      let conf = await this.LoadConf({name});
+      let libraryId = await this.client.ContentObjectLibraryId({objectId: conf.objectId});
+      let mainMeta = await this.client.ContentObjectMetadata({
+        libraryId: libraryId,
+        objectId: conf.objectId
+      });
+
+      let master_hash = mainMeta.master.hash;
+      let objectId = conf.objectId;
+      let playout_options = await this.client.PlayoutOptions({
+        objectId,
+        master_hash,
+        linkPath: "public/asset_metadata/sources/default"
+      });
+
+      let hls_clear_enabled = playout_options?.hls?.playoutMethods?.clear != undefined; 
+      if (hls_clear_enabled) {
+        playout_urls.hls_clear = await this.client.FabricUrl({
+          libraryId: libraryId,
+          objectId: objectId,
+          rep: "playout/default/hls-clear/playlist.m3u8",
+        });
+      }
+
+      let hls_aes128_enabled = playout_options?.hls?.playoutMethods?.["aes-128"] != undefined; 
+      if (hls_aes128_enabled) {
+        playout_urls.hls_aes128 = await this.client.FabricUrl({
+          libraryId: libraryId,
+          objectId: objectId,
+          rep: "playout/default/hls-aes128/playlist.m3u8",
+        });
+      }
+
+      let hls_sample_aes_enabled = playout_options?.hls?.playoutMethods?.["sample-aes"] != undefined; 
+      if (hls_sample_aes_enabled) {
+        playout_urls.hls_sample_aes = await this.client.FabricUrl({
+          libraryId: libraryId,
+          objectId: objectId,
+          rep: "playout/default/hls-sample-aes/playlist.m3u8",
+        });
+      }
+
+      let token = await MakeTxLessToken({client: this.client, libraryId: libraryId});
+      let embed_net = "main";
+      if (this.configUrl.includes("demo")) {
+        embed_net = "demo";
+      }
+      let embed_url = `https://embed.v3.contentfabric.io/?net=${embed_net}&p&ct=h&oid=${conf.objectId}&mt=v&ath=${token}`;
+      playout_urls.embed_url = embed_url;
+    } catch (error) {
+      console.error(error);
+    }
+    return playout_urls;
+  }
+
 } // End class
 
 function sleep(ms) {

--- a/utilities/EluvioLiveStreamCli.js
+++ b/utilities/EluvioLiveStreamCli.js
@@ -96,29 +96,6 @@ const CmdStreamStatus = async ({ argv }) => {
   }
 };
 
-const CmdStreamMonitor = async ({ argv }) => {
-  try {
-    let elvStream = new EluvioLiveStream({
-      configUrl: Config.networks[Config.net],
-      debugLogging: argv.verbose
-    });
-
-    await elvStream.Init({
-      privateKey: process.env.PRIVATE_KEY,
-    });
-
-    let status = await elvStream.Status({name: argv.stream, stopLro: false, showParams: argv.show_params});
-    if (status.state == "running") {
-      let playoutUrls = await elvStream.MonitorStream({name: argv.stream});
-      console.log(yaml.dump(playoutUrls));
-    } else {
-      console.log("Error: stream is not running.");
-    }
-  } catch (e) {
-    console.error("ERROR:", e);
-  }
-};
-
 // Executes stream start, stop or reset
 const CmdStreamOp = async ({ argv, op }) => {
   try {
@@ -293,26 +270,6 @@ yargs(hideBin(process.argv))
     },
     (argv) => {
       CmdStreamStatus({ argv });
-    }
-  )
-  .command(
-    "monitor <stream>",
-    "monitor a running stream by fetching playout urls. This returns hls and embed urls.",
-    (yargs) => {
-      yargs
-        .positional("stream", {
-          describe:
-            "Stream name or QID (content ID)",
-          type: "string",
-        })
-        .option("show_params", {
-          describe:
-            "Show recording parameters (can be large)",
-          type: "bool",
-        })
-    },
-    (argv) => {
-      CmdStreamMonitor({ argv });
     }
   )
   .command(


### PR DESCRIPTION
When calling status I added logic to print out the streams embed url along with urls for enabled formats (hls-clear, aes, etc...)

These urls will ONLY print out when the status is running otherwise the logic to print these out is ignored. I tested this with streams with each status, udp source, rtmp source, public, non public streams.

I also had to upgrade the eslint ecmaVersion version to 2020 to support the js optional chaining feature, without this the git precommit hooks fail. 
 
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining



Here is an example
```
❯ ./elv-stream status  iq__4DiAL37UXWN3xwdVYfVzQs5UPm47
name: iq__4DiAL37UXWN3xwdVYfVzQs5UPm47
library_id: ilib3MUNGcWxTNmK2WCJ5HYCvpxdSfFE
object_id: iq__4DiAL37UXWN3xwdVYfVzQs5UPm47
fabric_api: 'https://host-76-74-91-16.contentfabric.io'
url: 'udp://76.74.91.16:11001'
edge_write_token: >-
  tqw__HSZAyL4aNZsw6cy6g2u87EtrSSTZjyeNYJqjVXqov1MNz12BfSDfCd1j1QTUEVcwxPASaibM6DjfyEx86mb
stream_id: >-
  tqw__HSZAyL4aNZsw6cy6g2u87EtrSSTZjyeNYJqjVXqov1MNz12BfSDfCd1j1QTUEVcwxPASaibM6DjfyEx86mb
recording_period_sequence: 1
tlro: tlro1EjcGsTdAVrCWQpSfYxbfmBPDowC6bRK4VsjtcUsBTpbGQ8yLQxkMh
recording_period:
  activation_time_epoch_sec: 1692741973
  start_time_epoch_sec: 1692741974
  start_time_text: '8/22/2023, 3:06:14 PM'
  end_time_epoch_sec: 0
  end_time_text: null
  video_parts: 1
  video_last_part_finalized_epoch_sec: 1692742004.799112
  video_since_last_finalize_sec: 13.20088791847229
lro_status_url: >-
  https://host-76-74-91-16.contentfabric.io/qlibs/ilib3MUNGcWxTNmK2WCJ5HYCvpxdSfFE/q/tqw__HSZAyL4aNZsw6cy6g2u87EtrSSTZjyeNYJqjVXqov1MNz12BfSDfCd1j1QTUEVcwxPASaibM6DjfyEx86mb/call/live/status/tlro1EjcGsTdAVrCWQpSfYxbfmBPDowC6bRK4VsjtcUsBTpbGQ8yLQxkMh?authorization=eyJxc3BhY2VfaWQiOiJpc3BjM0FOb1ZTek5BM1A2dDdhYkxSNjlobzVZUFBaVSIsImFkZHIiOiIweGU3MDVlNWI5MWQ1NWM2MDQ0MzllY2UzYTYyM2JlODU5MWVlZTgwMDEiLCJxbGliX2lkIjoiaWxpYjNNVU5HY1d4VE5tSzJXQ0o1SFlDdnB4ZFNmRkUifQ%3D%3D.RVMyNTZLXzRSZ2dFUWFyaFVHOFhVV0M1VkJwTlRMTENycTZ1aGlpZ2VVOGJ1bmplUzFUYVZFcU1GWlJKYUZwQ1ZlSjZVOGdKM1hMWEVETFRMa1JnUGRzeG9ETUcyTFhD
insertions: []
state: running
playout_urls:
  hls_clear: >-
    https://host-76-74-91-16.contentfabric.io/qlibs/ilib3MUNGcWxTNmK2WCJ5HYCvpxdSfFE/q/hq__L756q3PTD5JSXPsQwokzM7VKf7jvyFs71ZP8PoJRUZvrxS1PsX6VGAzepwY8tf2fdcQR7ZAqvT/rep/playout/default/hls-clear/playlist.m3u8?authorization=eyJxc3BhY2VfaWQiOiJpc3BjM0FOb1ZTek5BM1A2dDdhYkxSNjlobzVZUFBaVSIsImFkZHIiOiIweGU3MDVlNWI5MWQ1NWM2MDQ0MzllY2UzYTYyM2JlODU5MWVlZTgwMDEiLCJxbGliX2lkIjoiaWxpYjNNVU5HY1d4VE5tSzJXQ0o1SFlDdnB4ZFNmRkUifQ%3D%3D.RVMyNTZLXzRSZ2dFUWFyaFVHOFhVV0M1VkJwTlRMTENycTZ1aGlpZ2VVOGJ1bmplUzFUYVZFcU1GWlJKYUZwQ1ZlSjZVOGdKM1hMWEVETFRMa1JnUGRzeG9ETUcyTFhD
  embed_url: >-
    https://embed.v3.contentfabric.io/?net=demo&p&ct=h&oid=iq__4DiAL37UXWN3xwdVYfVzQs5UPm47&mt=v&ath=eyJxc3BhY2VfaWQiOiJpc3BjM0FOb1ZTek5BM1A2dDdhYkxSNjlobzVZUFBaVSIsImFkZHIiOiIweGU3MDVlNWI5MWQ1NWM2MDQ0MzllY2UzYTYyM2JlODU5MWVlZTgwMDEiLCJxbGliX2lkIjoiaWxpYjNNVU5HY1d4VE5tSzJXQ0o1SFlDdnB4ZFNmRkUifQ==.RVMyNTZLXzRSZ2dFUWFyaFVHOFhVV0M1VkJwTlRMTENycTZ1aGlpZ2VVOGJ1bmplUzFUYVZFcU1GWlJKYUZwQ1ZlSjZVOGdKM1hMWEVETFRMa1JnUGRzeG9ETUcyTFhD
```