### PR TITLE
add elv-live installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ From the elv-live-js directory, simply run:
 npm install
 ```
 
-to install the binaries `elv-live`, `elv-stream`, 'elv-admin` globally in your path
+to install the binaries `elv-live`, `elv-stream`, `elv-admin` globally in your path
 (eg, /opt/homebrew/bin/ on mac), use:
 
 ```

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ From the elv-live-js directory, simply run:
 npm install
 ```
 
+to install the binaries `elv-live`, `elv-stream`, 'elv-admin` globally in your path
+(eg, /opt/homebrew/bin/ on mac), use:
+
+```
+npm install -g
+```
+
 ## EluvioLive CLI
 
 The EluvioLive CLI (`elv-live`) provides tenant, token, and marketplace management commands.

--- a/elv-admin
+++ b/elv-admin
@@ -2,4 +2,14 @@
 
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-node $SOURCE_DIR/utilities/EluvioCli.js $* 
+
+if [ -e $SOURCE_DIR/utilities/EluvioCli.js ]
+then
+  node $SOURCE_DIR/utilities/EluvioCli.js $* 2>&1
+elif [ -e $SOURCE_DIR/../lib/node_modules/@eluvio/elv-live-js/utilities/EluvioCli.js ]
+then
+  node $SOURCE_DIR/../lib/node_modules/@eluvio/elv-live-js/utilities/EluvioCli.js $* 2>&1
+else
+  echo "(elv-live-js) cannot find utilities/EluvioCli.js" 1>&2
+  exit 1
+fi

--- a/elv-live
+++ b/elv-live
@@ -12,4 +12,3 @@ else
   echo "(elv-live-js) cannot find utilities/EluvioLiveCli.js" 1>&2
   exit 1
 fi
-

--- a/elv-live
+++ b/elv-live
@@ -9,6 +9,7 @@ elif [ -e $SOURCE_DIR/../lib/node_modules/@eluvio/elv-live-js/utilities/EluvioLi
 then
   node $SOURCE_DIR/../lib/node_modules/@eluvio/elv-live-js/utilities/EluvioLiveCli.js $* 2>&1
 else
-  echo "(elv-live-js) cannot find utilities/EluvioLiveCli.js"
+  echo "(elv-live-js) cannot find utilities/EluvioLiveCli.js" 1>&2
+  exit 1
 fi
 

--- a/elv-live
+++ b/elv-live
@@ -2,4 +2,13 @@
 
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-node $SOURCE_DIR/utilities/EluvioLiveCli.js $* 2>&1
+if [ -e $SOURCE_DIR/utilities/EluvioLiveCli.js ]
+then
+  node $SOURCE_DIR/utilities/EluvioLiveCli.js $* 2>&1
+elif [ -e $SOURCE_DIR/../lib/node_modules/@eluvio/elv-live-js/utilities/EluvioLiveCli.js ]
+then
+  node $SOURCE_DIR/../lib/node_modules/@eluvio/elv-live-js/utilities/EluvioLiveCli.js $* 2>&1
+else
+  echo "cannot find elv-live"
+fi
+

--- a/elv-live
+++ b/elv-live
@@ -9,6 +9,6 @@ elif [ -e $SOURCE_DIR/../lib/node_modules/@eluvio/elv-live-js/utilities/EluvioLi
 then
   node $SOURCE_DIR/../lib/node_modules/@eluvio/elv-live-js/utilities/EluvioLiveCli.js $* 2>&1
 else
-  echo "cannot find elv-live"
+  echo "(elv-live-js) cannot find utilities/EluvioLiveCli.js"
 fi
 

--- a/elv-stream
+++ b/elv-stream
@@ -2,4 +2,14 @@
 
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-node $SOURCE_DIR/utilities/EluvioLiveStreamCli.js $* 
+
+if [ -e $SOURCE_DIR/utilities/EluvioLiveStreamCli.js ]
+then
+  node $SOURCE_DIR/utilities/EluvioLiveStreamCli.js $* 2>&1
+elif [ -e $SOURCE_DIR/../lib/node_modules/@eluvio/elv-live-js/utilities/EluvioLiveStreamCli.js ]
+then
+  node $SOURCE_DIR/../lib/node_modules/@eluvio/elv-live-js/utilities/EluvioLiveStreamCli.js $* 2>&1
+else
+  echo "(elv-live-js) cannot find utilities/EluvioLiveStreamCli.js" 1>&2
+  exit 1
+fi

--- a/installer/elv-live-bin
+++ b/installer/elv-live-bin
@@ -1,5 +1,0 @@
-#! /usr/bin/env bash
-
-SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-node $SOURCE_DIR/../lib/node_modules/@eluvio/elv-live-js/utilities/EluvioLiveCli.js $* 2>&1

--- a/installer/elv-live-bin
+++ b/installer/elv-live-bin
@@ -1,0 +1,5 @@
+#! /usr/bin/env bash
+
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+node $SOURCE_DIR/../lib/node_modules/@eluvio/elv-live-js/utilities/EluvioLiveCli.js $* 2>&1

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.5.1",
   "description": "Eluvio Live SDK and Tools",
   "main": "EluvioLive.js",
+  "bin": {
+    "elv-live": "installer/elv-live-bin"
+   },
   "scripts": {
     "bump-version": "npm --git-tag-version --no-commit-hooks version patch",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Eluvio Live SDK and Tools",
   "main": "EluvioLive.js",
   "bin": {
-    "elv-live": "installer/elv-live-bin"
+    "elv-live": "elv-live"
    },
   "scripts": {
     "bump-version": "npm --git-tag-version --no-commit-hooks version patch",


### PR DESCRIPTION
will put a valid elv-live in /opt/homebrew/bin/ (or equiv) when running `npm i -g`


not sure if this is the appropriate thing to do or not, for getting elv-live in people's path (for use in scripts)

"worksforme"