### PR TITLE
fix-tenant-show-no-marketplace-items

### DIFF
--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -349,7 +349,7 @@ class EluvioLive {
       tenantInfo.marketplaces[key] = {};
       tenantInfo.marketplaces[key].items = {};
       tenantInfo.marketplaces[key].summary = {};
-      var totalNfts = m.marketplaces[key].info.items.length || 0;
+      var totalNfts = m.marketplaces[key]?.info?.items?.length || 0;
       tenantInfo.marketplaces[key].summary.total_nfts = totalNfts;
 
       var totalMinted = 0;
@@ -358,7 +358,7 @@ class EluvioLive {
       var topMintedValue = 0;
       var topMintedList = [];
 
-      for (var i in m.marketplaces[key].info.items) {
+      for (var i in m.marketplaces[key]?.info?.items) {
         const item = m.marketplaces[key].info.items[i];
 
         const sku = item.sku;
@@ -3399,9 +3399,7 @@ class EluvioLive {
 
       latestVersionHash = await this.client.LatestVersionHash({objectId});
       contentHash = latestVersionHash;
-      if (this.debug){
-        console.log("Update links latest version hash: ", contentHash, " object Id ", objectId, " library Id ", libraryId);
-      }
+      console.log("Submitting latest version hash:", contentHash, "objectId:", objectId, "libraryId:", libraryId);
     }
 
     let tenantConfigResult = null;

--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -3399,7 +3399,9 @@ class EluvioLive {
 
       latestVersionHash = await this.client.LatestVersionHash({objectId});
       contentHash = latestVersionHash;
-      console.log("Submitting latest version hash:", contentHash, "objectId:", objectId, "libraryId:", libraryId);
+      if (this.debug) {
+        console.log("Submitting latest version hash:", contentHash, "objectId:", objectId, "libraryId:", libraryId);
+      }
     }
 
     let tenantConfigResult = null;

--- a/src/LiveStream.js
+++ b/src/LiveStream.js
@@ -387,7 +387,7 @@ class EluvioLiveStream {
     // If a target object is not specified, create it here
     if (object == undefined) {
       if (library == undefined) {
-        throw "one of object or library must be specified"
+        throw "one of object or library must be specified";
       }
       const typeId = await this.FindContentType({label: "title"});
       if (typeId == undefined) {


### PR DESCRIPTION
fix for marketplace w/ no items.

---

when running the marketplace billing for Warner, I get an error.

```
Tenant - show iten29j4CvEN5FwVK7Vpdsd9zvi7hF3f
check_nfts undefined
Network: main
(node:66492) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
minterConfig:  {
  config: {
    transfer_proxy_address: '0xB9d966e8ED09124bFb70Efa2b8ab7D20B8FDfEA2',
    minter_address: '0x6F11fA091Ee9D2a6D71b397B633bFf4668c11875',
    minter: 'ikms2YkSJrVY9C4fUZUbLFfc7QTqjjEC',
    proxy_owner_address: '0x0512556115025CCf39eFcD166b07568c3e239D03',
    proxy_owner: 'ikms56grkwy8o7ECYpMUdbfR5ak8zW6',
    minter_helper: '0x54C7FffEa31533Cac08c747a61c9e361536db7Dc',
    mint_shuffle_key_id: '',
    legacy_shuffle_seed: ''
  }
}
ERROR: TypeError: Cannot read properties of undefined (reading 'items')
    at EluvioLive.TenantShow (/Users/marc-olivier/ELV/elv-live-js/src/EluvioLive.js:341:48)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async CmdTenantShow (/Users/marc-olivier/ELV/elv-live-js/utilities/EluvioLiveCli.js:337:15)
As of Wed Jul 3 17:27:54 UTC 2024
```

```
$ ./elv-live tenant_show iten29j4CvEN5FwVK7Vpdsd9zvi7hF3f
```

https://eluvio.slack.com/archives/C06HNF6FEPJ/p1720053359375969


