### PR TITLE
Add TenantActionsReport( ) and tenant_actions_report parameter

### DIFF
--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -14,6 +14,7 @@ const url = require("url");
 const crypto = require("crypto");
 const ethers = require("ethers");
 const { parse } = require("csv-parse");
+const { start } = require("repl");
 
 /**
  * EluvioLive is an application platform built on top of the Eluvio Content Fabric.
@@ -3079,6 +3080,85 @@ class EluvioLive {
 
     return toJson ? await res.json() : await res.text();
   }
+
+  /**
+   * Get actions report for the tenant
+   *
+   * @namedParams
+   * @param {string} tenant - The Tenant ID
+   * @param {string} actions - The actions to report on
+   * @param {integer} offset - The offset to start from
+   * @param {integer} count - The number of records to return
+   * @param {integer} start_ts - The start timestamp secs
+   * @param {integer} end_ts - The end timestamp secs
+   * @param {string} start_date - The ISO start date
+   * @param {string} end_date - The ISO end date
+   * @param {string} fileout - The file to write the report to
+   * @return {Promise<Object>} - The API Response containing primary sales info
+   */
+  async TenantActionsReport({   
+    tenant, 
+    actions = "nft-open,nft-buy,nft-claim,nft-redeem,nft-offer-redeem,vote-drop", 
+    offset, 
+    count, 
+    start_ts,
+    end_ts,
+    start_date,
+    end_date,
+    fileout,
+    verbose = false
+  }) {
+
+    let start_ts_param = 0;
+    let end_ts_param = 0;
+
+    let headers = {};
+    let prettyPrint = true;
+    if (fileout && fileout != "") {
+      prettyPrint = false;
+    }
+
+    let validActions = ["nft-open", "nft-buy", "nft-claim", "nft-redeem", "nft-offer-redeem", "nft-transfer", "vote-drop"];
+    let actionList = actions.split(",");
+    for (let i = 0; i < actionList.length; i++) {
+      if (!validActions.includes(actionList[i])) {
+        throw new Error(`Invalid action: ${actionList[i]}`);
+      }
+    }
+
+    // use start timestamp if provided, else convert dates string to timestamps
+    if (!(start_ts)) {
+      if (verbose) {
+        console.log("start_date: ", start_date);
+        console.log("end_date: ", end_date);
+      }
+      if (start_date || end_date) {
+
+        // convert ISO date strings to timestamps in secs
+        start_ts_param = start_date ? new Date(start_date).getTime() / 1000 : 0;
+        end_ts_param = end_date ? new Date(end_date).getTime() / 1000 : 0;
+
+        if (verbose) {
+          console.log("start_ts_param: ", start_ts_param);
+          console.log("end_ts_param: ", end_ts_param);
+        }
+      } else {
+        start_ts_param = start_ts;
+        end_ts_param = end_ts;
+      }
+
+    }
+  
+    let res = await this.GetServiceRequest({
+      path: urljoin("/tnt/", tenant, "/actions"),
+      queryParams: { actions: actions, offset: offset, count: count, 
+        start_ts : start_ts_param, end_ts : end_ts_param},
+      headers
+    });
+  
+    return prettyPrint ? await res.json() : await res.text();
+  }
+  
 
   /**
    * Get unified primary&secondary sales history for the tenant

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -712,6 +712,66 @@ const CmdTenantSecondarySales = async ({ argv }) => {
   }
 };
 
+const CmdTenantActionsReport = async ({ argv }) => {
+  console.log(`Tenant Actions Report: ${argv.tenant}`);
+  if (argv.verbose) {
+    if (argv.actions) {
+      console.log(`actions: ${argv.actions}`);
+    }
+    if (argv.offset) {
+      console.log(`offset: ${argv.offset}`);
+    }
+    if (argv.count) {
+      console.log(`count: ${argv.count}`);
+    }
+    if (argv.start_ts) {
+      console.log(`start_ts: ${argv.start_ts}`);
+    }
+    if (argv.end_ts) {
+      console.log(`end_ts: ${argv.end_ts}`);
+    }
+
+    if (argv.start_date) {
+      console.log(`start_date: ${argv.start_date}`);
+    }
+    if (argv.end_date) {
+      console.log(`end_date: ${argv.end_date}`);
+    }
+
+    if (argv.fileout) { 
+      console.log(`fileout: ${argv.fileout}`);
+    }
+  }
+
+  try {
+    await Init({debugLogging: argv.verbose, asUrl: argv.as_url});
+
+    let res = await elvlv.TenantActionsReport({
+      tenant: argv.tenant,
+      actions: argv.actions,
+      offset: argv.offset,
+      count: argv.count,
+      start_ts: argv.start_ts,
+      end_ts: argv.end_ts,
+      start_date: argv.start_date,
+      end_date: argv.end_date,
+
+      fileout: argv.fileout,
+      verbose: argv.verbose,
+    });
+
+    if (argv.fileout && argv.fileout != "") {
+      fs.writeFileSync( argv.fileout, res);
+    } else {
+      console.log(res);
+    }
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
+
+
 const CmdTenantUnifiedSales = async ({ argv }) => {
   console.log(`Tenant Unified Sales: ${argv.tenant}`);
   console.log(`Processor: ${argv.processor}`);
@@ -2600,6 +2660,60 @@ yargs(hideBin(process.argv))
     },
     (argv) => {
       CmdTenantSecondarySales({ argv });
+    }
+  )
+
+  .command(
+    "tenant_actions_report <tenant>",
+    "Show tenant actions report history",
+    (yargs) => {
+      yargs
+        .positional("tenant", {
+          describe: "Tenant ID",
+          type: "string",
+        })
+        // offset in hours
+        .option("offset", {
+          describe: "Offset in hours to dump data where 0 is the current hour",
+          type: "number",
+          //default: 0,
+        })
+        // count of hours, combine with offset
+        .option("count", {
+          describe: "Count of hours to dump data",
+          type: "number",
+          //default: 0,
+        })
+        // start_ts, end_ts - unix timestamp
+        .option("start_ts", {
+          describe: "Start timestamp to dump data",
+          type: "number",
+          //default: 0,
+        })
+        .option("end_ts", {
+          describe: "End timestamp to dump data",
+          type: "number",
+          //default: 0,   // default is current time in API
+        })
+        // start_date, end_date - ISO date string format
+        .option("start_date", {
+          describe: "Start date string to dump data",
+          type: "string",
+          //default: 0,
+        })
+        .option("end_date", {
+          describe: "End date string to dump data",
+          type: "string",
+          //default: 0,   // default is current time in API
+        })
+        
+        .option("fileout", {
+          describe: "File path to output to",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdTenantActionsReport({ argv });
     }
   )
 


### PR DESCRIPTION

*WIP* still testing

main feature is using friendly ISO date strings at the command line for testing /tnt/:tid/actions endpoint

testing combinations of start/end dates and offset or count-limit param

requires Tenant Auth

currently prints or save JSON

TODO:  add user auth version or /wlt/:addr/actions endpoint


