### PR TITLE
add token transfer and balanceOf cmds

### DIFF
--- a/src/ElvToken.js
+++ b/src/ElvToken.js
@@ -1,6 +1,7 @@
 const { ElvClient } = require("@eluvio/elv-client-js");
 const fs = require("fs");
 const path = require("path");
+const Ethers = require("ethers");
 
 class ElvToken {
 
@@ -96,7 +97,51 @@ class ElvToken {
     };
   }
 
+  /**
+   * Transfer the token to the given address
+   *
+   * @namedParams
+   * @param {string} tokenAddr - Token address
+   * @param {string} toAddr - To address
+   * @param {integer} amount - Token amount
+   * @return {Promise<Object>} - Token Transfer Info JSON
+   */
+  async ElvTokenTransfer({ tokenAddr, toAddr, amount }) {
+    const abi = fs.readFileSync(
+      path.resolve(__dirname, "../contracts/v4/IERC20.abi")
+    );
 
+    return await this.client.CallContractMethodAndWait({
+      contractAddress: tokenAddr,
+      abi: JSON.parse(abi),
+      methodName: "transfer",
+      methodArgs: [toAddr, amount],
+      formatArguments: true,
+    });
+  }
+
+  /**
+   * Get the Token balance for a given user address
+   *
+   * @namedParams
+   * @param {string} tokenAddr - Token address
+   * @param {string} userAddr - Token address
+   * @return {integer} - Token balance
+   */
+  async ElvTokenBalance({ tokenAddr, userAddr }) {
+    const abi = fs.readFileSync(
+      path.resolve(__dirname, "../contracts/v4/IERC20.abi")
+    );
+
+    let res = await this.client.CallContractMethod({
+      contractAddress: tokenAddr,
+      abi: JSON.parse(abi),
+      methodName: "balanceOf",
+      methodArgs: [userAddr],
+      formatArguments: true,
+    });
+    return Ethers.BigNumber.from(res).toNumber();
+  }
 
 }
 

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -1609,6 +1609,67 @@ const CmdTokenCreate = async ({ argv }) => {
   }
 };
 
+const CmdTokenTransfer = async ({ argv }) => {
+  console.log(`token transfer, 
+    token_addr=${argv.token_addr}
+    to_addr=${argv.to_addr}
+    amount=${argv.amount}`);
+
+  try {
+    let elvToken = new ElvToken({
+      configUrl: Config.networks[Config.net],
+      debugLogging: argv.verbose
+    });
+
+    await elvToken.Init({
+      privateKey: process.env.PRIVATE_KEY,
+    });
+
+    let res;
+    res = await elvToken.ElvTokenTransfer({
+      tokenAddr: argv.token_addr,
+      toAddr: argv.to_addr,
+      amount: argv.amount,
+    });
+    var status = await res.status;
+    if (status === 1){
+      console.log("status: transfer successful")
+    }else {
+      console.log("status: transfer failed")
+    }
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
+const CmdTokenBalanceOf = async ({ argv }) => {
+
+  console.log(`token_addr: ${argv.token_addr}`);
+  console.log(`user_addr: ${argv.user_addr}`);
+
+  try {
+    let elvToken = new ElvToken({
+      configUrl: Config.networks[Config.net],
+      debugLogging: argv.verbose
+    });
+
+    await elvToken.Init({
+      privateKey: process.env.PRIVATE_KEY,
+    });
+
+    let res;
+    res = await elvToken.ElvTokenBalance({
+      tokenAddr: argv.token_addr,
+      userAddr : argv.user_addr,
+    });
+    console.log("token_balance:",yaml.dump(await res));
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
+
+
 const CmdContentSetPolicy  = async ({ argv }) => {
   console.log("Content Set Policy");
   console.log(`Object: ${argv.object}`);
@@ -3168,6 +3229,49 @@ yargs(hideBin(process.argv))
     },
     (argv) => {
       CmdTokenCreate({ argv });
+    }
+  )
+
+  .command(
+    "token_transfer <token_addr> <to_addr> <amount> [options]",
+    "Transfer given elv tokens to address provided",
+    (yargs) => {
+      yargs
+        .positional("token_addr", {
+          describe: "elv_token address",
+          type: "string",
+        })
+        .positional("to_addr", {
+          describe: "to address",
+          type: "string",
+        })
+        .positional("amount", {
+          describe: "transfer amount",
+          type: "number",
+        });
+    },
+    (argv) => {
+      CmdTokenTransfer({ argv });
+    }
+  )
+
+
+  .command(
+    "token_balance_of <token_addr> <user_addr> [options]",
+    "Get the token balance of a given user",
+    (yargs) => {
+      yargs
+        .positional("token_addr", {
+          describe: "elv_token address",
+          type: "string",
+        })
+        .positional("user_addr", {
+          describe: "user address",
+          type: "string",
+        })
+    },
+    (argv) => {
+      CmdTokenBalanceOf({ argv });
     }
   )
 


### PR DESCRIPTION
Commands added (helpful for testing):
```
token_transfer <token_addr> <to_addr> <amount> [options]      Transfer given elv tokens to address provided
  token_balance_of <token_addr> <user_addr> [options]           Get the token balance of a given user
```

examples:
```
export PRIVATE_KEY="0x..."
 ./elv-live token_transfer 0xe8c93b603a1d0f55fc6faebdecf1f4eba07a285b 0xe8e2bc33fd9eaade1035531b6afa3afd8dd3ac72 1000000
token transfer, 
    token_addr=0xe8c93b603a1d0f55fc6faebdecf1f4eba07a285b
    to_addr=0xe8e2bc33fd9eaade1035531b6afa3afd8dd3ac72
    amount=1000000
status: transfer successful
```

```
export PRIVATE_KEY="0x..."
./elv-live token_balance_of 0xe8c93b603a1d0f55fc6faebdecf1f4eba07a285b 0xe8e2bc33fd9eaade1035531b6afa3afd8dd3ac72
token_addr: 0xe8c93b603a1d0f55fc6faebdecf1f4eba07a285b
user_addr: 0xe8e2bc33fd9eaade1035531b6afa3afd8dd3ac72
token_balance: 4000000
```