### PR TITLE
rm broken offerId output on-add-redeemable-offer

### DIFF
--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -1110,7 +1110,7 @@ const CmdNftAddRedeemableOffer = async ({ argv }) => {
     res = await elvlv.NFTAddRedeemableOffer({ addr: argv.addr });
 
     console.log(yaml.dump(res));
-    console.log("Offer ID: ",res.logs[0].values.offerId);
+    //console.log("Offer ID: ", res.logs[0].values.offerId); // no longer  available in the response
   } catch (e) {
     console.error("ERROR:", e);
   }

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -1110,6 +1110,7 @@ const CmdNftAddRedeemableOffer = async ({ argv }) => {
     res = await elvlv.NFTAddRedeemableOffer({ addr: argv.addr });
 
     console.log(yaml.dump(res));
+    console.log("added offerId", res?.logs[0]?.args[0] ?? "unknown offerId");
   } catch (e) {
     console.error("ERROR:", e);
   }

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -1110,7 +1110,6 @@ const CmdNftAddRedeemableOffer = async ({ argv }) => {
     res = await elvlv.NFTAddRedeemableOffer({ addr: argv.addr });
 
     console.log(yaml.dump(res));
-    //console.log("Offer ID: ", res.logs[0].values.offerId); // no longer  available in the response
   } catch (e) {
     console.error("ERROR:", e);
   }


### PR DESCRIPTION
https://github.com/eluv-io/elv-live-js/issues/159

no idea why there would be no values in the "logs", I have to imagine they used to appear, as this code used to work.

looks like we can get it from `res?.logs[0]?.args[0]`
