### PR TITLE
add elv-live tenant_auth_curl

### DIFF
--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -15,6 +15,8 @@ const yaml = require("js-yaml");
 const fs = require("fs");
 const path = require("path");
 const prompt = require("prompt-sync")({ sigint: true });
+const exec = require('child_process').exec;
+
 
 // hack that quiets this msg:
 //  node:87980) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
@@ -45,21 +47,53 @@ const Init = async ({debugLogging = false, asUrl}={}) => {
 };
 
 const CmdTenantAuthToken = async ({ argv }) => {
-  await Init({debugLogging: argv.verbose})
+  await Init({debugLogging: argv.verbose});
 
-  let ts = Date.now()
-  let message = argv.path_or_body + "?ts=" + ts
+  let ts = Date.now();
+  let message = argv.path_or_body + "?ts=" + ts;
   try {
-    let j = JSON.parse(argv.path_or_body)
-    j.ts = ts
-    message = JSON.stringify(j)
+    let j = JSON.parse(argv.path_or_body);
+    j.ts = ts;
+    message = JSON.stringify(j);
   } catch (e) {}
 
   const { multiSig } = await elvlv.TenantSign({
     message: message
-  })
-  console.log(`Timestamped path or body: ${message}`)
-  console.log(`Token: Authorization: Bearer ${multiSig}`)
+  });
+  console.log(`Timestamped path or body: ${message}`);
+  console.log(`Token: Authorization: Bearer ${multiSig}`);
+};
+
+const CmdTenantAuthCurl = async ({ argv }) => {
+  await Init({debugLogging: argv.verbose});
+
+  let ts = Date.now();
+  let message = argv.url_path + "?ts=" + ts;
+  try {
+    let j = JSON.parse(argv.url_path);
+    j.ts = ts;
+    message = JSON.stringify(j);
+  } catch (e) {}
+
+  const { multiSig } = await elvlv.TenantSign({
+    message: message
+  });
+
+  let cmd;
+  if (argv.post_body) {
+    cmd = `curl -s -H "Authorization: Bearer ${multiSig}" ${argv.url_prefix}${message} -d '${argv.post_body}'`;
+  } else {
+    cmd = `curl -s -H "Authorization: Bearer ${multiSig}" ${argv.url_prefix}${message}`;
+  }
+  console.log(cmd);
+  exec(cmd, (error, stdout, stderr) => {
+    if (error) {
+      console.error(`exec error: ${error}`);
+      return;
+    }
+    console.log(stdout);
+  });
+
 };
 
 const CmfNftTemplateAddNftContract = async ({ argv }) => {
@@ -2302,6 +2336,29 @@ yargs(hideBin(process.argv))
     },
     (argv) => {
       CmdTenantAuthToken({argv}).then();
+    }
+  )
+
+  .command(
+    "tenant_auth_curl <url_path> <url_prefix> [post_body]",
+    "Generate a tenant token and use it to call an authd endpoint.",
+    (yargs) => {
+      yargs
+        .positional("url_path", {
+          describe: "URL path",
+          type: "string",
+        })
+        .positional("url_prefix", {
+          describe: "URL prefix to use for POST or GET",
+          type: "string",
+        })
+        .positional("post_body", {
+          describe: "optional body; if set will POST, if not, will GET",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdTenantAuthCurl({argv}).then();
     }
   )
 


### PR DESCRIPTION
we need this because these tenant auth tokens time out after 10 seconds, not enough time to copy-n-paste tokens, needs to be a single operation.


```
$ ./elv-live tenant_auth_curl
 tenant_auth_curl <url_path> [post_body]

Generate a tenant token and use it to call an authd endpoint.

Positionals:
  url_path   URL path                                                                                [string] [required]
  post_body  optional body; if set will POST, if not, will GET                                                  [string]

Options:
      --as_url   Alternate authority service URL (include '/as/' route if necessary)                            [string]
```

sample:
```
$ ./elv-live tenant_auth_curl /faucet/addOTP/iten4TXq2en3qtu3JREnE5tSLRf9zLod '{"tenant_id":"iten4TXq2en3qtu3JREnE5tSLRf9zLod","eth_amount":0.03}' --as_url http://localhost:8080/as
Network: demov3
curl -s -H "Authorization: Bearer ES256K_7MoEEbwCQyGoFv24FMKhz3mveCUrygk2wNuE3PQTYs2tTuP7LHKFaqpQGHH6Uif2kkfWcjN18BBcHcdxBJEbio3mV" http://localhost:8080/as/faucet/addOTP/iten4TXq2en3qtu3JREnE5tSLRf9zLod?ts=1705609696246 -d '{"tenant_id":"iten4TXq2en3qtu3JREnE5tSLRf9zLod","eth_amount":0.03}'
{"otp_id":"9OI47zMJPeVa","status":"success"}
```
