### PR TITLE
better show-owners missing data msg

### DIFF
--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -1520,7 +1520,7 @@ class EluvioLive {
           delete nftInfo.tokens[i].token_owner;
           delete nftInfo.tokens[i].token_uri;
         } catch (e) {
-          warns.push("Failed to re-process token ID (index: " + i + ") for " + addr + ", error: " + e +
+          warns.push("Failed to process token " + addr + " index " + i + "/" + (totalSupply-1) + ", error: " + e +
             ", token: " + JSON.stringify(nftInfo.tokens[i]));
           continue;
         }

--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -1489,6 +1489,11 @@ class EluvioLive {
       }
 
       for (var i = 0; i < maxShowOwners && i < nftInfo.totalSupply; i++) {
+        if (nftInfo.tokens[i] === undefined) {
+          warns.push("missing token information for index " + i + " of " + (totalSupply-1) + " (totalSupply=" + totalSupply +
+            "); likely the blockchain indexer is not up to date; try using --show_owners_via_contract instead.");
+          continue;
+        }
         try {
           // adapt to format:
           // hold -> holdSecs
@@ -1515,7 +1520,8 @@ class EluvioLive {
           delete nftInfo.tokens[i].token_owner;
           delete nftInfo.tokens[i].token_uri;
         } catch (e) {
-          warns.push("Failed to re-process token ID (index: " + i + "): " + addr);
+          warns.push("Failed to re-process token ID (index: " + i + ") for " + addr + ", error: " + e +
+            ", token: " + JSON.stringify(nftInfo.tokens[i]));
           continue;
         }
 


### PR DESCRIPTION

for `elv-live nft_show --show_owners`, make this msg:

```
warns:
  - >-
    Failed to re-process token ID (index: 50):
    0xd706aa21d627390c386198a09972a7a599a12f43
```
into
```
    missing token information for index 50 of 50 (totalSupply=51); likely the
    blockchain indexer is not up to date; try using --show_owners_via_contract
    instead.
```

for when the data is missing

(the prod blockchain indexer is currently lagging, which causes this)