### PR TITLE
Stream download support for offset and frames generation

### DIFF
--- a/src/LiveStream.js
+++ b/src/LiveStream.js
@@ -247,6 +247,8 @@ class EluvioLiveStream {
 
       let inputs = "";
       let inputs_map = "";
+      let makeFrameCmds = [];
+
       for (let mi = 0; mi < mts.length; mi ++) {
         let mt = mts[mi];
         inputs = inputs + " -i " + dpath + "/" + mt + ".mp4";
@@ -264,7 +266,7 @@ class EluvioLiveStream {
 
           if (i * 30 <= offset) {
             console.log(sources[i].hash, "skipped");
-            continue
+            continue;
           }
 
           console.log(sources[i].hash);
@@ -291,13 +293,18 @@ class EluvioLiveStream {
               console.log(err);
           });
 
-          makeFrame = false;
-          if (makeFrame) {
-            const cmd = "ffmpeg -i " + partfile+ " -vframes 1 -update 1 -q:v 1 " + partfile + ".jpg"
-            console.log("Frame cmd", cmd);
-            execSync(cmd);
+          if (makeFrame && mt.includes("video")) {
+            const makeFrameCmd = "ffmpeg -i " + partfile+ " -vframes 1 -update 1 -q:v 1 " + mtpath + "/" + partHash + ".jpg";
+            makeFrameCmds.push(makeFrameCmd);
           }
+        }
 
+        // Make frames from parts
+        if (makeFrame && mt.includes("video")) {
+          for (let i = 0; i < makeFrameCmds.length - 1; i++) {
+            console.log("Frame cmd", makeFrameCmds[i]);
+            execSync(makeFrameCmds[i]);
+          }
         }
 
         // Concatenate parts into one mp4

--- a/src/LiveStream.js
+++ b/src/LiveStream.js
@@ -301,7 +301,7 @@ class EluvioLiveStream {
 
         // Make frames from parts
         if (makeFrame && mt.includes("video")) {
-          for (let i = 0; i < makeFrameCmds.length - 1; i++) {
+          for (let i = 0; i < makeFrameCmds.length; i++) {
             console.log("Frame cmd", makeFrameCmds[i]);
             execSync(makeFrameCmds[i]);
           }

--- a/src/LiveStream.js
+++ b/src/LiveStream.js
@@ -173,7 +173,7 @@ class EluvioLiveStream {
     return this.client.StreamInsertion({name, insertionTime, sinceStart, duration, targetHash, remove});
   }
 
-  async StreamDownload({name, period}) {
+  async StreamDownload({name, period, offset, makeFrame}) {
 
     let objectId = name;
     let status = {name};
@@ -261,7 +261,14 @@ class EluvioLiveStream {
         !fs.existsSync(mtpath) && fs.mkdirSync(mtpath);
         var sources = recording.sources[mt].parts;
         for (let i = 0; i < sources.length - 1; i++) {
+
+          if (i * 30 <= offset) {
+            console.log(sources[i].hash, "skipped");
+            continue
+          }
+
           console.log(sources[i].hash);
+
           let partHash = sources[i].hash;
           let buf = await this.client.DownloadPart({
             libraryId,
@@ -283,6 +290,14 @@ class EluvioLiveStream {
             if (err)
               console.log(err);
           });
+
+          makeFrame = false;
+          if (makeFrame) {
+            const cmd = "ffmpeg -i " + partfile+ " -vframes 1 -update 1 -q:v 1 " + partfile + ".jpg"
+            console.log("Frame cmd", cmd);
+            execSync(cmd);
+          }
+
         }
 
         // Concatenate parts into one mp4

--- a/utilities/EluvioLiveStreamCli.js
+++ b/utilities/EluvioLiveStreamCli.js
@@ -183,7 +183,7 @@ const CmdStreamDownload = async ({ argv }) => {
       privateKey: process.env.PRIVATE_KEY,
     });
 
-    let status = await elvStream.StreamDownload({name: argv.stream, period: argv.period});
+    let status = await elvStream.StreamDownload({name: argv.stream, period: argv.period, offset: argv.offset});
     console.log(yaml.dump(status));
   } catch (e) {
     console.error("ERROR:", e);
@@ -544,7 +544,13 @@ yargs(hideBin(process.argv))
             "Download a specific recording period (instead of the lastone)",
           type: "int",
         })
-    },
+        .option("offset", {
+          describe:
+            "Start downloading at this offset (seconds).",
+          type: "int",
+        })
+
+      },
     (argv) => {
       CmdStreamDownload({ argv });
     }

--- a/utilities/EluvioLiveStreamCli.js
+++ b/utilities/EluvioLiveStreamCli.js
@@ -183,7 +183,7 @@ const CmdStreamDownload = async ({ argv }) => {
       privateKey: process.env.PRIVATE_KEY,
     });
 
-    let status = await elvStream.StreamDownload({name: argv.stream, period: argv.period, offset: argv.offset});
+    let status = await elvStream.StreamDownload({name: argv.stream, period: argv.period, offset: argv.offset, makeFrame: argv.frames});
     console.log(yaml.dump(status));
   } catch (e) {
     console.error("ERROR:", e);
@@ -548,6 +548,11 @@ yargs(hideBin(process.argv))
           describe:
             "Start downloading at this offset (seconds).",
           type: "int",
+        })
+        .option("frames", {
+          describe:
+            "Create a frame JPG for each video part",
+          type: "bool",
         })
 
       },


### PR DESCRIPTION
Offset is specified in seconds since the start of the stream recording period.
Frames are generated in the 'video' directory (JPGs)

Example:

```
./elv-stream download iq__21LdDBzSjczHjoG9gnSJWfkB84tJ --offset 3600 --frames
```