### PR TITLE
add env to tenant-publish

### DIFF
--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -3394,9 +3394,13 @@ class EluvioLive {
     * @param {string} tenant - The Tenant ID
     * @param {string} host - Authority Service url (Optional)
     * @param {string} contentHash - Version hash of the new Tenant Object to submit
+    * @param {boolean} updateLinks - True to update links
+    * @param {string} env - Environment to update -- "production" or "staging", default production
     * @return {Promise<Object>} - The API Response for the request
     */
-  async TenantPublishData({tenant, host, contentHash, updateLinks=false}) {
+  async TenantPublishData(
+    {tenant, host, contentHash, updateLinks=false, env="production"}
+  ) {
     let latestVersionHash = contentHash;
     if (updateLinks){
       let objectId = this.client.utils.DecodeVersionHash(contentHash).objectId;
@@ -3413,7 +3417,8 @@ class EluvioLive {
     let tenantConfigResult = null;
 
     var body = {
-      content_hash: contentHash
+      content_hash: contentHash,
+      env: env,
     };
 
     let res = await this.PostServiceRequest({

--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -3398,9 +3398,7 @@ class EluvioLive {
     * @param {string} env - Environment to update -- "production" or "staging", default production
     * @return {Promise<Object>} - The API Response for the request
     */
-  async TenantPublishData(
-    {tenant, host, contentHash, updateLinks=false, env="production"}
-  ) {
+  async TenantPublishData({tenant, host, contentHash, updateLinks=false, env="production"}) {
     let latestVersionHash = contentHash;
     if (updateLinks){
       let objectId = this.client.utils.DecodeVersionHash(contentHash).objectId;

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -397,13 +397,13 @@ const CmdTenantSetTokenURI = async ({ argv }) => {
     console.log("csv ", argv?.csv);
   }
 
-  
+
   try {
     // Validate the token URI from the command line for single, all requests
     if ((argv.request_type != "batch") && (!(ElvUtils.IsValidURI(argv.new_token_uri)))) {
       console.log("Invalid token_uri: ", argv.new_token_uri);
       return;
-    } 
+    }
 
     await Init({debugLogging: argv.verbose, asUrl: argv.as_url});
 
@@ -1508,6 +1508,7 @@ const CmdTenantPublishData  = async ({ argv }) => {
   console.log(`TenantId: ${argv.tenant}`);
   console.log(`Content Hash: ${argv.content_hash}`);
   console.log(`Update Links: ${argv.update_links}`);
+  console.log(`Env: ${argv.env}`);
   console.log(`Host: ${argv.as_url}`);
 
   try {
@@ -1516,7 +1517,8 @@ const CmdTenantPublishData  = async ({ argv }) => {
     let res = await elvlv.TenantPublishData({
       tenant: argv.tenant,
       contentHash: argv.content_hash,
-      updateLinks: argv.update_links
+      updateLinks: argv.update_links,
+      env: argv.env,
     });
 
     console.log("\n" + yaml.dump(res));
@@ -3126,6 +3128,10 @@ yargs(hideBin(process.argv))
         .option("update_links", {
           describe: "Update links on your tenant Fabric object",
           type: "boolean",
+        })
+        .option("env", {
+          describe: "Environment to use, 'staging' or 'production' (default: production)",
+          type: "string",
         });
     },
     (argv) => {


### PR DESCRIPTION
use the new authd staging tenant PostConfigMeta
`/tnt/config/:tid/metadata [POST]`

previously required a POST body with `{ "content_hash": <hash> }`; it now also accepts an optional env:  `{ "content_hash": <hash>, "env": "staging" }` and will publish to the matching live object.

