### PR TITLE
Add command to retrieve content space nodes

### DIFF
--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -1047,6 +1047,27 @@ const CmdClaimerBurnOf = async ({ argv }) => {
   }
 };
 
+const CmdNodes = async ({ argv }) => {
+  try {
+    let space = new ElvSpace({
+      configUrl: Config.networks[Config.net],
+      spaceAddress: Config.consts[Config.net].spaceAddress,
+      kmsAddress: Config.consts[Config.net].kmsAddress,
+      debugLogging: argv.verbose
+    });
+    await space.Init({ spaceOwnerKey: process.env.PRIVATE_KEY });
+
+    let res = await space.SpaceNodes({
+      matchEndpoint: argv.endpoint,
+      matchNodeId: argv.node_id
+    });
+
+    console.log(yaml.dump(res));
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
 yargs(hideBin(process.argv))
   .option("verbose", {
     describe: "Verbose mode",
@@ -1672,6 +1693,25 @@ yargs(hideBin(process.argv))
     },
     (argv) => {
       CmdClaimerBurnOf({ argv });
+    }
+  )
+
+  .command(
+    "nodes",
+    "Retrieve all nodes in the content space, with optional filters.",
+    (yargs) => {
+      yargs
+        .option("endpoint", {
+          describe: "Match nodes with endpoints that contain this string.",
+          type: "string",
+        })
+        .option("node_id", {
+          describe: "Only match the node with this node ID",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdNodes({ argv });
     }
   )
 


### PR DESCRIPTION
The primary driver for this function is the live stream configurator but I am making a separate PR since the functionality is independent and can be reviewed separately.

If run with no options, returns all nodes in the content space.
If run with `--node_id` or `--endpoint`, only returns the matching node(s).

Examples:

```
./elv-admin nodes --node_id inod3EFQaXzGAFz7ndDoeDxwYsxU2RQs

- id: inod3EFQaXzGAFz7ndDoeDxwYsxU2RQs
  endpoints:
    - 'http://192.168.90.216/'
```

```
./elv-admin nodes --endpoint 76-74-28

- id: inod2xdvZF9Jtt4sCFrxRHQAA9VDdDTh
  endpoints:
    - 'https://host-76-74-28-243.contentfabric.io/'
- id: inod3ixE9cx9S3An4KsdR45LE57pPe6D
  endpoints:
    - 'https://host-76-74-28-227.contentfabric.io/'
- id: inodKmtYm77dUuTSzbTTWAKUTDZhDLN
  endpoints:
    - 'https://host-76-74-28-235.contentfabric.io/'
- id: inod3P5oPk4azq8eYUiSh4JYKpRmMoQg
  endpoints:
    - 'https://host-76-74-28-233.contentfabric.io/'
- id: inod26sQ6ScYjxzd1BCc2zkQNv5i9BTJ
  endpoints:
    - 'https://host-76-74-28-234.contentfabric.io/'
```
