### PR TITLE
Add tenant commands

### DIFF
--- a/src/Constants.js
+++ b/src/Constants.js
@@ -1,0 +1,16 @@
+// Define constant values
+const Constants = {
+  // tenant groups
+  TENANT_ADMIN: "tenant_admin",
+  CONTENT_ADMIN: "content_admin",
+  TENANT_USER_GROUP: "tenant_user_group",
+
+  // tenant status
+  TENANT_STATE:"_ELV_TENANT_STATE",
+  TENANT_STATE_ACTIVE:"active",
+  TENANT_STATE_INACTIVE:"inactive",
+  TENANT_STATE_FROZEN:"frozen"
+};
+
+// Export the constants object
+module.exports = Constants;

--- a/src/ElvAccount.js
+++ b/src/ElvAccount.js
@@ -1,7 +1,5 @@
 const { ElvClient } = require("@eluvio/elv-client-js");
 const ethers = require("ethers");
-const fs = require("fs");
-const path = require("path");
 const { ElvUtils } = require("./Utils");
 
 const TOKEN_DURATION = 120000; //2 min
@@ -89,6 +87,9 @@ class ElvAccount {
     }
 
     // create new account
+    let account = await ElvClient.FromConfigurationUrl({
+      configUrl: this.configUrl,
+    });
     let wallet = this.client.GenerateWallet();
     const mnemonic = wallet.GenerateMnemonic();
     const signer = wallet.AddAccountFromMnemonic({ mnemonic });
@@ -110,10 +111,6 @@ class ElvAccount {
         console.log("Send Funds result: ", res);
       }
 
-      // new account
-      let account = await ElvClient.FromConfigurationUrl({
-        configUrl: this.configUrl,
-      });
       await account.SetSigner({signer});
       // the new account can create wallet when it has funds
       await account.userProfileClient.CreateWallet();
@@ -131,7 +128,7 @@ class ElvAccount {
         });
       }
 
