### PR TITLE
Add support for live-to-vod copy

### DIFF
--- a/src/LiveStream.js
+++ b/src/LiveStream.js
@@ -1109,7 +1109,7 @@ class EluvioLiveStream {
   }
 
 
- /*
+  /*
   * Copy a portion of a live stream recording into a standard VoD object using the zero-copy content fabric API.
   *
   * Limitations:
@@ -1165,7 +1165,7 @@ class EluvioLiveStream {
 
     // Validation - require target object
     if (!object) {
-      throw "Must specify a target object ID"
+      throw "Must specify a target object ID";
     }
 
     let targetLibraryId = await this.client.ContentObjectLibraryId({objectId: object});
@@ -1178,7 +1178,7 @@ class EluvioLiveStream {
       objectId: object,
       metadataSubtree: kmsCapId
     });
-    if(!kmsCap) {
+    if (!kmsCap) {
       throw Error("No content encryption key set for this object");
     }
 
@@ -1201,10 +1201,6 @@ class EluvioLiveStream {
           endTime = event.eventEnd;
         }
       }
-
-      // Temp special node ch1-001
-      const specialNode = "https://host-76-74-34-194.contentfabric.io";
-      this.client.SetNodes({fabricURIs: [specialNode]});
 
       let edt = await this.client.EditContentObject({
         objectId: object,

--- a/src/abr_profile_live_to_vod.json
+++ b/src/abr_profile_live_to_vod.json
@@ -20,6 +20,15 @@
         }
       ]
     },
+    "{\"media_type\":\"audio\",\"channels\":6}": {
+      "rung_specs": [
+        {
+          "bit_rate": 384000,
+          "media_type": "audio",
+          "pregenerate": true
+        }
+      ]
+    },
     "{\"media_type\":\"video\",\"aspect_ratio_height\":273,\"aspect_ratio_width\":640}": {
       "rung_specs": [
         {

--- a/src/abr_profile_live_to_vod.json
+++ b/src/abr_profile_live_to_vod.json
@@ -1,0 +1,1884 @@
+{
+  "drm_optional": true,
+  "store_clear": true,
+  "ladder_specs": {
+    "{\"media_type\":\"audio\",\"channels\":1}": {
+      "rung_specs": [
+        {
+          "bit_rate": 128000,
+          "media_type": "audio",
+          "pregenerate": true
+        }
+      ]
+    },
+    "{\"media_type\":\"audio\",\"channels\":2}": {
+      "rung_specs": [
+        {
+          "bit_rate": 128000,
+          "media_type": "audio",
+          "pregenerate": true
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":273,\"aspect_ratio_width\":640}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2538
+        },
+        {
+          "bit_rate": 6000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1692
+        },
+        {
+          "bit_rate": 2640000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1270
+        },
+        {
+          "bit_rate": 1450000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1016
+        },
+        {
+          "bit_rate": 1070000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        },
+        {
+          "bit_rate": 690000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        }
+
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":267,\"aspect_ratio_width\":640}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2538
+        },
+        {
+          "bit_rate": 6000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1692
+        },
+        {
+          "bit_rate": 2640000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1270
+        },
+        {
+          "bit_rate": 1450000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1016
+        },
+        {
+          "bit_rate": 1070000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        },
+        {
+          "bit_rate": 690000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":729,\"aspect_ratio_width\":1280}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":1,\"aspect_ratio_width\":2}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2160
+        },
+        {
+          "bit_rate": 5000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1440
+        },
+        {
+          "bit_rate": 2250000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1200000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 864
+        },
+        {
+          "bit_rate": 910000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 720
+        },
+        {
+          "bit_rate": 580000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 720
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":67,\"aspect_ratio_width\":120}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":539,\"aspect_ratio_width\":960}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":11,\"aspect_ratio_width\":15}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":11,\"aspect_ratio_width\":20}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":12296,\"aspect_ratio_width\":21851}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":131072,\"aspect_ratio_width\":192165}": {
+      "rung_specs": [
+        {
+          "bit_rate": 5500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1620
+        },
+        {
+          "bit_rate": 2400000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1400000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 810
+        },
+        {
+          "bit_rate": 900000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 648
+        },
+        {
+          "bit_rate": 680000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 440000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":135,\"aspect_ratio_width\":176}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":135,\"aspect_ratio_width\":316}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2528
+        },
+        {
+          "bit_rate": 6000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1692
+        },
+        {
+          "bit_rate": 2640000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1270
+        },
+        {
+          "bit_rate": 1450000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1016
+        },
+        {
+          "bit_rate": 1070000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        },
+        {
+          "bit_rate": 690000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":135,\"aspect_ratio_width\":76}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1920,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1080
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 1280,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 720
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 960,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 768,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 432
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":16,\"aspect_ratio_width\":9}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1920,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1080
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 1280,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 720
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 960,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 768,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 432
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":17,\"aspect_ratio_width\":40}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2538
+        },
+        {
+          "bit_rate": 6000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1692
+        },
+        {
+          "bit_rate": 2640000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1270
+        },
+        {
+          "bit_rate": 1450000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1016
+        },
+        {
+          "bit_rate": 1070000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        },
+        {
+          "bit_rate": 690000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":173,\"aspect_ratio_width\":320}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1036,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4700000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1334
+        },
+        {
+          "bit_rate": 2080000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1000
+        },
+        {
+          "bit_rate": 1145000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 800
+        },
+        {
+          "bit_rate": 843000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        },
+        {
+          "bit_rate": 541000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":2,\"aspect_ratio_width\":3}": {
+      "rung_specs": [
+        {
+          "bit_rate": 5500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1620
+        },
+        {
+          "bit_rate": 2400000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1400000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 810
+        },
+        {
+          "bit_rate": 900000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 648
+        },
+        {
+          "bit_rate": 680000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 440000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":20,\"aspect_ratio_width\":27}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":240,\"aspect_ratio_width\":427}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":243,\"aspect_ratio_width\":320}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":259,\"aspect_ratio_width\":480}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1036,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4700000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1334
+        },
+        {
+          "bit_rate": 2080000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1000
+        },
+        {
+          "bit_rate": 1145000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 800
+        },
+        {
+          "bit_rate": 843000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        },
+        {
+          "bit_rate": 541000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":262144,\"aspect_ratio_width\":319905}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1280
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 853
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 512
+        },
+        {
+          "bit_rate": 540000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 426
+        },
+        {
+          "bit_rate": 350000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 426
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":27,\"aspect_ratio_width\":32}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1280
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 853
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 512
+        },
+        {
+          "bit_rate": 540000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 426
+        },
+        {
+          "bit_rate": 350000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 426
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":27,\"aspect_ratio_width\":40}": {
+      "rung_specs": [
+        {
+          "bit_rate": 5500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1620
+        },
+        {
+          "bit_rate": 2400000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1400000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 810
+        },
+        {
+          "bit_rate": 900000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 648
+        },
+        {
+          "bit_rate": 680000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 440000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":297,\"aspect_ratio_width\":400}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":3,\"aspect_ratio_width\":4}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":30,\"aspect_ratio_width\":53}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":40,\"aspect_ratio_width\":71}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":429,\"aspect_ratio_width\":1024}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2538
+        },
+        {
+          "bit_rate": 6000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1692
+        },
+        {
+          "bit_rate": 2640000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1270
+        },
+        {
+          "bit_rate": 1450000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1016
+        },
+        {
+          "bit_rate": 1070000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        },
+        {
+          "bit_rate": 690000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":466577,\"aspect_ratio_width\":912058}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1036,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4700000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1334
+        },
+        {
+          "bit_rate": 2080000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1000
+        },
+        {
+          "bit_rate": 1145000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 800
+        },
+        {
+          "bit_rate": 843000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        },
+        {
+          "bit_rate": 541000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 666
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":480,\"aspect_ratio_width\":853}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":486,\"aspect_ratio_width\":853}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":5,\"aspect_ratio_width\":12}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 2538
+        },
+        {
+          "bit_rate": 6000000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1692
+        },
+        {
+          "bit_rate": 2640000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1270
+        },
+        {
+          "bit_rate": 1450000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1016
+        },
+        {
+          "bit_rate": 1070000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        },
+        {
+          "bit_rate": 690000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 846
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":582543,\"aspect_ratio_width\":776720}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":639,\"aspect_ratio_width\":889}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":65536,\"aspect_ratio_width\":87381}": {
+      "rung_specs": [
+        {
+          "bit_rate": 4900000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1452
+        },
+        {
+          "bit_rate": 3375000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 968
+        },
+        {
+          "bit_rate": 1500000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 726
+        },
+        {
+          "bit_rate": 825000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 580
+        },
+        {
+          "bit_rate": 610000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        },
+        {
+          "bit_rate": 390000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 484
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":81,\"aspect_ratio_width\":128}": {
+      "rung_specs": [
+        {
+          "bit_rate": 5500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1620
+        },
+        {
+          "bit_rate": 2400000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1400000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 810
+        },
+        {
+          "bit_rate": 900000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 648
+        },
+        {
+          "bit_rate": 680000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 440000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":8192,\"aspect_ratio_width\":12015}": {
+      "rung_specs": [
+        {
+          "bit_rate": 5500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1620
+        },
+        {
+          "bit_rate": 2400000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1080
+        },
+        {
+          "bit_rate": 1400000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 810
+        },
+        {
+          "bit_rate": 900000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 648
+        },
+        {
+          "bit_rate": 680000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        },
+        {
+          "bit_rate": 440000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 540
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":891,\"aspect_ratio_width\":1600}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    },
+    "{\"media_type\":\"video\",\"aspect_ratio_height\":9,\"aspect_ratio_width\":16}": {
+      "rung_specs": [
+        {
+          "bit_rate": 9500000,
+          "height": 1080,
+          "media_type": "video",
+          "pregenerate": true,
+          "width": 1920
+        },
+        {
+          "bit_rate": 4500000,
+          "height": 720,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 1280
+        },
+        {
+          "bit_rate": 2000000,
+          "height": 540,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 960
+        },
+        {
+          "bit_rate": 1100000,
+          "height": 432,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 768
+        },
+        {
+          "bit_rate": 810000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        },
+        {
+          "bit_rate": 520000,
+          "height": 360,
+          "media_type": "video",
+          "pregenerate": false,
+          "width": 640
+        }
+      ]
+    }
+  },
+  "playout_formats": {
+    "hls-clear": {
+      "drm": null,
+      "protocol": {
+        "type": "ProtoHls"
+      }
+    }
+  },
+  "segment_specs": {
+    "audio": {
+      "segs_per_chunk": 15,
+      "target_dur": 1.984 
+    },
+    "video": {
+      "segs_per_chunk": 15,
+      "target_dur": 2.000
+    }
+  }
+}
+

--- a/utilities/EluvioLiveStreamCli.js
+++ b/utilities/EluvioLiveStreamCli.js
@@ -210,6 +210,25 @@ const CmdStreamConfig = async ({ argv }) => {
   }
 };
 
+const CmdStreamCopyToVod = async ({ argv }) => {
+  try {
+    let elvStream = new EluvioLiveStream({
+      configUrl: Config.networks[Config.net],
+      debugLogging: argv.verbose
+    });
+
+    await elvStream.Init({
+      privateKey: process.env.PRIVATE_KEY,
+    });
+
+    let status = await elvStream.StreamCopyToVod({name: argv.stream, object: argv.object});
+    console.log(yaml.dump(status));
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
+
 yargs(hideBin(process.argv))
   .option("verbose", {
     describe: "Verbose mode",
@@ -427,6 +446,28 @@ yargs(hideBin(process.argv))
       CmdStreamDownload({ argv });
     }
   )
+
+  .command(
+    "copy_as_vod <stream>",
+    "Copy the stream to a new VoD object.",
+    (yargs) => {
+      yargs
+        .positional("stream", {
+          describe:
+            "Stream name or QID (content ID)",
+          type: "string",
+        })
+        .option("object", {
+          describe:
+            "Copy to an existing object instead of creatng a new one",
+          type: "string",
+        })
+    },
+    (argv) => {
+      CmdStreamCopyToVod({ argv });
+    }
+  )
+
 
   .strict()
   .help()

--- a/utilities/EluvioLiveStreamCli.js
+++ b/utilities/EluvioLiveStreamCli.js
@@ -221,7 +221,10 @@ const CmdStreamCopyToVod = async ({ argv }) => {
       privateKey: process.env.PRIVATE_KEY,
     });
 
-    let status = await elvStream.StreamCopyToVod({name: argv.stream, object: argv.object});
+    let status = await elvStream.StreamCopyToVod({
+      name: argv.stream,
+      object: argv.object,
+      eventId: argv.event_id});
     console.log(yaml.dump(status));
   } catch (e) {
     console.error("ERROR:", e);
@@ -460,6 +463,11 @@ yargs(hideBin(process.argv))
         .option("object", {
           describe:
             "Copy to an existing object instead of creatng a new one",
+          type: "string",
+        })
+        .option("event_id", {
+          describe:
+            "Optional SCTE35 program or chapter event ID",
           type: "string",
         })
     },


### PR DESCRIPTION
Add support for copying a portion of a live stream recording to a standard VoD object using the zero-copy content-fabric API.

### Example:

```
./elv-stream copy_as_vod iq__6T98e47cfkxW3TpaVXUDjy2BePK --object iq__4AgZa3z1asibHreiWxfVTzKAZ7BA
```

### Limitations:
  * currently requires the target object to be pre-created and have content encryption keys (CAPS)
  * for audio and video to be sync'd, the live stream needs to have the beginning of the desired recording period
    *  for an event stream, make sure the TTL is long enough to allow running the live-to-vod command before the beginning of the recording expires
    * for 24/7 streams, make sure to reset the stream before the desired recording (as to create a new recording period) and have the TTL long enough to allow running the live-to-vod command before the beginning of the recording expires.
  * startTime and endTime are not currently implemented by this tool