### PR TITLE
fixed sync_audio_to_stream id when configuring live streams

### DIFF
--- a/src/LiveConf.js
+++ b/src/LiveConf.js
@@ -114,8 +114,7 @@ class LiveConf {
     let videoStream = this.getStreamDataForCodecType("video");
     switch (this.probeKind()) {
       case "udp":
-        let video_id_hex = videoStream.stream_id;
-        sync_id = parseInt(video_id_hex, 16);
+        sync_id = videoStream.stream_id;
         break;
       case "rtmp":
         sync_id = -1; // Pending fabric API: videoStream.stream_index


### PR DESCRIPTION
Our probe API returns stream IDs in decimal, I removed the code that would convert these IDs from hex to decimal. With this small change sync_audio_to_stream_id is fixed when calling config
