### PR TITLE
handle inactive marketplaces

### DIFF
--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -3045,11 +3045,29 @@ class EluvioLive {
       toJson = false;
     }
 
-    let res = await this.GetServiceRequest({
-      path: urljoin("/tnt/purchases/", tenant, marketplace),
-      queryParams: { offset, processor },
-      headers,
-    });
+    let res;
+    try {
+      res = await this.GetServiceRequest({
+        path: urljoin("/tnt/purchases/", tenant, marketplace),
+        queryParams: { offset, processor },
+        headers,
+      });
+    } catch (e) {
+      console.error(e);
+      try {
+        // if unauthorized try again with inactive marketplace flag
+        if (e.status == 401) {
+          res = await this.GetServiceRequest({
+            path: urljoin("/tnt/purchases/", tenant, marketplace, "/inactive"),
+            queryParams: { offset, processor },
+            headers,
+          });
+        }
+      } catch (e) {
+        console.error(e);
+        throw e;
+      }
+    }
 
     return toJson ? await res.json() : await res.text();
   }

--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -3053,18 +3053,18 @@ class EluvioLive {
         headers,
       });
     } catch (e) {
-      console.error(e);
       try {
-        // if unauthorized try again with inactive marketplace flag
+        // if unauthorized try again as admin for inactive marketplaces
         if (e.status == 401) {
           res = await this.GetServiceRequest({
-            path: urljoin("/tnt/purchases/", tenant, marketplace, "/inactive"),
+            path: urljoin("/adm/purchases/", tenant, marketplace),
             queryParams: { offset, processor },
             headers,
           });
         }
-      } catch (e) {
-        console.error(e);
+      } catch (err2) {
+        console.log("Error: unauthorized or invalid tenant or marketplace");
+        // throw original error
         throw e;
       }
     }


### PR DESCRIPTION
add nested try catch to get 401 and send request as inactive 

this requires admin Auth for the second request to work

does not solve for tenant Auth on deleted/inactive marketplaces