### PR TITLE
Add support for creating new object in stream copy as VoD

### DIFF
--- a/utilities/EluvioLiveStreamCli.js
+++ b/utilities/EluvioLiveStreamCli.js
@@ -247,6 +247,7 @@ const CmdStreamCopyToVod = async ({ argv }) => {
     let status = await elvStream.StreamCopyToVod({
       name: argv.stream,
       object: argv.object,
+      library: argv.library,
       eventId: argv.event_id,
       startTime: argv.start_time,
       endTime: argv.end_time,
@@ -574,6 +575,11 @@ yargs(hideBin(process.argv))
         .option("object", {
           describe:
             "Copy to an existing object instead of creating a new one",
+          type: "string",
+        })
+        .option("library", {
+          describe:
+            "Copy to a new object in this library",
           type: "string",
         })
         .option("event_id", {

--- a/utilities/Tools.js
+++ b/utilities/Tools.js
@@ -1,0 +1,62 @@
+const { EluvioLiveStream } = require("../src/LiveStream.js");
+const { Config } = require("../src/Config.js");
+
+const got = require("got");
+const { HTTPError } = require('got')
+
+// hack that quiets this msg:
+//  node:87980) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
+//  (Use `node --trace-warnings ...` to show where the warning was created)
+const originalEmit = process.emit;
+process.emit = function (name, data, ...args) {
+  if(name === `warning` && typeof data === `object` && data.name === `ExperimentalWarning`) {
+    return false;
+  }
+  return originalEmit.apply(process, arguments);
+};
+
+const hdr = {
+  "X-Content-Fabric-Trace": "enable"
+};
+
+const CheckMezSegment = async({}) => {
+
+}
+
+
+const LiveStreamParameters = async({}) => {
+
+  const fpsList = [
+    new Fraction(24000, 1001),
+    new Fraction(24),
+    new Fraction(25),
+    new Fraction(30000, 1001),
+    new Fraction(30),
+    new Fraction(60000, 1001),
+    new Fraction(60)
+  ];
+
+  for (let i = 0;i < fpsList.length; i++) {
+    const fps = fpsList[i];
+    console.log(fps);
+  }
+
+  // RTMP
+
+
+
+  // MPEGTS
+
+}
+
+const Run = async ({}) => {
+  try {
+
+    LiveStreamParameters({});
+
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
+Run({});


### PR DESCRIPTION
Add a new option to `elv-stream copy_as_vod`: `--library ilib*`
One of `--object` or `--library` is required. If both specified then `--object` takes precedence.

Usage:

```
./elv-stream copy_as_vod
 copy_as_vod <stream>

Copy the stream to a new VoD object.

Positionals:
  stream  Stream name or QID (content ID)                    [string] [required]

Options:
      --version           Show version number                          [boolean]
  -v, --verbose           Verbose mode                                 [boolean]
      --url               Optional node endpoint (eg.
                          https://host-x-x-x-x.contentfabric.io)        [string]
      --help              Show help                                    [boolean]
      --object            Copy to an existing object instead of creating a new
                          one                                           [string]
      --library           Copy to a new object in this library          [string]
      --event_id          Optional SCTE35 program or chapter event ID   [string]
      --end_time          End at the specified time in the stream       [string]
      --recording_period  Use only the specified recording period
      --streams           List specific streams to be copied (eg.
                          'video:0,audio:1,audio_spa:2')                [string]
```

Example:
```
./elv-stream copy_as_vod iq__2mgMKL39Zb5Z4ESoLP3Lg8bcEacZ --library ilib4HjZxzmrTuhSEZBFXynsvpatdVJN
```

The name is automatically generated like so:

```
VOD - Live Stream iq__2mgMKL39Zb5Z4ESoLP3Lg8bcEacZ - 2024-06-26T00:46:52.202Z
```