### PR TITLE
Add support for creation of class 4 ticket codes

### DIFF
--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -2931,12 +2931,26 @@ class EluvioLive {
    * @namedParams
    * @param {string} tenant - The Tenant ID
    * @param {string} otp - The OTP ID
+   * @param {integer} otpClass - The OTP class (4 or 5)
    * @param {integer} quantity - Number of tickets to generate
    * @return {Promise<Object>} - Tickets API Response Object
    */
-  async TenantTicketsGenerate({ tenant, otp, host, quantity = 1 }) {
+  async TenantTicketsGenerate({ tenant, otp, otpClass, host, quantity = 1 }) {
     let now = Date.now();
 
+    if (otpClass && otpClass == 4) {
+      let codes = [];
+      for (let i = 0; i < quantity; i ++) {
+        let code = await this.client.IssueNTPCode({
+          tenantId: tenant,
+          ntpId: otp
+        });
+        codes.push(code);
+      }
+      return codes;
+    }
+
+    // NTP class 5 (authd)
     let body = {
       tickets: {
         quantity: quantity,

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -539,7 +539,9 @@ const CmdTenantTicketsGenerate = async ({ argv }) => {
       tenant: argv.tenant,
       otp: argv.otp,
       otpClass: argv.otp_class,
-      quantity: argv.quantity
+      quantity: argv.quantity,
+      emails: argv.emails,
+      embedUrlBase: argv.embed_url_base
     });
 
     console.log("Tickets: ", res);
@@ -2497,6 +2499,14 @@ yargs(hideBin(process.argv))
         .option("quantity", {
           describe: "Specify how many to generate (default 1)",
           type: "integer",
+        })
+        .option("emails", {
+          describe: "File containing one email per line - create email-bound ticket codes",
+          type: "string",
+        })
+        .option("embed_url_base", {
+          describe: "Generate embed URLs for each ticket based on this template",
+          type: "string",
         })
         .option("otp_class", {
           describe: "Use authority services (class 5) or contract (class 4) (default 5)",

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -538,6 +538,7 @@ const CmdTenantTicketsGenerate = async ({ argv }) => {
     let res = await elvlv.TenantTicketsGenerate({
       tenant: argv.tenant,
       otp: argv.otp,
+      otpClass: argv.otp_class,
       quantity: argv.quantity
     });
 
@@ -2495,6 +2496,10 @@ yargs(hideBin(process.argv))
         })
         .option("quantity", {
           describe: "Specify how many to generate (default 1)",
+          type: "integer",
+        })
+        .option("otp_class", {
+          describe: "Use authority services (class 5) or contract (class 4) (default 5)",
           type: "integer",
         });
     },

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -2501,7 +2501,7 @@ yargs(hideBin(process.argv))
           type: "integer",
         })
         .option("emails", {
-          describe: "File containing one email per line - create email-bound ticket codes",
+          describe: "File containing one email per line (or any user identifier). Generate codes bound to these identifiers",
           type: "string",
         })
         .option("embed_url_base", {


### PR DESCRIPTION
The current elv-live tool can create ticket codes for the 'class 5' NTPs (backed by authd) but not for class 4 (contract-based, and supported by the elvmaster API).

Added option `--otp_class` which can take values 4 or 5

For the class 4 NTPs:
- added support for email-bound tickets (by specifying `--emails file-containing-emails`)
- added support for generating embed URLs (by specifying a base URL to add code to `--embed_url_base ...`)

Example:

```bash
./elv-live tenant_tickets_generate iten4CEZmYniuxBsmbNu7rUK3r4DUPg6 QOTPhc5E53XZE8x --quantity 3 --otp_class 4
```

```
./elv-live tenant_tickets_generate iten4CEZmYniuxBsmbNu7rUK3r4DUPg6 QOTPhc5E53XZE8x  --otp_class 4 --embed_url_base 'https://elv-tv4-embed.web.app/?p=&net=main&cid=iq__3WMwaTLKbrRS4EE21pCMj4Qk92Q7&type=v&ptk=&ten=iten4CEZmYniuxBsmbNu7rUK3r4DUPg6&ntp=QOTPhc5E53XZE8x&ct=h' --quantity 3
```

```
./elv-live tenant_tickets_generate iten4CEZmYniuxBsmbNu7rUK3r4DUPg6 QOTPhc5E53XZE8x  --otp_class 4 --embed_url_base 'https://elv-tv4-embed.web.app/?p=&net=main&cid=iq__3WMwaTLKbrRS4EE21pCMj4Qk92Q7&type=v&ptk=&ten=iten4CEZmYniuxBsmbNu7rUK3r4DUPg6&ntp=QOTPhc5E53XZE8x&ct=h' --emails emails.txt
```