### PR TITLE
Live stream watermark configuration

### DIFF
--- a/resources/sample_text_watermark.json
+++ b/resources/sample_text_watermark.json
@@ -1,0 +1,9 @@
+{
+  "font_color": "white@0.80",
+  "font_relative_height": 0.025,
+  "shadow": true,
+  "shadow_color": "black@0.18",
+  "template": "Sample - $USERNAME",
+  "x": "(w-tw)/100*85",
+  "y": "(h-th)/100*20"
+}

--- a/utilities/EluvioLiveStreamCli.js
+++ b/utilities/EluvioLiveStreamCli.js
@@ -231,6 +231,27 @@ const CmdStreamCopyToVod = async ({ argv }) => {
   }
 };
 
+const CmdWatermark = async ({op, argv}) => {
+  try {
+    let elvStream = new EluvioLiveStream({
+      configUrl: Config.networks[Config.net],
+      debugLogging: argv.verbose
+    });
+
+    await elvStream.Init({
+      privateKey: process.env.PRIVATE_KEY,
+    });
+
+    let res = await elvStream.Watermark({
+      op,
+      objectId: argv.stream,
+      fileName: argv.file});
+    console.log(yaml.dump(res));
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+
+}
 
 yargs(hideBin(process.argv))
   .option("verbose", {
@@ -462,7 +483,7 @@ yargs(hideBin(process.argv))
         })
         .option("object", {
           describe:
-            "Copy to an existing object instead of creatng a new one",
+            "Copy to an existing object instead of creating a new one",
           type: "string",
         })
         .option("event_id", {
@@ -473,6 +494,43 @@ yargs(hideBin(process.argv))
     },
     (argv) => {
       CmdStreamCopyToVod({ argv });
+    }
+  )
+
+  .command(
+    "watermark_set <stream> <file>",
+    "Set watermark for this stream.",
+    (yargs) => {
+      yargs
+      .positional("stream", {
+        describe:
+          "Stream name or QID (content ID)",
+        type: "string",
+      })
+      .positional("file", {
+          describe:
+            "File containing JSON watermark spec",
+          type: "string",
+        })
+    },
+    (argv) => {
+      CmdWatermark({ op: "set", argv });
+    }
+  )
+
+  .command(
+    "watermark_remove <stream>",
+    "Remove watermark from the stream.",
+    (yargs) => {
+      yargs
+      .positional("stream", {
+        describe:
+          "Stream name or QID (content ID)",
+        type: "string",
+      })
+  },
+    (argv) => {
+      CmdWatermark({ op: "rm", argv });
     }
   )
 


### PR DESCRIPTION
Added `elv-stream` support for setting and removing text watermark for live streams.

Example:

```
   ./elv-stream watermark_set iq__2yHDPgNdsqQkCuGKJpABYBkJPVPf  resources/sample_text_watermark.json
   ./elv-stream watermark_remove iq__2yHDPgNdsqQkCuGKJpABYBkJPVPf
```

I included a sample file that shows the typical the watermark parameters.

