### PR TITLE
add tenant-auth-curl arg handling

### DIFF
--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -255,7 +255,6 @@ const CmdNftShow = async ({ argv }) => {
     });
 
     console.log(yaml.dump(res));
-    console.log(JSON.stringify(res, null, 4));
   } catch (e) {
     console.error("ERROR:", e);
   }

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -65,9 +65,14 @@ const CmdTenantAuthCurl = async ({ argv }) => {
   await Init({ debugLogging: argv.verbose, asUrl: argv.as_url });
 
   let ts = Date.now();
-  let message = argv.url_path + "?ts=" + ts;
+
+  let message = argv.url_path;
+  let msgNoArgs = message.includes("?") ? message.split("?")[0] : message;
+  let args = message.includes("?") ? ("&" + message.split("?")[1]) : "";
+  message = msgNoArgs + "?ts=" + ts;
+
   try {
-    let j = JSON.parse(argv.url_path);
+    let j = JSON.parse(message);
     j.ts = ts;
     message = JSON.stringify(j);
   } catch (e) {}
@@ -81,7 +86,7 @@ const CmdTenantAuthCurl = async ({ argv }) => {
     prefix = argv.as_url;
   }
 
-  let cmd = `curl -s -H "Authorization: Bearer ${multiSig}" ${prefix}${message}`;
+  let cmd = `curl -s -H "Authorization: Bearer ${multiSig}" ${prefix}${message}${args}`;
   if (argv.post_body) {
     cmd = cmd + ` -d '${argv.post_body}'`;
   }
@@ -250,6 +255,7 @@ const CmdNftShow = async ({ argv }) => {
     });
 
     console.log(yaml.dump(res));
+    console.log(JSON.stringify(res, null, 4));
   } catch (e) {
     console.error("ERROR:", e);
   }

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -69,7 +69,7 @@ const CmdTenantAuthCurl = async ({ argv }) => {
   let message = argv.url_path;
   let msgNoArgs = message.includes("?") ? message.split("?")[0] : message;
   let args = message.includes("?") ? ("&" + message.split("?")[1]) : "";
-  message = msgNoArgs + "?ts=" + ts;
+  message = msgNoArgs + "?ts=" + ts + args;
 
   try {
     let j = JSON.parse(message);
@@ -86,7 +86,7 @@ const CmdTenantAuthCurl = async ({ argv }) => {
     prefix = argv.as_url;
   }
 
-  let cmd = `curl -s -H "Authorization: Bearer ${multiSig}" ${prefix}${message}${args}`;
+  let cmd = `curl -s -H "Authorization: Bearer ${multiSig}" "${prefix}${message}"`;
   if (argv.post_body) {
     cmd = cmd + ` -d '${argv.post_body}'`;
   }


### PR DESCRIPTION
allow additional url params to be used in a tenant auth query to elvauthd

eg.
```
$ elv-live tenant_auth_curl /tnt/iten4TXq2en3qtu3JREnE5tSLRf9zLod/actions?count=1 

curl -s -H "Authorization: Bearer ES256K_6b.." "https://host-76-74-28-227.contentfabric.io/as/tnt/iten4TXq2en3qtu3JREnE5tSLRf9zLod/actions?ts=1707259185246&count=2"

{ ... } 
```