### PR TITLE
validate URI for token_uri command for non-batch tenant_set_token_uri

### DIFF
--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -15,6 +15,7 @@ const yaml = require("js-yaml");
 const fs = require("fs");
 const path = require("path");
 const prompt = require("prompt-sync")({ sigint: true });
+const url = require('url');
 
 // hack that quiets this msg:
 //  node:87980) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
@@ -345,6 +346,16 @@ const CmdTenantShow = async ({ argv }) => {
   }
 };
 
+
+function isValidURI(uri) {
+  try {
+    const parsedUrl = new URL(uri);
+    return parsedUrl.protocol === 'https:'; 
+  } catch (error) {
+    return false; 
+  }
+}
+
 const CmdTenantSetTokenURI = async ({ argv }) => {
   console.log("request_type ", argv.request_type);
   console.log("tenantId ", argv.tenant);
@@ -357,7 +368,14 @@ const CmdTenantSetTokenURI = async ({ argv }) => {
     console.log("csv ", argv?.csv);
   }
 
+  
   try {
+    // Validate the token URI from the command line for single, all requests
+    if ((argv.request_type != "batch") && (!(isValidURI(argv.new_token_uri)))) {
+      console.log("Invalid token_uri: ", argv.new_token_uri);
+      return;
+    } 
+
     await Init({debugLogging: argv.verbose, asUrl: argv.as_url});
 
     let res = await elvlv.TenantSetTokenURI({


### PR DESCRIPTION

Does not validate csv file URIs yet.  

Will add to parsing csv.