-      let balance = await wallet.GetAccountBalance({ signer });
+      let balance = await wallet.GetAccountBalance({signer});
 
       let accountInfo = {
         accountName,
@@ -147,7 +144,7 @@ class ElvAccount {
     } catch (e) {
       // Return funds in case of error
       if (funds > 0.01) {
-        await elvAccount.SendFunds({
+        await account.SendFunds({
           recipient: this.client.signer.address,
           ether: funds - 0.01,
         });

--- a/src/ElvAccount.js
+++ b/src/ElvAccount.js
@@ -188,21 +188,6 @@ class ElvAccount {
     let balance = await wallet.GetAccountBalance({ signer: this.client.signer });
     let userId = ElvUtils.AddressToId({prefix:"iusr", address});
 
-    const abi = fs.readFileSync(
-      path.resolve(__dirname, "../contracts/v3/BaseAccessWallet.abi")
-    );
-
-    let userTenantIdHex = await this.client.CallContractMethod({
-      contractAddress: walletAddress,
-      abi: JSON.parse(abi),
-      methodName: "getMeta",
-      methodArgs: ["_ELV_TENANT_ID"],
-    });
-    const userTenantId = ethers.utils.toUtf8String(userTenantIdHex);
-
-    if (tenantId != userTenantId) {
-      console.log("Bad user - inconsistent tenant ID", tenantId, userTenantId);
-    }
     return { address, userId, tenantId, tenantAdminsId, walletAddress, userWalletObject, userMetadata, balance };
   }
 

--- a/src/ElvAccount.js
+++ b/src/ElvAccount.js
@@ -281,21 +281,6 @@ class ElvAccount {
         contractAddress: groupAddress,
         tenantContractId: tenantContractId
       });
-
-      // Set the tenant field on the contract to tenantContractId so that it is consistent with the metadata
-      try {
-        await this.client.CallContractMethod({
-          contractAddress: groupAddress,
-          methodName: "setTenant",
-          methodArgs: [this.client.utils.HashToAddress(tenantContractId)],
-        });
-      } catch (e) {
-        if (e.message.includes("Unknown method: setTenant")) {
-          console.log(`Log: The group contract with address ${groupAddress} doesn't support setTenant method`);
-        } else {
-          throw e;
-        }
-      }
     }
   }
 

--- a/src/ElvAccount.js
+++ b/src/ElvAccount.js
@@ -30,9 +30,18 @@ class ElvAccount {
     this.client.ToggleLogging(this.debug);
   }
 
-  async InitWithId({ privateKey, id }) {
+  async InitWithId({ privateKey, tenantContractId, tenantId }) {
     await this.Init({privateKey});
-    await this.SetAccountTenantContractId({ tenantContractId: id });
+
+    if (typeof tenantContractId !== "undefined"){
+      await this.SetAccountTenantContractId({ tenantContractId });
+    } else {
+      if (typeof tenantId !== "undefined") {
+        await this.SetAccountTenantId({tenantId});
+      }
+    }
+    console.log(`tenantContractID: ${this.client.userProfileClient.tenantContractId}`);
+    console.log(`tenantAdminGroup: ${this.client.userProfileClient.tenantId}`);
   }
 
   InitWithClient({ elvClient }) {
@@ -191,13 +200,13 @@ class ElvAccount {
     return { address, userId, tenantContractId, tenantAdminsId, walletAddress, userWalletObject, userMetadata, balance };
   }
 
-  async SetAccountTenantAdminsAddress({ tenantAdminsAddress }) {
+  async SetAccountTenantId({ tenantId }) {
     if (!this.client) {
       throw Error("ElvAccount not intialized");
     }
 
     await this.client.userProfileClient.SetTenantId({
-      address: tenantAdminsAddress,
+      id: tenantId,
     });
   }
 

--- a/src/ElvAccount.js
+++ b/src/ElvAccount.js
@@ -275,11 +275,11 @@ class ElvAccount {
     const groupTenantContractId = await this.client.TenantContractId({
       contractAddress: groupAddress
     });
-    if (typeof groupTenantContractId !== "undefined" ){
+    if (groupTenantContractId){
       if (groupTenantContractId === tenantContractId){
         console.log(`Group ${groupAddress} has tenantContractId = ${tenantContractId}`);
       } else {
-        throw Error(`Group ${groupAddress} has different tenantContractId = ${tenantContractId}, aborting...`);
+        throw Error(`Group ${groupAddress} has different tenantContractId = ${groupTenantContractId}, aborting...`);
       }
     } else {
       await this.client.SetTenantContractId({

--- a/src/ElvSpace.js
+++ b/src/ElvSpace.js
@@ -112,11 +112,11 @@ class ElvSpace {
 
       // Add tenant details to group
       await elvAccount.SetGroupTenantConfig({
-        tenantId: tenant.id,
+        tenantContractId: tenant.id,
         groupAddress: tenantAdminGroup.address
       });
       await elvAccount.SetGroupTenantConfig({
-        tenantId: tenant.id,
+        tenantContractId: tenant.id,
         groupAddress: contentAdminGroup.address
       });
 

--- a/src/ElvSpace.js
+++ b/src/ElvSpace.js
@@ -77,6 +77,7 @@ class ElvSpace {
         isManager: true,
       });
 
+      // TODO: fix elv-client-js tenantId
       // await elvAccount.SetAccountTenantAdminsAddress({
       //   tenantAdminsAddress: tenantAdminGroup.address,
       // });

--- a/src/ElvSpace.js
+++ b/src/ElvSpace.js
@@ -104,7 +104,7 @@ class ElvSpace {
       if (this.debug){
         console.log("tenant admins:", tenantAdminGroup);
         console.log("content admins:", contentAdminGroup);
-        console.log("tenant user group:", tenantUserGroup)
+        console.log("tenant user group:", tenantUserGroup);
       }
       let adminGroups = {tenantAdminGroup, contentAdminGroup, tenantUserGroup};
 
@@ -162,7 +162,7 @@ class ElvSpace {
     });
     await elvTenant.Init({
       privateKey: process.env.PRIVATE_KEY,
-    })
+    });
 
     let res = {};
 
@@ -193,7 +193,7 @@ class ElvSpace {
 
     const tenantContractId = ElvUtils.AddressToId({
       prefix:"iten",
-      address: tenantContract.address})
+      address: tenantContract.address});
 
     if (tenantAdminGroupAddress) {
       res = await elvTenant.TenantSetGroup({

--- a/src/ElvSpace.js
+++ b/src/ElvSpace.js
@@ -77,12 +77,6 @@ class ElvSpace {
         isManager: true,
       });
 
-      // TODO: fix elv-client-js tenantId
-      // await elvAccount.SetAccountTenantAdminsAddress({
-      //   tenantAdminsAddress: tenantAdminGroup.address,
-      // });
-      // account.tenantAdminsId = await elvAccount.client.userProfileClient.TenantId();
-
       // Create Content Admin Access Group
       let contentAdminGroup = await elvAccount.CreateAccessGroup({
         name: `${tenantName} Content Admins`,
@@ -108,7 +102,7 @@ class ElvSpace {
       });
 
       // Assign the created tenant and tenant_admin group to account
-      await elvAccount.SetAccountTenantContractId({tenantId: tenant.id});
+      await elvAccount.SetAccountTenantContractId({tenantContractId: tenant.id});
 
       // Add tenant details to group
       await elvAccount.SetGroupTenantConfig({

--- a/src/ElvSpace.js
+++ b/src/ElvSpace.js
@@ -107,7 +107,7 @@ class ElvSpace {
       });
 
       // Assign the created tenant and tenant_admin group to account
-      elvAccount.SetAccountTenantContractId({tenantId: tenant.id});
+      await elvAccount.SetAccountTenantContractId({tenantId: tenant.id});
 
       // Add tenant details to group
       await elvAccount.SetGroupTenantConfig({

--- a/src/ElvSpace.js
+++ b/src/ElvSpace.js
@@ -77,10 +77,10 @@ class ElvSpace {
         isManager: true,
       });
 
-      await elvAccount.SetAccountTenantAdminsAddress({
-        tenantAdminsAddress: tenantAdminGroup.address,
-      });
-      account.tenantAdminsId = await elvAccount.client.userProfileClient.TenantId();
+      // await elvAccount.SetAccountTenantAdminsAddress({
+      //   tenantAdminsAddress: tenantAdminGroup.address,
+      // });
+      // account.tenantAdminsId = await elvAccount.client.userProfileClient.TenantId();
 
       // Create Content Admin Access Group
       let contentAdminGroup = await elvAccount.CreateAccessGroup({
@@ -106,15 +106,14 @@ class ElvSpace {
         contentAdminGroupAddress: contentAdminGroup.address,
       });
 
-      // Assign the created tenant to account
+      // Assign the created tenant and tenant_admin group to account
       elvAccount.SetAccountTenantContractId({tenantId: tenant.id});
 
-      // Add _ELV_TENANT_ID to groups' metadata so we can identify the tenant these groups belong to
+      // Add tenant details to group
       await elvAccount.SetGroupTenantConfig({
         tenantId: tenant.id,
         groupAddress: tenantAdminGroup.address
       });
-
       await elvAccount.SetGroupTenantConfig({
         tenantId: tenant.id,
         groupAddress: contentAdminGroup.address

--- a/src/ElvTenant.js
+++ b/src/ElvTenant.js
@@ -196,11 +196,11 @@ class ElvTenant {
       methodArgs: [],
     });
 
-    const groupList = await this.TenantGroup({tenantContractId})
-    for(let group in groupList) {
-      let groupName = group.replace(/_/g, ' ');
-      if(!groupList[group]){
-        errors.push(`missing ${groupName}`)
+    const groupList = await this.TenantGroup({tenantContractId});
+    for (let group in groupList) {
+      let groupName = group.replace(/_/g, " ");
+      if (!groupList[group]){
+        errors.push(`missing ${groupName}`);
       } else {
         // check _ELV_TENANT_ID set on these groups
         let res = await this.TenantCheckGroupConfig({

--- a/src/ElvTenant.js
+++ b/src/ElvTenant.js
@@ -377,7 +377,7 @@ class ElvTenant {
    * @param {string} tenantUserGroupAddr - Tenant User Group's address, new group will be created if not specified (optional)
    * @returns {string} Tenant User Group's address
    */
-  async SetTenantUserGroup({ tenantContractId, tenantUserGroupAddr }) {
+  async TenantSetTenantUserGroup({ tenantContractId, tenantUserGroupAddr }) {
 
     let elvAccount = new ElvAccount({configUrl:this.configUrl, debugLogging: this.debug});
     elvAccount.InitWithClient({elvClient:this.client});
@@ -450,7 +450,7 @@ class ElvTenant {
    * @param {string} tenantContractId - The ID of the tenant Id (iten***)
    * @param {string} tenantUserGroupAddr - Address of tenant user group we want to remove.
    */
-  async RemoveTenantUserGroup({ tenantContractId, tenantUserGroupAddr }) {
+  async TenantRemoveTenantUserGroup({ tenantContractId, tenantUserGroupAddr }) {
 
     //Check that the user is the owner of the tenant
     const tenantOwner = await this.client.authClient.Owner({id: tenantContractId});

--- a/src/ElvTenant.js
+++ b/src/ElvTenant.js
@@ -137,8 +137,8 @@ class ElvTenant {
     });
 
     const m = await this.client.ContentObjectMetadata({
-      libraryId: ElvUtils.AddressToId({prefix: "ilib", address: tenantAddr}),
-      objectId: ElvUtils.AddressToId({prefix: "iq__", address: tenantAddr}),
+      libraryId: ElvUtils.AddressToId({prefix: "ilib", address: tenantContractAddr}),
+      objectId: ElvUtils.AddressToId({prefix: "iq__", address: tenantContractAddr}),
       noAuth: true
     });
 
@@ -241,7 +241,7 @@ class ElvTenant {
 
     if (show_metadata) {
       let services = [];
-      let tenantObjectId = ElvUtils.AddressToId({prefix: "iq__", address: tenantAddr});
+      let tenantObjectId = ElvUtils.AddressToId({prefix: "iq__", address: tenantContractAddr});
       let tenantLibraryId = await this.client.ContentObjectLibraryId({objectId: tenantObjectId});
 
       try {
@@ -378,8 +378,10 @@ class ElvTenant {
     let tid = await this.client.TenantContractId({
       contractAddress: groupAddress
     });
-    if (tid !== ""){
-      throw Error(`Group ${groupAddress} has tenant contract ID set to ${tid}, aborting...`);
+    if (typeof tid !== "undefined"){
+      if (tid !== tenantContractId){
+        throw Error(`Group ${groupAddress} has different tenant contract ID set to ${tid}, aborting...`);
+      }
     }
 
     return await this.client.SetTenantContractId({

--- a/src/ElvTenant.js
+++ b/src/ElvTenant.js
@@ -256,8 +256,8 @@ class ElvTenant {
     const tenantAddr = Utils.HashToAddress(tenantContractId);
 
     if (groupType){
-      if (groupType !== constants.TENANT_ADMIN ||
-        groupType !== constants.CONTENT_ADMIN ||
+      if (groupType !== constants.TENANT_ADMIN &&
+        groupType !== constants.CONTENT_ADMIN &&
         groupType !== constants.TENANT_USER_GROUP){
         throw Error(`Invalid groupType, require tenant_admin | content_admin | tenant_user_group: ${groupType}`);
       }
@@ -308,8 +308,8 @@ class ElvTenant {
 
     const tenantAddr = Utils.HashToAddress(tenantContractId);
 
-    if (groupType !== constants.TENANT_ADMIN ||
-      groupType !== constants.CONTENT_ADMIN ||
+    if (groupType !== constants.TENANT_ADMIN &&
+      groupType !== constants.CONTENT_ADMIN &&
       groupType !== constants.TENANT_USER_GROUP){
       throw Error(`Invalid groupType, require tenant_admin | content_admin | tenant_user_group: ${groupType}`);
     }
@@ -355,8 +355,8 @@ class ElvTenant {
       });
     }
 
-    //Associate the group with this tenant
-    await this.TenantSetGroupConfig({tenantContractId, groupAddress});
+    //Associate the group with this tenant -- needs group owner to run
+    //await this.TenantSetGroupConfig({tenantContractId, groupAddress});
 
     //Associate the tenant with this group - set tenant's group on the tenant's contract.
     await this.client.CallContractMethodAndWait({
@@ -378,8 +378,8 @@ class ElvTenant {
    */
   async TenantRemoveGroup({ tenantContractId, groupType, groupAddress }) {
 
-    if (groupType !== constants.TENANT_ADMIN ||
-      groupType !== constants.CONTENT_ADMIN ||
+    if (groupType !== constants.TENANT_ADMIN &&
+      groupType !== constants.CONTENT_ADMIN &&
       groupType !== constants.TENANT_USER_GROUP){
       throw Error(`Invalid groupType, require tenant_admin or content_admin or tenant_user_group: ${groupType}`);
     }
@@ -413,11 +413,11 @@ class ElvTenant {
    *
    * @param {string} tenantContractId - The ID of the tenant Id (iten***)
    * @param {string} tenantStatus - tenant status: acive | inactive | frozen
-   * @returns {Promise<string>}
+   * @returns {Promise<{tenantStatus: string, tenantContractId: string}>}
    */
   async TenantSetStatus({tenantContractId, tenantStatus}) {
-    if (tenantStatus !== constants.TENANT_STATE_ACTIVE ||
-      tenantStatus !== constants.TENANT_STATE_INACTIVE ||
+    if (tenantStatus !== constants.TENANT_STATE_ACTIVE &&
+      tenantStatus !== constants.TENANT_STATE_INACTIVE &&
       tenantStatus !== constants.TENANT_STATE_FROZEN){
       throw Error(`Invalid tenant status, require active | inactive | frozen: ${tenantStatus}`);
     }
@@ -437,7 +437,7 @@ class ElvTenant {
     });
 
     tenantStatus = await this.TenantStatus({tenantContractId});
-    return `{tenantContractId:${tenantContractId}, tenantState:${tenantStatus}}`;
+    return {tenantContractId, tenantStatus};
   }
 
   /**
@@ -457,7 +457,7 @@ class ElvTenant {
     } catch (e) {
       tenantStatus = "";
     }
-    return `{tenantContractId:${tenantContractId}, tenantState:${tenantStatus}}`;
+    return tenantStatus;
   }
 
   /**

--- a/src/ElvTenant.js
+++ b/src/ElvTenant.js
@@ -114,20 +114,7 @@ class ElvTenant {
       tenant.warns.push(`Bad space ID creator id=${tenant.creatorId}`);
     }
 
-    tenant.adminsGroup = await this.client.CallContractMethod({
-      contractAddress: tenantContractAddr,
-      abi: JSON.parse(abi),
-      methodName: "groupsMapping",
-      methodArgs: ["tenant_admin", 0],
-      formatArguments: true,
-    });
-    tenant.contentAdminsGroup = await this.client.CallContractMethod({
-      contractAddress: tenantContractAddr,
-      abi: JSON.parse(abi),
-      methodName: "groupsMapping",
-      methodArgs: ["content_admin", 0],
-      formatArguments: true,
-    });
+    tenant.tenantGroups = await this.TenantGroup({tenantContractId});
 
     // Fabric object information
     tenant.fabric_object_visibility = await this.client.CallContractMethod({
@@ -157,7 +144,7 @@ class ElvTenant {
 
     tenant.libs = await this.client.ContentLibraries();
     for (var i = 0; i < tenant.libs.length; i ++) {
-      const libTenantContractId = this.client.TenantContractId({
+      const libTenantContractId = await this.client.TenantContractId({
         contractAddress: Utils.HashToAddress(tenant.libs[i])
       });
 
@@ -170,7 +157,8 @@ class ElvTenant {
   }
 
   /**
-   * Return tenant admins group and content admins group corresponding to this tenant.
+   * Show tenant information like root key, tenant_admin, cotent_admin, tenant_user_group and metadata.
+   *
    * @param {string} tenantContractId - The ID of the tenant contract (iten***)
    * @param {boolean} show_metadata - show metadata of tenant
    */

--- a/src/ElvTenant.js
+++ b/src/ElvTenant.js
@@ -378,7 +378,7 @@ class ElvTenant {
     let tid = await this.client.TenantContractId({
       contractAddress: groupAddress
     });
-    if (typeof tid !== "undefined"){
+    if (tid !== ""){
       if (tid !== tenantContractId){
         throw Error(`Group ${groupAddress} has different tenant contract ID set to ${tid}, aborting...`);
       }
@@ -405,7 +405,7 @@ class ElvTenant {
       return {success: false, message: "on the tenant contract is not a group", need_format: true};
     }
 
-    //Retrieve tenant contract id assoicated with this group from the contract's metadata
+    //Retrieve tenant contract id assoicated with this group
     try {
       let groupTenantContractId = await this.client.TenantContractId({
         contractAddress: groupAddr,

--- a/src/ElvTenant.js
+++ b/src/ElvTenant.js
@@ -203,6 +203,8 @@ class ElvTenant {
     tenantInfo["groups"] = groupList;
     tenantInfo["tenant_root_key"] = owner;
 
+    tenantInfo["tenant_status"] = await this.TenantStatus({tenantContractId});
+
     if (show_metadata) {
       let services = [];
       let tenantObjectId = ElvUtils.AddressToId({prefix: "iq__", address: tenantContractAddr});

--- a/src/ElvTenant.js
+++ b/src/ElvTenant.js
@@ -1,6 +1,6 @@
 const { ElvUtils } = require("./Utils");
 const { ElvAccount } = require("./ElvAccount");
-const constants = require("./Constants")
+const constants = require("./Constants");
 
 const { ElvClient } = require("@eluvio/elv-client-js");
 const Utils = require("@eluvio/elv-client-js/src/Utils.js");
@@ -293,7 +293,7 @@ class ElvTenant {
 
     const tenantAddr = Utils.HashToAddress(tenantContractId);
 
-    if(groupType){
+    if (groupType){
       if (groupType !== constants.TENANT_ADMIN ||
         groupType !== constants.CONTENT_ADMIN ||
         groupType !== constants.TENANT_USER_GROUP){
@@ -304,11 +304,11 @@ class ElvTenant {
     const groupTypes = [constants.TENANT_ADMIN, constants.CONTENT_ADMIN, constants.TENANT_USER_GROUP];
 
     let groupList = [];
-    let groupAddress
+    let groupAddress;
     for (let i = 0; i < groupTypes.length; i++) {
-      if(typeof groupType === "undefined" || groupType === groupTypes[i]){
+      if (typeof groupType === "undefined" || groupType === groupTypes[i]){
         try {
-          let groupAddress = await this.client.CallContractMethod({
+          groupAddress = await this.client.CallContractMethod({
             contractAddress: tenantAddr,
             abi: JSON.parse(abi),
             methodName: "groupsMapping",
@@ -319,7 +319,7 @@ class ElvTenant {
           //call cannot override gasLimit error will be thrown if content admin group doesn't exist for this tenant.
           groupAddress = null;
         }
-        groupList.push({ [groupTypes[i]]:groupAddress})
+        groupList.push({ [groupTypes[i]]:groupAddress});
       }
     }
     return groupList;
@@ -381,7 +381,7 @@ class ElvTenant {
       });
 
       let newGroup = await elvAccount.CreateAccessGroup({
-        name: `${accountName} ${groupType.replace(/_/g, ' ').toUpperCase()}`,
+        name: `${accountName} ${groupType.replace(/_/g, " ").toUpperCase()}`,
       });
 
       groupAddress = newGroup.address;
@@ -492,7 +492,7 @@ class ElvTenant {
         contractAddress: tenantAddr,
         metadataKey: constants.TENANT_STATE
       });
-    }catch (e) {
+    } catch (e) {
       tenantStatus = "";
     }
     return `{tenantContractId:${tenantContractId}, tenantState:${tenantStatus}}`;

--- a/src/Provision.js
+++ b/src/Provision.js
@@ -119,10 +119,10 @@ const InitializeTenant = async ({client, kmsId, tenantId, debug=false}) => {
 
   let groupList = await client.TenantGroup({
     tenantContractId: tenantContractId,
-  })
-  const tenantAdminGroupAddress = groupList[constants.TENANT_ADMIN]
-  const contentAdminGroupAddress = groupList[constants.CONTENT_ADMIN]
-  const tenantUserGroupAddress = groupList[constants.TENANT_USER_GROUP]
+  });
+  const tenantAdminGroupAddress = groupList[constants.TENANT_ADMIN];
+  const contentAdminGroupAddress = groupList[constants.CONTENT_ADMIN];
+  const tenantUserGroupAddress = groupList[constants.TENANT_USER_GROUP];
 
   const contentViewersGroupAddress = await client.CreateAccessGroup({
     name: `${tenantName} Content Viewers`

--- a/src/Provision.js
+++ b/src/Provision.js
@@ -3,6 +3,7 @@ const fs = require("fs");
 const path = require("path");
 const { ElvUtils } = require("../src/Utils");
 const Utils = require("@eluvio/elv-client-js/src/Utils.js");
+const constants = require("Constants");
 
 const TYPE_LIVE_DROP_EVENT_SITE = "Eluvio LIVE Drop Event Site";
 const TYPE_LIVE_TENANT = "Eluvio LIVE Tenant";
@@ -99,38 +100,29 @@ const InitializeTenant = async ({client, kmsId, tenantId, debug=false}) => {
     throw Error("No tenant admin group set for account.");
   }
 
-  if (tenantId != tenantContractId) {
+  if (tenantId !== tenantContractId) {
     throw Error("Signer associated with different tenant", tenantId, tenantContractId);
   }
 
-  const tenantAddr = Utils.HashToAddress(tenantId);
+  const tenantContractAddr = Utils.HashToAddress(tenantId);
   const abi = fs.readFileSync(
     path.resolve(__dirname, "../contracts/v3/BaseTenantSpace.abi")
   );
 
   const tenantName = await client.CallContractMethod({
-    contractAddress: tenantAddr,
+    contractAddress: tenantContractAddr,
     abi: JSON.parse(abi),
     methodName: "name",
     methodArgs: [],
     formatArguments: true,
   });
 
-  let tenantAdminGroupAddress = await client.CallContractMethod({
-    contractAddress: tenantAddr,
-    abi: JSON.parse(abi),
-    methodName: "groupsMapping",
-    methodArgs : ["tenant_admin", 0],
-    formatArguments: true,
-  });
-  
-  let contentAdminGroupAddress = await client.CallContractMethod({
-    contractAddress: tenantAddr,
-    abi: JSON.parse(abi),
-    methodName: "groupsMapping",
-    methodArgs: ["content_admin", 0],
-    formatArguments: true,
-  });
+  let groupList = await client.TenantGroup({
+    tenantContractId: tenantContractId,
+  })
+  const tenantAdminGroupAddress = groupList[constants.TENANT_ADMIN]
+  const contentAdminGroupAddress = groupList[constants.CONTENT_ADMIN]
+  const tenantUserGroupAddress = groupList[constants.TENANT_USER_GROUP]
 
   const contentViewersGroupAddress = await client.CreateAccessGroup({
     name: `${tenantName} Content Viewers`
@@ -157,6 +149,7 @@ const InitializeTenant = async ({client, kmsId, tenantId, debug=false}) => {
   let groups = {
     tenantAdminGroupAddress,
     contentAdminGroupAddress,
+    tenantUserGroupAddress,
     contentViewersGroupAddress
   };
 
@@ -354,12 +347,12 @@ const InitializeTenant = async ({client, kmsId, tenantId, debug=false}) => {
     }
   };
 
-  let siteId = await CreateFabricObject({client, 
-    libraryId: propertiesLibraryId, 
-    typeId: titleCollectionTypeId, 
-    publicMetadata, 
-    tenantAdminGroupAddress, 
-    contentAdminGroupAddress, 
+  let siteId = await CreateFabricObject({client,
+    libraryId: propertiesLibraryId,
+    typeId: titleCollectionTypeId,
+    publicMetadata,
+    tenantAdminGroupAddress,
+    contentAdminGroupAddress,
     contentViewersGroupAddress});
 
   if (debug) {
@@ -386,12 +379,12 @@ const InitializeTenant = async ({client, kmsId, tenantId, debug=false}) => {
     }
   };
 
-  let marketplaceId = await CreateFabricObject({client, 
-    libraryId: propertiesLibraryId, 
-    typeId: liveTypeIds[TYPE_LIVE_MARKETPLACE], 
-    publicMetadata, 
-    tenantAdminGroupAddress, 
-    contentAdminGroupAddress, 
+  let marketplaceId = await CreateFabricObject({client,
+    libraryId: propertiesLibraryId,
+    typeId: liveTypeIds[TYPE_LIVE_MARKETPLACE],
+    publicMetadata,
+    tenantAdminGroupAddress,
+    contentAdminGroupAddress,
     contentViewersGroupAddress});
 
   if (debug) {
@@ -419,12 +412,12 @@ const InitializeTenant = async ({client, kmsId, tenantId, debug=false}) => {
     }
   };
 
-  let dropEventId = await CreateFabricObject({client, 
-    libraryId: propertiesLibraryId, 
-    typeId: liveTypeIds[TYPE_LIVE_DROP_EVENT_SITE], 
-    publicMetadata, 
-    tenantAdminGroupAddress, 
-    contentAdminGroupAddress, 
+  let dropEventId = await CreateFabricObject({client,
+    libraryId: propertiesLibraryId,
+    typeId: liveTypeIds[TYPE_LIVE_DROP_EVENT_SITE],
+    publicMetadata,
+    tenantAdminGroupAddress,
+    contentAdminGroupAddress,
     contentViewersGroupAddress});
 
   let dropEventHash = await client.LatestVersionHash({objectId: dropEventId});
@@ -460,12 +453,12 @@ const InitializeTenant = async ({client, kmsId, tenantId, debug=false}) => {
     }
   };
 
-  let tenantObjectId = await CreateFabricObject({client, 
-    libraryId: propertiesLibraryId, 
-    typeId: liveTypeIds[TYPE_LIVE_TENANT], 
-    publicMetadata, 
-    tenantAdminGroupAddress, 
-    contentAdminGroupAddress, 
+  let tenantObjectId = await CreateFabricObject({client,
+    libraryId: propertiesLibraryId,
+    typeId: liveTypeIds[TYPE_LIVE_TENANT],
+    publicMetadata,
+    tenantAdminGroupAddress,
+    contentAdminGroupAddress,
     contentViewersGroupAddress});
 
   if (debug) {

--- a/src/Provision.js
+++ b/src/Provision.js
@@ -3,7 +3,7 @@ const fs = require("fs");
 const path = require("path");
 const { ElvUtils } = require("../src/Utils");
 const Utils = require("@eluvio/elv-client-js/src/Utils.js");
-const constants = require("Constants");
+const constants = require("../src/Constants");
 
 const TYPE_LIVE_DROP_EVENT_SITE = "Eluvio LIVE Drop Event Site";
 const TYPE_LIVE_TENANT = "Eluvio LIVE Tenant";

--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -212,6 +212,7 @@ const CmdSpaceTenantDeploy = async ({ argv }) => {
   console.log(`Owner address: ${argv.owner_addr}`);
   console.log(`Tenant admin group address: ${argv.tenant_admin_addr}`);
   console.log(`Content admin group address: ${argv.content_admin_addr}`);
+  console.log(`Tenant user group address: ${argv.tenant_user_group_addr}`)
 
   try {
     let space = new ElvSpace({
@@ -227,6 +228,7 @@ const CmdSpaceTenantDeploy = async ({ argv }) => {
       ownerAddress: argv.owner_addr,
       tenantAdminGroupAddress: argv.tenant_admin_addr,
       contentAdminGroupAddress: argv.content_admin_addr,
+      tenantUserGroupAddress: argv.tenant_user_group_addr,
     });
 
     console.log(yaml.dump(res));
@@ -1848,6 +1850,10 @@ yargs(hideBin(process.argv))
           type: "string",
         })
         .positional("content_admin_addr", {
+          describe: "Address of the content admins groups",
+          type: "string",
+        })
+      .positional("tenant_user_group_addr", {
           describe: "Address of the content admins groups",
           type: "string",
         });

--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -398,6 +398,156 @@ const CmdTenantFixSuite = async({ argv }) => {
   }
 };
 
+const CmdSetTenantContractId = async ({objectId, contractAddress, versionHash, tenantContractId}) => {
+
+  let elvAccount = new ElvAccount({
+    configUrl: Config.networks[Config.net],
+    debugLogging: argv.verbose
+  });
+  await elvAccount.Init({
+    privateKey: process.env.PRIVATE_KEY,
+  });
+
+  const objTenantId = await elvAccount.client.TenantId({
+    objectId,
+    contractAddress,
+    versionHash,
+  });
+
+  if (objTenantId !== "") {
+    // get tenantContractId from tenantId
+    const tenantContractIdFromTenantAdminGrp = await elvAccount.client.TenantId({
+      objectId: objTenantId,
+    });
+    if (tenantContractIdFromTenantAdminGrp !== ""){
+      if (tenantContractIdFromTenantAdminGrp !== tenantContractId){
+        throw Error(`object tenantId have different tenantContractId set:
+          Given TenantId: ${tenantContractId}
+          From TenantId: ${tenantContractIdFromTenantAdminGrp},
+        `);
+      }
+      return `object has ${tenantContractId} already set`;
+    }
+  }
+
+  const res = await elvAccount.client.SetTenantContractId({
+    objectId,
+    contractAddress,
+    versionHash,
+    tenantContractId
+  });
+  return `object is set with tenantContractId ${res.tenantContractId} and tenantId ${res.tenantId}`;
+};
+
+const CmdTenantContractId = async ({objectId, contractAddress, versionHash}) => {
+
+  let elvAccount = new ElvAccount({
+    configUrl: Config.networks[Config.net],
+    debugLogging: argv.verbose
+  });
+  await elvAccount.Init({
+    privateKey: process.env.PRIVATE_KEY,
+  });
+
+  const objTenantContractId = await elvAccount.client.TenantContractId({
+    objectId,
+    contractAddress,
+    versionHash
+  });
+  return `object TenantContractId: ${objTenantContractId}`;
+};
+
+const CmdSetTenantId = async({objectId, contractAddress, versionHash, tenantId}) => {
+  let elvAccount = new ElvAccount({
+    configUrl: Config.networks[Config.net],
+    debugLogging: argv.verbose
+  });
+  await elvAccount.Init({
+    privateKey: process.env.PRIVATE_KEY,
+  });
+
+  // check if the tenant admin has tenant contract id set
+  const tenantContractId = await elvAccount.client.TenantContractId({
+    objectId: tenantId,
+  });
+  if (tenantContractId === ""){
+    throw Error("tenantId provided requires tenantContractId to be set, run tenant-fix command");
+  }
+
+  const objTenantId = await elvAccount.client.TenantId({
+    objectId,
+    contractAddress,
+    versionHash,
+  });
+  if (objTenantId !== "" && objTenantId !== tenantId) {
+    throw Error(` object provided have different tenantId set:
+       Object TenantId: ${objTenantId};
+       Given TenantId: ${tenantId};
+    `);
+  }
+
+  const res = await elvAccount.client.SetTenantId({
+    objectId,
+    contractAddress,
+    versionHash,
+  });
+  return `object is set with tenantId: ${res.tenantId} and tenantContractId: ${res.tenantContractId}`;
+};
+
+const CmdTenantId = async ({objectId, contractAddress, versionHash}) => {
+  let elvAccount = new ElvAccount({
+    configUrl: Config.networks[Config.net],
+    debugLogging: argv.verbose
+  });
+  await elvAccount.Init({
+    privateKey: process.env.PRIVATE_KEY,
+  });
+
+  const objTenantId = await elvAccount.client.TenantId({
+    objectId,
+    contractAddress,
+    versionHash
+  });
+  return `object TenantId: ${objTenantId}`;
+};
+
+const CmdRemoveTenant = async ({objectId, contractAddress, versionHash}) => {
+  let elvAccount = new ElvAccount({
+    configUrl: Config.networks[Config.net],
+    debugLogging: argv.verbose
+  });
+  await elvAccount.Init({
+    privateKey: process.env.PRIVATE_KEY,
+  });
+
+  await elvAccount.client.RemoveTenant({
+    objectId,
+    contractAddress,
+    versionHash
+  });
+
+  const tenantId = await elvAccount.client.TenantId({
+    objectId,
+    contractAddress,
+    versionHash
+  });
+  const tenantContractId = await elvAccount.client.TenantId({
+    objectId,
+    contractAddress,
+    vesionHash,
+  });
+
+  if (tenantId !== "" || tenantContractId !== "") {
+    throw Error(`Tenant details present in object: 
+      TenantId: ${tenantId},
+      TenantContractId: ${tenantContractId}
+    `);
+  }
+  return "Removed tenant details from object";
+};
+
+
+
 const CmdQuery = async ({ argv }) => {
   REP1V_TENANT_ADDRESSES = [
     "0x2c07551A4496c3E27E0311F6eBeDdc15b32297F6", "0x714c4Be6bCa847005aBb1Cb7AB3e80e3aaa4B4c0", "0x3cC0c93915d812D4faf3A061886B0DdfDdC13D48", "0xf23197d15ABC1366C5153ffc0D17Ef07943C4A39", "0xa9bA823bb963D589E36C53e06136dE9660541155", "0x9Ebd35e2a036f40a76F9142b563f94b020F9D96C", "0x7aFC069c78f576099b0A818A1cf492Ed621e9782", "0xA179b345dB18e2a42F85DF3913B4a23A131919B6", "0x4ecE33d9822A9F46a21684deEa1D26eC6f37CdbD", "0x1E56dE48412d58f5e4613C7B5D309e4919b55150", "0x1eD884a289580EC10D4c4a8d7115229BBF4fb7fA", "0x75136c2a738aE3Aac5A92F49BFa3b5038b971D33", "0xdbFB2c45e9F9B9b3254B52ddfBc3180AF36E37bD", "0xaE34E8d680D8f3F9287d76F37D73d485430aBB49", "0x36A83153f0A55D4691FA77057170E09382318144", "0x71F0Cacd8F4d3b44722C11B11e59B19e7E87B0ee", "0x452b05C729b08568A2289447c3f1Fc722461cA6b", "0xE8e3eB4e204F75e94dB84D0f1Bf397c351b020CC", "0xa15b57d8A2662B7fe5a66C633B0b06aE1A2062b7", "0x3475e7f8b6D324b75bEFcCaD1933d84Ed3e0e8C0", "0x95222A22d64B90cbA72e63860E5D18D597FC460f", "0xc12c0F82E510CB388cF5371bf9F086183bD854B1", "0xf78eaee6C000BB1df9401D0694E91B5c5e0FE80B", "0xa0d066Ad1FF8c6A91e9f26dF24E7f4EF1f00C28d", "0xBe0b80A31bb254E77BBD79299d847D3849aD1216", "0xd8E69D47B1BD9cF3dBfce212ee8724E18F88EDdA", "0x3864d2a2B02403cBA81DFb73b3eFc64313f5A52f", "0xB266F13cF7ad298ca5eECbd11Dd532b93C0B792D", "0x81602F301924F17D86Cbf2BF2Cd37DD056F3Ef62", "0xF86C0D46f941433D345b8D6ed2999616FE2f97DD", "0xA1e0896445c5868407E02943b79C274911C56388", "0x5293A4615dD587B59842C134ECb6A801AE811d92", "0xF2bDb066ED30D8D5594Ef36B199ceAA6D5f57777", "0x9D7F2966F8B6bdE35f4090295b281e39caA90760", "0x5621c53138824c233a012Ca03A66b6fBB71abDAA", "0x69a245795292a3771665ac028c30e132c13433eB", "0x3D81c153B6f86cDe641F3cc9f84CE1DAB098AFbB", "0x55A9521E1829D82D6511fA2ce65De4Ec6EDE6D1B", "0x6fFEe5d2D398992b125B3871284Bd4af7248C2a1", "0xe25d688f86e96517e41AdA42aa174533a7eed94E", "0x2a4C258b352f224f217EF26B7Fb044e3FfD8821F", "0x46c4e0cE270675f85ebe641Fde30ef1EF3F94290", "0x18A48C2DB800cde99fe7346F79E1c059205Cd5c8", "0x171cB30b3db328e7272ee532FDe9aBb85D868657", "0x6BcBECF5D51c61B243b7095fC13b94b01A1734eC", "0xf4BcBb526d90a53D2bbB2EEc4Ded6A535475EDC5", "0x8A64942Df99613c0618C75B3C14a6cAfF1987670", "0xA2b0ACA9b30ddC1fa82495AFBC77BEcaDBd30eEa", "0x741515714446dB947aa5246E79aCE4F9542d5550", "0x50C5b54be8005A45f81B049700aE43aae234D8F6", "0xe1d75c8D99aa9a3819F8c1CDbA9c908BC2267F87", "0xd34e10385FeB8598CcAfE267E34C5774ABC3742D", "0xF432fd18eC218c1D6A310B9066CaB51AEb0c6c3f", "0xA5fad4738e65c309F0E5E88198fecCAdf28Cdc52", "0x56a4f256425224aeCE3152E3E2DE94a1fAcB391f", "0x7829c4Cf39F3d7aEA5678E6fEd6969A8efe26090", "0x74414E5F2E07c594a11cbF9E5B7761B0B107754B", "0xA77dd02453D82f7038bA144e1abd1450DA9046Fc", "0x8Acf64e19e7420c52636F526B2FB0bC2752D3351", "0x947cC80fCD9718E15d9737dFDa7Db4675AD423e2", "0xa9c2c40aa14fC4057628801EAab484C4E0e998Aa", "0x2ecAEc97FC88aA25987791ae38559E2F8175B3c8"
@@ -1353,6 +1503,155 @@ yargs(hideBin(process.argv))
       CmdTenantFixSuite({ argv });
     }
   )
+
+
+  .command(
+    "set_tenant_contract_id <objectId> <contractAddress> <versionHash> <tenantContractId> [options]",
+    "Set tenant_contract_id and tenant_id to given object when tenantContractId is provided",
+    (yargs) => {
+      yargs
+        .positional("objectId", {
+          describe: "Object ID",
+          type: "string",
+        })
+        .positional("contractAddress", {
+          describe: "object address",
+          type: "string",
+        })
+        .positional("versionHash", {
+          describe: "object hash",
+          type: "string",
+        })
+        .positional("tenantContractId", {
+          describe: "tenant contract Id",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdSetTenantContractId({
+        objectId: argv.objectId,
+        contractAddress: argv.contractAddress,
+        versionHash: argv.versionHash,
+        tenantContractId: argv.tenantContractId,
+      });
+    }
+  )
+
+
+  .command(
+    "set_tenant_id <objectId> <contractAddress> <versionHash> <tenantContractId> [options]",
+    "Set tenant_contract_id and tenant_id to given object when tenantId is provided",
+    (yargs) => {
+      yargs
+        .positional("objectId", {
+          describe: "Object ID",
+          type: "string",
+        })
+        .positional("contractAddress", {
+          describe: "object address",
+          type: "string",
+        })
+        .positional("versionHash", {
+          describe: "object hash",
+          type: "string",
+        })
+        .positional("tenantId", {
+          describe: "tenant admin group Id",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdSetTenantId({
+        objectId: argv.objectId,
+        contractAddress: argv.contractAddress,
+        versionHash: argv.versionHash,
+        tenantId: argv.tenantId,
+      });
+    }
+  )
+
+  .command(
+    "tenant_contract_id <objectId> <contractAddress> <versionHash> [options]",
+    "Retrieve tenant_contract_id for given object",
+    (yargs) => {
+      yargs
+        .positional("objectId", {
+          describe: "Object ID",
+          type: "string",
+        })
+        .positional("contractAddress", {
+          describe: "object address",
+          type: "string",
+        })
+        .positional("versionHash", {
+          describe: "object hash",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdTenantContractId({
+        objectId: argv.objectId,
+        contractAddress: argv.contractAddress,
+        versionHash: argv.versionHash,
+      });
+    }
+  )
+
+  .command(
+    "tenant_id <objectId> <contractAddress> <versionHash> [options]",
+    "Retrieve tenant_id for given object",
+    (yargs) => {
+      yargs
+        .positional("objectId", {
+          describe: "Object ID",
+          type: "string",
+        })
+        .positional("contractAddress", {
+          describe: "object address",
+          type: "string",
+        })
+        .positional("versionHash", {
+          describe: "object hash",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdTenantId({
+        objectId: argv.objectId,
+        contractAddress: argv.contractAddress,
+        versionHash: argv.versionHash,
+      });
+    }
+  )
+
+
+  .command(
+    "remove_tenant <objectId> <contractAddress> <versionHash> [options]",
+    "Remove tenant_id and tenant_contract_id for given object",
+    (yargs) => {
+      yargs
+        .positional("objectId", {
+          describe: "Object ID",
+          type: "string",
+        })
+        .positional("contractAddress", {
+          describe: "object address",
+          type: "string",
+        })
+        .positional("versionHash", {
+          describe: "object hash",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdRemoveTenant({
+        objectId: argv.objectId,
+        contractAddress: argv.contractAddress,
+        versionHash: argv.versionHash,
+      });
+    }
+  )
+
 
   .command(
     "tenant_set_content_admins <tenant> [options]",

--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -243,7 +243,7 @@ const CmdSpaceTenantInfo = async ({ argv }) => {
     await t.Init({ privateKey: process.env.PRIVATE_KEY });
 
     res = await t.TenantInfo({
-      tenantId: argv.tenant
+      tenantContractId: argv.tenant
     });
 
     console.log(yaml.dump(res));
@@ -289,7 +289,7 @@ const CmdTenantFix = async({ argv }) => {
     await t.Init({ privateKey: process.env.PRIVATE_KEY });
 
     let res = await t.TenantShow({
-      tenantId: argv.tenant
+      tenantContractId: argv.tenant
     });
     let errors = res.errors;
     let unresolved = [];
@@ -307,16 +307,16 @@ const CmdTenantFix = async({ argv }) => {
       let error = errors[i];
       switch(error) {
         case 'missing content admins':
-          let addr = await t.TenantSetContentAdmins({tenantId: argv.tenant, contentAdminAddr: argv.content_admin_address});
+          let addr = await t.TenantSetContentAdmins({tenantContractId: argv.tenant, contentAdminAddr: argv.content_admin_address});
           console.log(`Set content admin group for tenant with tenantId ${argv.tenant} to ${addr}`);
           break;
 
         case `tenant admin group can't be verified or is not associated with any tenant`:
-          await t.TenantSetGroupConfig({tenantId: argv.tenant, groupAddress: res.tenant_admin_address});
+          await t.TenantSetGroupConfig({tenantContractId: argv.tenant, groupAddress: res.tenant_admin_address});
           break;
 
         case `content admin group can't be verified or is not associated with any tenant`:
-          await t.TenantSetGroupConfig({tenantId: argv.tenant, groupAddress: res.content_admin_address});
+          await t.TenantSetGroupConfig({tenantContractId: argv.tenant, groupAddress: res.content_admin_address});
           break;
 
         default:
@@ -483,7 +483,7 @@ const CmdQuery = async ({ argv }) => {
               formatArguments: true
             });
 
-            res = await t.TenantShow({tenantId: tenant_contract_id});
+            res = await t.TenantShow({tenantContractId: tenant_contract_id});
             if (!res.errors) {
               success_count += 1
               continue;
@@ -557,7 +557,7 @@ const CmdTenantSetContentAdmins = async ({ argv }) => {
     await t.Init({ privateKey: process.env.PRIVATE_KEY });
 
     let res = await t.TenantSetContentAdmins({
-      tenantId: argv.tenant,
+      tenantContractId: argv.tenant,
       contentAdminAddr: argv.content_admin_address,
     });
 
@@ -580,7 +580,7 @@ const CmdTenantRemoveContentAdmin = async ({ argv }) => {
     await t.Init({ privateKey: process.env.PRIVATE_KEY });
 
     let res = await t.TenantRemoveContentAdmin({
-      tenantId: argv.tenant,
+      tenantContractId: argv.tenant,
       contentAdminsAddress: argv.content_admin_address
     });
 

--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -2,6 +2,7 @@ const { ElvSpace } = require("../src/ElvSpace.js");
 const { ElvTenant } = require("../src/ElvTenant.js");
 const { ElvAccount } = require("../src/ElvAccount.js");
 const { ElvContracts } = require("../src/ElvContracts.js");
+const { ElvFabric } = require("../src/ElvFabric.js");
 const { Config } = require("../src/Config.js");
 const Ethers = require("ethers");
 
@@ -174,7 +175,10 @@ const CmdSpaceTenantCreate = async ({ argv }) => {
   console.log("Tenant Deploy");
   console.log(`Tenant name: ${argv.tenant_name}`);
   console.log(`Funds: ${argv.funds}`);
-  console.log(`verbose: ${argv.verbose}`);
+  if(argv.verbose !== undefined) {
+    console.log(`verbose: ${argv.verbose}`);
+  }
+
 
   try {
     let space = new ElvSpace({
@@ -264,7 +268,7 @@ const CmdTenantShow = async({ argv }) => {
     });
 
     console.log(yaml.dump(res));
-    if (res.errors) { 
+    if (res.errors) {
       console.log(`ERROR: tenant_show detected ${res.errors.length} error(s), run ./elv-admin tenant_fix ${argv.tenant} to resolve them.`);
     }
   } catch (e) {
@@ -306,7 +310,7 @@ const CmdTenantFix = async({ argv }) => {
           console.log(`Set content admin group for tenant with tenantId ${argv.tenant} to ${addr}`);
           break;
 
-        case `tenant admin group can't be verified or is not associated with any tenant`: 
+        case `tenant admin group can't be verified or is not associated with any tenant`:
           await t.TenantSetGroupConfig({tenantId: argv.tenant, groupAddress: res.tenant_admin_address});
           break;
 
@@ -382,7 +386,7 @@ const CmdTenantFixSuite = async({ argv }) => {
           });
           console.log(`Failed to set _ELV_TENANT_ID of ${lib} - doesn't belong to this account and can only be set by the account with address ${libOwner}`);
           failedLibraries.push(lib);
-        } 
+        }
       }
       if (failedLibraries.length == 0) {
         console.log('Tenant successfully fixed!');
@@ -484,17 +488,17 @@ const CmdQuery = async ({ argv }) => {
               continue;
             }
             failure_log.push({
-              owner: owner, 
-              tenant_contract_id: tenant_contract_id, 
-              tenant_admins_id: tenant_admins_id, 
+              owner: owner,
+              tenant_contract_id: tenant_contract_id,
+              tenant_admins_id: tenant_admins_id,
               libraries: tenant.libraries,
               fix_required: res.errors.length});
             failure_count += 1;
 
           } catch (e) {
             failure_log.push({
-              owner: owner, 
-              tenant_contract_id: tenant_contract_id, 
+              owner: owner,
+              tenant_contract_id: tenant_contract_id,
               tenant_admins_id: tenant_admins_id,
               libraries: tenant.libraries,
               errors: e.message});
@@ -566,7 +570,7 @@ const CmdTenantRemoveContentAdmin = async ({ argv }) => {
   console.log(`Removing a Content Admin from Tenant ${argv.tenant}`);
   console.log(`Removed Content Admin's Address: ${argv.content_admin_address}`);
   console.log("Network: " + Config.net);
-  
+
   try {
     let t = new ElvTenant({
       configUrl: Config.networks[Config.net],
@@ -747,7 +751,7 @@ const CmdFabricSetMetaBatch = async ({ argv }) => {
 };
 
 const CmdContractGetMeta = async ({ argv }) => {
-  console.log("Get Contract Metadata", 
+  console.log("Get Contract Metadata",
     `address: ${argv.addr}`,
     `key: ${argv.key}`,
     `verbose: ${argv.verbose}`);
@@ -774,7 +778,7 @@ const CmdContractGetMeta = async ({ argv }) => {
 };
 
 const CmdContractSetMeta = async ({ argv }) => {
-  console.log("Set Contract Metadata", 
+  console.log("Set Contract Metadata",
     `address: ${argv.addr}`,
     `key: ${argv.key}`,
     `value: ${argv.value}`,
@@ -803,7 +807,7 @@ const CmdContractSetMeta = async ({ argv }) => {
 };
 
 const CmdAccessGroupMember = async ({ argv }) => {
-  console.log("AccessGroupMember", 
+  console.log("AccessGroupMember",
     `group: ${argv.group}`,
     `addr: ${argv.addr}`);
 
@@ -829,7 +833,7 @@ const CmdAccessGroupMember = async ({ argv }) => {
 };
 
 const CmdAccessGroupMembers = async ({ argv }) => {
-  console.log("AccessGroupMembers", 
+  console.log("AccessGroupMembers",
     `group: ${argv.group}`);
 
   try {
@@ -1327,7 +1331,7 @@ yargs(hideBin(process.argv))
     "tenant_fix_suite <tenant> <content_admin_address> [options]",
     "Fix old-gen tenant",
     (yargs) => {
-      yargs 
+      yargs
         .positional("tenant", {
           describe: "Tenant ID",
           type: "string",

--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -49,7 +49,7 @@ const CmdAccountCreate = async ({ argv }) => {
     let res = await elvAccount.Create({
       funds: argv.funds,
       accountName: argv.account_name,
-      tenantId: argv.tenant,
+      tenantContractId: argv.tenant,
     });
 
     console.log(yaml.dump(res));
@@ -264,7 +264,7 @@ const CmdTenantShow = async({ argv }) => {
     await t.Init({ privateKey: process.env.PRIVATE_KEY });
 
     let res = await t.TenantShow({
-      tenantId: argv.tenant,
+      tenantContractId: argv.tenant,
       show_metadata: argv.show_metadata
     });
 

--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -292,6 +292,13 @@ const CmdTenantFix = async({ argv }) => {
     });
     await t.Init({ privateKey: process.env.PRIVATE_KEY });
 
+    if (argv.tenant_status) {
+      await t.TenantSetStatus({
+        tenantContractId,
+        tenantStatus: argv.tenant_status,
+      });
+    }
+
     let res = await t.TenantShow({
       tenantContractId: argv.tenant
     });
@@ -1560,6 +1567,15 @@ yargs(hideBin(process.argv))
           describe: "Address of the tenant user group",
           type: "string"
         })
+        .options("tenant_status", {
+          describe: "Status of tenant",
+          type: "string",
+          choices: [
+            constants.TENANT_STATE_ACTIVE,
+            constants.TENANT_STATE_INACTIVE,
+            constants.TENANT_STATE_FROZEN
+          ],
+        })
     },
     (argv) => {
       CmdTenantFix({ argv });
@@ -1586,6 +1602,15 @@ yargs(hideBin(process.argv))
         .options("libraries", {
           describe: "List of libraries that belong to this tenant",
           type: "array",
+        })
+        .options("tenant_status", {
+          describe: "Status of tenant",
+          type: "string",
+          choices: [
+            constants.TENANT_STATE_ACTIVE,
+            constants.TENANT_STATE_INACTIVE,
+            constants.TENANT_STATE_FROZEN
+          ],
         });
     },
     (argv) => {

--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -398,7 +398,7 @@ const CmdTenantFixSuite = async({ argv }) => {
   }
 };
 
-const CmdSetTenantContractId = async ({objectId, contractAddress, versionHash, tenantContractId}) => {
+const CmdSetTenantContractId = async ({objectId, tenantContractId}) => {
 
   let elvAccount = new ElvAccount({
     configUrl: Config.networks[Config.net],
@@ -410,8 +410,6 @@ const CmdSetTenantContractId = async ({objectId, contractAddress, versionHash, t
 
   const objTenantId = await elvAccount.client.TenantId({
     objectId,
-    contractAddress,
-    versionHash,
   });
 
   if (objTenantId !== "") {
@@ -439,7 +437,7 @@ const CmdSetTenantContractId = async ({objectId, contractAddress, versionHash, t
   return `object is set with tenantContractId ${res.tenantContractId} and tenantId ${res.tenantId}`;
 };
 
-const CmdTenantContractId = async ({objectId, contractAddress, versionHash}) => {
+const CmdTenantContractId = async ({objectId}) => {
 
   let elvAccount = new ElvAccount({
     configUrl: Config.networks[Config.net],
@@ -451,13 +449,11 @@ const CmdTenantContractId = async ({objectId, contractAddress, versionHash}) => 
 
   const objTenantContractId = await elvAccount.client.TenantContractId({
     objectId,
-    contractAddress,
-    versionHash
   });
   return `object TenantContractId: ${objTenantContractId}`;
 };
 
-const CmdSetTenantId = async({objectId, contractAddress, versionHash, tenantId}) => {
+const CmdSetTenantId = async({objectId, tenantId}) => {
   let elvAccount = new ElvAccount({
     configUrl: Config.networks[Config.net],
     debugLogging: argv.verbose
@@ -476,8 +472,6 @@ const CmdSetTenantId = async({objectId, contractAddress, versionHash, tenantId})
 
   const objTenantId = await elvAccount.client.TenantId({
     objectId,
-    contractAddress,
-    versionHash,
   });
   if (objTenantId !== "" && objTenantId !== tenantId) {
     throw Error(` object provided have different tenantId set:
@@ -488,13 +482,11 @@ const CmdSetTenantId = async({objectId, contractAddress, versionHash, tenantId})
 
   const res = await elvAccount.client.SetTenantId({
     objectId,
-    contractAddress,
-    versionHash,
   });
-  return `object is set with tenantId: ${res.tenantId} and tenantContractId: ${res.tenantContractId}`;
+  return `object ${objectId} is set with tenantId: ${res.tenantId} and tenantContractId: ${res.tenantContractId}`;
 };
 
-const CmdTenantId = async ({objectId, contractAddress, versionHash}) => {
+const CmdTenantId = async ({objectId}) => {
   let elvAccount = new ElvAccount({
     configUrl: Config.networks[Config.net],
     debugLogging: argv.verbose
@@ -505,13 +497,11 @@ const CmdTenantId = async ({objectId, contractAddress, versionHash}) => {
 
   const objTenantId = await elvAccount.client.TenantId({
     objectId,
-    contractAddress,
-    versionHash
   });
-  return `object TenantId: ${objTenantId}`;
+  return `${objectId} TenantId: ${objTenantId}`;
 };
 
-const CmdRemoveTenant = async ({objectId, contractAddress, versionHash}) => {
+const CmdTenantRemove = async ({objectId}) => {
   let elvAccount = new ElvAccount({
     configUrl: Config.networks[Config.net],
     debugLogging: argv.verbose
@@ -522,19 +512,13 @@ const CmdRemoveTenant = async ({objectId, contractAddress, versionHash}) => {
 
   await elvAccount.client.RemoveTenant({
     objectId,
-    contractAddress,
-    versionHash
   });
 
   const tenantId = await elvAccount.client.TenantId({
     objectId,
-    contractAddress,
-    versionHash
   });
-  const tenantContractId = await elvAccount.client.TenantId({
+  const tenantContractId = await elvAccount.client.TenantContractId({
     objectId,
-    contractAddress,
-    vesionHash,
   });
 
   if (tenantId !== "" || tenantContractId !== "") {
@@ -543,7 +527,7 @@ const CmdRemoveTenant = async ({objectId, contractAddress, versionHash}) => {
       TenantContractId: ${tenantContractId}
     `);
   }
-  return "Removed tenant details from object";
+  return `Removed tenant details from object ${objectId}`;
 };
 
 
@@ -707,7 +691,6 @@ const CmdTenantSetContentAdmins = async ({ argv }) => {
       tenantContractId: argv.tenant,
       contentAdminAddr: argv.content_admin_address,
     });
-
     console.log(yaml.dump(res));
   } catch (e) {
     console.error("ERROR:", e);
@@ -736,6 +719,51 @@ const CmdTenantRemoveContentAdmin = async ({ argv }) => {
     console.error("ERROR:", e);
   }
 };
+
+const CmdTenantSetTenantUserGroup = async ({ argv }) => {
+  console.log(`Setting a new tenant user group for Tenant ${argv.tenant}`);
+  console.log("Network: " + Config.net);
+
+  try {
+    let t = new ElvTenant({
+      configUrl: Config.networks[Config.net],
+      debugLogging: argv.verbose
+    });
+    await t.Init({ privateKey: process.env.PRIVATE_KEY });
+
+    let res = await t.TenantSetTenantUserGroup({
+      tenantContractId: argv.tenant,
+      tenantUserGroupAddr: argv.tenant_user_group_addr
+    });
+    console.log(yaml.dump(res));
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
+const CmdTenantRemoveTenantUserGroup = async ({ argv }) => {
+  console.log(`Removing a tenant user group from Tenant ${argv.tenant}`);
+  console.log("Network: " + Config.net);
+
+  try {
+    let t = new ElvTenant({
+      configUrl: Config.networks[Config.net],
+      debugLogging: argv.verbose
+    });
+    await t.Init({ privateKey: process.env.PRIVATE_KEY });
+
+    let res = await t.TenantRemoveTenantUserGroup({
+      tenantContractId: argv.tenant,
+      tenantUserGroupAddr: argv.tenant_user_group_addr
+    });
+
+    console.log(`Removed tenant user group Address: ${argv.tenant_user_group_addr}`);
+    console.log(yaml.dump(res));
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
 
 const CmdSpaceTenantSetEluvioLiveId = async ({ argv }) => {
   console.log("Tenant set Eluvio Live ID");
@@ -1506,20 +1534,12 @@ yargs(hideBin(process.argv))
 
 
   .command(
-    "set_tenant_contract_id <objectId> <contractAddress> <versionHash> <tenantContractId> [options]",
+    "set_tenant_contract_id <objectId> <tenantContractId> [options]",
     "Set tenant_contract_id and tenant_id to given object when tenantContractId is provided",
     (yargs) => {
       yargs
         .positional("objectId", {
           describe: "Object ID",
-          type: "string",
-        })
-        .positional("contractAddress", {
-          describe: "object address",
-          type: "string",
-        })
-        .positional("versionHash", {
-          describe: "object hash",
           type: "string",
         })
         .positional("tenantContractId", {
@@ -1530,29 +1550,18 @@ yargs(hideBin(process.argv))
     (argv) => {
       CmdSetTenantContractId({
         objectId: argv.objectId,
-        contractAddress: argv.contractAddress,
-        versionHash: argv.versionHash,
         tenantContractId: argv.tenantContractId,
       });
     }
   )
 
-
   .command(
-    "set_tenant_id <objectId> <contractAddress> <versionHash> <tenantContractId> [options]",
+    "set_tenant_id <objectId> <tenantContractId> [options]",
     "Set tenant_contract_id and tenant_id to given object when tenantId is provided",
     (yargs) => {
       yargs
         .positional("objectId", {
           describe: "Object ID",
-          type: "string",
-        })
-        .positional("contractAddress", {
-          describe: "object address",
-          type: "string",
-        })
-        .positional("versionHash", {
-          describe: "object hash",
           type: "string",
         })
         .positional("tenantId", {
@@ -1563,91 +1572,59 @@ yargs(hideBin(process.argv))
     (argv) => {
       CmdSetTenantId({
         objectId: argv.objectId,
-        contractAddress: argv.contractAddress,
-        versionHash: argv.versionHash,
         tenantId: argv.tenantId,
       });
     }
   )
 
   .command(
-    "tenant_contract_id <objectId> <contractAddress> <versionHash> [options]",
+    "tenant_contract_id <objectId> [options]",
     "Retrieve tenant_contract_id for given object",
     (yargs) => {
       yargs
         .positional("objectId", {
           describe: "Object ID",
           type: "string",
-        })
-        .positional("contractAddress", {
-          describe: "object address",
-          type: "string",
-        })
-        .positional("versionHash", {
-          describe: "object hash",
-          type: "string",
         });
     },
     (argv) => {
       CmdTenantContractId({
         objectId: argv.objectId,
-        contractAddress: argv.contractAddress,
-        versionHash: argv.versionHash,
       });
     }
   )
 
   .command(
-    "tenant_id <objectId> <contractAddress> <versionHash> [options]",
+    "tenant_id <objectId> [options]",
     "Retrieve tenant_id for given object",
     (yargs) => {
       yargs
         .positional("objectId", {
           describe: "Object ID",
           type: "string",
-        })
-        .positional("contractAddress", {
-          describe: "object address",
-          type: "string",
-        })
-        .positional("versionHash", {
-          describe: "object hash",
-          type: "string",
         });
     },
     (argv) => {
       CmdTenantId({
         objectId: argv.objectId,
-        contractAddress: argv.contractAddress,
-        versionHash: argv.versionHash,
       });
     }
   )
 
 
   .command(
-    "remove_tenant <objectId> <contractAddress> <versionHash> [options]",
+    "tenant_remove <objectId> [options]",
     "Remove tenant_id and tenant_contract_id for given object",
     (yargs) => {
       yargs
         .positional("objectId", {
           describe: "Object ID",
           type: "string",
-        })
-        .positional("contractAddress", {
-          describe: "object address",
-          type: "string",
-        })
-        .positional("versionHash", {
-          describe: "object hash",
-          type: "string",
         });
     },
     (argv) => {
-      CmdRemoveTenant({
+      CmdTenantRemove({
         objectId: argv.objectId,
-        contractAddress: argv.contractAddress,
-        versionHash: argv.versionHash,
       });
     }
   )
@@ -1688,6 +1665,44 @@ yargs(hideBin(process.argv))
     },
     (argv) => {
       CmdTenantRemoveContentAdmin({ argv });
+    }
+  )
+
+  .command(
+    "tenant_set_user_group <tenant> [options]",
+    "Set new tenant user group",
+    (yargs) => {
+      yargs
+        .positional("tenant", {
+          describe: "Tenant ID",
+          type: "string",
+        })
+        .options("tenant_user_group_address", {
+          describe: "Address of the tenant user groups",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdTenantSetTenantUserGroup({ argv });
+    }
+  )
+
+  .command(
+    "tenant_remove_user_group <tenant> <tenant_user_group_addr>",
+    "Remove a tenant user group",
+    (yargs) => {
+      yargs
+        .positional("tenant", {
+          describe: "Tenant ID",
+          type: "string",
+        })
+        .positional("tenant_user_group_addr", {
+          describe: "Tenant user group address",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdTenantRemoveTenantUserGroup({ argv });
     }
   )
 
@@ -2024,6 +2039,6 @@ yargs(hideBin(process.argv))
 
   .strict()
   .help()
-  .usage("EluvioLive Admin CLI\n\nUsage: elv-admin <command>")
+  .usage("Eluvio Live Admin CLI\n\nUsage: elv-admin <command>")
   .scriptName("")
   .demandCommand(1).argv;

--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -51,6 +51,7 @@ const CmdAccountCreate = async ({ argv }) => {
       accountName: argv.account_name,
       tenantId: argv.tenant,
     });
+
     console.log(yaml.dump(res));
   } catch (e) {
     console.error("ERROR:", e);
@@ -69,7 +70,7 @@ const CmdAccountSetTenantContractId = async ({ argv }) => {
     await elvAccount.InitWithId({
       privateKey: process.env.PRIVATE_KEY,
       id: argv.tenant,
-    })
+    });
     console.log("Success!");
   } catch (e) {
     console.error("ERROR:", e);

--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -471,7 +471,7 @@ const CmdSetTenantId = async({objectId, contractAddress, versionHash, tenantId})
     objectId: tenantId,
   });
   if (tenantContractId === ""){
-    throw Error("tenantId provided requires tenantContractId to be set, run tenant-fix command");
+    throw Error("tenantId provided requires tenantContractId to be set, run ./elv-admin tenant-fix command");
   }
 
   const objTenantId = await elvAccount.client.TenantId({
@@ -690,7 +690,7 @@ const CmdQuery = async ({ argv }) => {
   }
 
   return;
-}
+};
 
 const CmdTenantSetContentAdmins = async ({ argv }) => {
   console.log(`Setting a new content admin group for Tenant ${argv.tenant}`);

--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -60,7 +60,9 @@ const CmdAccountCreate = async ({ argv }) => {
 
 const CmdAccountSetTenantContractId = async ({ argv }) => {
   console.log("Account Set Tenant Contract ID\n");
-  console.log(`tenant_contract_id: ${argv.tenant}`);
+  console.log(`tenant_contract_id: ${argv.tenantContractId}`);
+  console.log(`tenant_admin: ${argv.tenantId}`)
+
 
   try {
     let elvAccount = new ElvAccount({
@@ -69,7 +71,8 @@ const CmdAccountSetTenantContractId = async ({ argv }) => {
     });
     await elvAccount.InitWithId({
       privateKey: process.env.PRIVATE_KEY,
-      id: argv.tenant,
+      tenantContractId: argv.tenantContractId,
+      tenantId: argv.tenantId,
     });
     console.log("Success!");
   } catch (e) {
@@ -355,7 +358,7 @@ const CmdTenantFixSuite = async({ argv }) => {
         throw Error(`The account with private key ${process.env.PRIVATE_KEY} is already associated with tenant ${tenantContractId}`);
       }
     } else {
-      elvAccount.SetAccountTenantContractId({ tenantId: argv.tenant });
+      await elvAccount.SetAccountTenantContractId({tenantContractId: argv.tenant});
     }
 
     //Set content admins group ID and fix problems related to the tenant and its admin groups
@@ -569,7 +572,6 @@ const CmdTenantSetContentAdmins = async ({ argv }) => {
 
 const CmdTenantRemoveContentAdmin = async ({ argv }) => {
   console.log(`Removing a Content Admin from Tenant ${argv.tenant}`);
-  console.log(`Removed Content Admin's Address: ${argv.content_admin_address}`);
   console.log("Network: " + Config.net);
 
   try {
@@ -584,6 +586,7 @@ const CmdTenantRemoveContentAdmin = async ({ argv }) => {
       contentAdminsAddress: argv.content_admin_address
     });
 
+    console.log(`Removed Content Admin's Address: ${argv.content_admin_address}`);
     console.log(yaml.dump(res));
   } catch (e) {
     console.error("ERROR:", e);
@@ -1112,13 +1115,19 @@ yargs(hideBin(process.argv))
   )
 
   .command(
-    "account_set_tenant <tenant>",
-    "Associate this account to the tenant - if an admins group ID is used, it will be converted to the tenant ID.",
+    "account_set_tenant <tenantContractId> [tenantId]",
+    "Associate this account to the tenant contract id and its tenant_admin group. " +
+    "We can provide tenantContractId or tenantId",
     (yargs) => {
-      yargs.option("tenant", {
-        describe: "Tenant contract ID (iten...)",
-        type: "string",
-      })
+      yargs
+        .positional("tenantContractId", {
+          describe: "Tenant contract ID (iten...)",
+          type: "string"
+        })
+        .positional("tenantId", {
+          describe: "Tenant admin group ID (iten...)",
+          type: "string"
+        });
     },
     (argv) => {
       CmdAccountSetTenantContractId({ argv });

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -374,7 +374,7 @@ const CmdTenantShow = async ({ argv }) => {
     await Init({ debugLogging: argv.verbose, asUrl: argv.as_url });
 
     let res = await elvlv.TenantShow({
-      tenantId: argv.tenant,
+      tenantContractId: argv.tenant,
       checkNft: argv.check_nfts,
     });
 
@@ -397,13 +397,13 @@ const CmdTenantSetTokenURI = async ({ argv }) => {
     console.log("csv ", argv?.csv);
   }
 
-  
+
   try {
     // Validate the token URI from the command line for single, all requests
     if ((argv.request_type != "batch") && (!(ElvUtils.IsValidURI(argv.new_token_uri)))) {
       console.log("Invalid token_uri: ", argv.new_token_uri);
       return;
-    } 
+    }
 
     await Init({debugLogging: argv.verbose, asUrl: argv.as_url});
 


### PR DESCRIPTION
**Added commands to:** 
* add, update and show tenant_status : active, inactive or frozen.
* add, remove and show tenant groups: tenant_admin, content_admin, tenant_user_group
* add and remove tenant contract id and tenant id from given object also from account

**Updated commands:**
* space_tenant_create : to add tenant_contract_id, tenant_user_group and set status to active
* account_set_tenant/ account_create/ group_create: to add tenant contract id and tenant id
* tenant_show: shows status and tenant_user_group
* tenant_fix: adds tenant_user_group and adds tenant status if provided

Requires **elv-client-js** PR: https://github.com/eluv-io/elv-client-js/pull/265

**Note:**
In `./elv-live` command:
* provision <tenant> : shows tenant_user_group (not able to test in dev environmant, since it required mainObjects)

**Commands Added/Changed:**
```
 tenant_show <tenant> [options]            Show info on this tenant
  tenant_fix <tenant> [options]             Fix tenant
  tenant_fix_suite <tenant>                 Fix old-gen tenant
  <content_admin_address>
  <tenant_user_group_address> [options]
  set_tenant_contract_id <objectId>         Set tenant_contract_id and tenant_id
  <tenantContractId> [options]              to given object when
                                            tenantContractId is provided
  set_tenant_id <objectId> <tenantId>       Set tenant_contract_id and tenant_id
  [options]                                 to given object when tenantId is
                                            provided
  tenant_contract_id <objectId> [options]   Retrieve tenant_contract_id for
                                            given object
  tenant_id <objectId> [options]            Retrieve tenant_id for given object
  tenant_remove <objectId> [options]        Remove tenant_id and
                                            tenant_contract_id for given object
  tenant_group <tenant> [group_type]        Retrieve all of specific group from
                                            tenant
  tenant_set_group <tenant> <group_type>    Set new content admin or user group
  [group_address]
  tenant_remove_group <tenant>              Remove tenant_admin, content_admin
  <group_type> <group_address>              or tenant_user_group address for
                                            give tenant
  tenant_set_status <tenant>                Set tenant status for give tenant
  <tenant_status>
  tenant_status <tenant>                    Get tenant status for give tenant

```

