### PR TITLE
fix account cmds

### DIFF
--- a/src/ElvAccount.js
+++ b/src/ElvAccount.js
@@ -119,9 +119,7 @@ class ElvAccount {
       await client.userProfileClient.CreateWallet();
 
       if (tenantId) {
-
-        await this.SetAccountTenantContractId({tenantId});
-
+        await client.userProfileClient.SetTenantContractId({tenantContractId: tenantId});
         await client.userProfileClient.SetTenantId({
           address: tenantAdminsAddr,
         });
@@ -283,7 +281,7 @@ class ElvAccount {
   }
 
   async ReplaceStuckTx({nonce}){
-    const newNonce = nonce? nonce : await this.signer.getTransactionCount("latest") // provides confirmed nonce
+    const newNonce = nonce? nonce : await this.signer.getTransactionCount("latest"); // provides confirmed nonce
     console.log("nonce:", newNonce);
 
     // get the current gas price from the Ethereum network


### PR DESCRIPTION
The method `this.SetAccountTenantContractId({tenantId});` sets the tenant contract ID for the user provided as private_key in the env variable. This method has been added to elv-client-js as SetTenantContractId({tenantContractId: tenantId});, which performs a similar function for the new account created.

**account_create:**
```
./elv-admin account_create 0.9 test_acct_123 iten2eQcZKr7y47hJkoS7crja61bf8E9
Account Create

funds: 0.9
account_name: test_acct_123
tenant: iten2eQcZKr7y47hJkoS7crja61bf8E9
0xf82a730644e83635a970F834B006bDc151B57023
accountName: test_acct_123
address: '0xC4575588144F2fCE99C226aa5D3578aA26983260'
mnemonic: enter tell allow tide canvas silly pepper fly fine valid breeze ice
privateKey: '0xd4778e98a959762ce31ddb5439643b4c91c66a9d8139e839c22f35085656a312'
balance: '0.892072466957719824'
tenantId: iten2eQcZKr7y47hJkoS7crja61bf8E9

```

**account_show:**
```
 ./elv-admin account_show
Account Show

address: '0xC4575588144F2fCE99C226aa5D3578aA26983260'
userId: iusr3jekzW42bhPTTGHdHwCT4weaACUX
tenantId: iten2eQcZKr7y47hJkoS7crja61bf8E9
tenantAdminsId: itenp6z6A9UDuvAUh7FdGpVDkkJZzXr
walletAddress: '0xf82a730644e83635a970F834B006bDc151B57023'
userWalletObject:
  libraryId: ilib2z2L47nE9GokWE7ePJWujt2TS4sD
  objectId: iq__4TXanGrZXyiQRiVhHbsTxUJ8yMQE
userMetadata:
  commit:
    author: '0xc4575588144f2fce99c226aa5d3578aa26983260'
    author_address: '0xc4575588144f2fce99c226aa5d3578aa26983260'
    message: Replace user metadata
    timestamp: '2024-08-29T19:46:07.489Z'
  public:
    name: test_acct_123
  tenantId: itenp6z6A9UDuvAUh7FdGpVDkkJZzXr
balance: '0.892072466957719824'
```

