### PR TITLE
add new args to create-wallet-account & fix tenant_auth_curl & add tenant_path_auth_curl

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -1,4 +1,4 @@
-const net = "main"; // Set to "main"  "demov3" "test" "dev"
+const net = "demov3"; // Set to "main"  "demov3" "test" "dev"
 
 const networks = {
   main: "https://main.net955305.contentfabric.io",

--- a/src/Config.js
+++ b/src/Config.js
@@ -1,4 +1,4 @@
-const net = "demov3"; // Set to "main"  "demov3" "test" "dev"
+const net = "main"; // Set to "main"  "demov3" "test" "dev"
 
 const networks = {
   main: "https://main.net955305.contentfabric.io",

--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -3161,7 +3161,7 @@ class EluvioLive {
    * create account for tenant
    *
    * @namedParams
-   * @param {string} email - The email to create
+   * @param {string} email - The email to create, or @filename to read a list of emails from file
    * @param {string} tenant - The Tenant ID
    * @param {string} callbackUrl - The base URL info for the link in the email
    * @param {boolean} onlyCreateAccount - only create the account
@@ -3171,21 +3171,41 @@ class EluvioLive {
    */
   async CreateWalletAccount({ email, tenant, callbackUrl, onlyCreateAccount, onlySendEmail, scheduleAt}) {
     let headers = {};
-
+    let res = "";
     console.log("email", email, "tenant", tenant, "callbackUrl", callbackUrl,
       "onlyCreateAccount", onlyCreateAccount, "onlySentEmail", onlySendEmail, "scheduleAt", scheduleAt);
 
-    let urlPath = "/wlt/ory/create_account";
-    let res = await this.PostServiceRequest({
-      path: urlPath,
-      body: {
-        email, tenant, "callback_url": callbackUrl,
-        "only_create_account": onlyCreateAccount,
-        "only_send_email": onlySendEmail,
-        "schedule_at": scheduleAt
-      },
-      headers,
-    });
+    // if email is a file, read the file
+    if (email.startsWith("@")) {
+      let emails = fs.readFileSync(email.slice(1), "utf-8").split(/\r?\n/);
+      let urlPath = "/wlt/ory/create_bulk_accounts";
+      res = await this.PostServiceRequest({
+        path: urlPath,
+        body: {
+          emails,
+          tenant,
+          "callback_url": callbackUrl,
+          "only_create_account": onlyCreateAccount,
+          "only_send_email": onlySendEmail,
+          "schedule_at": scheduleAt
+        },
+        headers,
+      });
+    } else {
+      let urlPath = "/wlt/ory/create_account";
+      res = await this.PostServiceRequest({
+        path: urlPath,
+        body: {
+          email,
+          tenant,
+          "callback_url": callbackUrl,
+          "only_create_account": onlyCreateAccount,
+          "only_send_email": onlySendEmail,
+          "schedule_at": scheduleAt
+        },
+        headers,
+      });
+    }
 
     return await res.json();
   }

--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -3164,17 +3164,26 @@ class EluvioLive {
    * @param {string} email - The email to create
    * @param {string} tenant - The Tenant ID
    * @param {string} callbackUrl - The base URL info for the link in the email
+   * @param {boolean} onlyCreateAccount - only create the account
+   * @param {boolean} onlySendEmail - only send email, do not create the account
+   * @param {string} scheduleAt - when to schedule the email
    * @return {Promise<Object>} - The API Response containing created account info
    */
-  async CreateWalletAccount({ email, tenant, callbackUrl}) {
+  async CreateWalletAccount({ email, tenant, callbackUrl, onlyCreateAccount, onlySendEmail, scheduleAt}) {
     let headers = {};
 
-    console.log("email", email, "tenant", tenant, "callbackUrl", callbackUrl);
+    console.log("email", email, "tenant", tenant, "callbackUrl", callbackUrl,
+        "onlyCreateAccount", onlyCreateAccount, "onlySentEmail", onlySendEmail, "scheduleAt", scheduleAt);
 
     let urlPath = "/wlt/ory/create_account";
     let res = await this.PostServiceRequest({
       path: urlPath,
-      body: { email, tenant, "callback_url": callbackUrl },
+      body: {
+        email, tenant, "callback_url": callbackUrl,
+        "only_create_account": onlyCreateAccount,
+        "only_send_email": onlySendEmail,
+        "schedule_at": scheduleAt
+      },
       headers,
     });
 
@@ -3492,7 +3501,7 @@ class EluvioLive {
       console.log("Create response: ", tenantConfigResult);
     }
 
-    return {response:tenantConfigResult, content_hash_updated:contentHash };
+    return {response:tenantConfigResult};
   }
 
   /**

--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -3173,7 +3173,7 @@ class EluvioLive {
     let headers = {};
 
     console.log("email", email, "tenant", tenant, "callbackUrl", callbackUrl,
-        "onlyCreateAccount", onlyCreateAccount, "onlySentEmail", onlySendEmail, "scheduleAt", scheduleAt);
+      "onlyCreateAccount", onlyCreateAccount, "onlySentEmail", onlySendEmail, "scheduleAt", scheduleAt);
 
     let urlPath = "/wlt/ory/create_account";
     let res = await this.PostServiceRequest({

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -737,6 +737,9 @@ const CmdCreateWalletAccount = async ({ argv }) => {
       email: argv.email,
       tenant: argv.tenant,
       callbackUrl: callbackUrl,
+      onlyCreateAccount: argv.only_create_account,
+      onlySendEmail: argv.only_send_email,
+      scheduleAt: argv.schedule_at,
     });
 
     console.log(res);
@@ -3584,6 +3587,18 @@ yargs(hideBin(process.argv))
         })
         .positional("property_slug", {
           describe: "the property slug. e.g., epcrtv",
+          type: "string",
+        })
+        .option("only_create_account", {
+          describe: "only create the account, don't send email",
+          type: "boolean",
+        })
+        .option("only_send_email", {
+          describe: "only send account-creation email, do not create the account",
+          type: "boolean",
+        })
+        .option("schedule_at", {
+          describe: "set future time for account-creation email (format is 2024-11-13T01:07:05Z)",
           type: "string",
         });
     },

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -707,7 +707,6 @@ const CmdList = async ({ argv }) => {
 };
 
 const CmdCreateWalletAccount = async ({ argv }) => {
-  console.log(`calling create_account with email:${argv.email} tenant:${argv.tenant} slug:${argv.property_slug}`);
   try {
     await Init({ debugLogging: argv.verbose, asUrl: argv.as_url });
     if (!argv.email || !argv.tenant || !argv.property_slug) {

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -14,6 +14,7 @@ const { hideBin } = require("yargs/helpers");
 const yaml = require("js-yaml");
 const fs = require("fs");
 const path = require("path");
+const urljoin = require("url-join");
 const prompt = require("prompt-sync")({ sigint: true });
 const exec = require("child_process").exec;
 
@@ -61,7 +62,7 @@ const CmdTenantAuthToken = async ({ argv }) => {
   console.log(`Token: Authorization: Bearer ${multiSig}`);
 };
 
-const CmdTenantAuthCurl = async ({ argv }) => {
+const CmdTenantPathAuthCurl = async ({ argv }) => {
   await Init({ debugLogging: argv.verbose, asUrl: argv.as_url });
 
   let ts = Date.now();
@@ -98,7 +99,18 @@ const CmdTenantAuthCurl = async ({ argv }) => {
     }
     console.log(stdout);
   });
+};
 
+const CmdTenantAuthCurl = async ({ argv }) => {
+  await Init({ debugLogging: argv.verbose, asUrl: argv.as_url });
+
+  let res = await elvlv.PostServiceRequest({
+    path: argv.url_path,
+    host: argv.as_url,
+    body: {},
+  });
+
+  console.log(await res.json());
 };
 
 const CmfNftTemplateAddNftContract = async ({ argv }) => {
@@ -2409,7 +2421,7 @@ yargs(hideBin(process.argv))
 
   .command(
     "tenant_auth_curl <url_path> [post_body]",
-    "Generate a tenant token and use it to call an authd endpoint.",
+    "Generate a tenant token and use it to call a baseTenantAuth authd endpoint.",
     (yargs) => {
       yargs
         .positional("url_path", {
@@ -2423,6 +2435,25 @@ yargs(hideBin(process.argv))
     },
     (argv) => {
       CmdTenantAuthCurl({argv}).then();
+    }
+  )
+
+  .command(
+    "tenant_path_auth_curl <url_path> [post_body]",
+    "Generate a tenant token and use it to call an tenantPathAuth authd endpoint.",
+    (yargs) => {
+      yargs
+        .positional("url_path", {
+          describe: "URL path",
+          type: "string",
+        })
+        .positional("post_body", {
+          describe: "optional body; if set will POST, if not, will GET",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdTenantPathAuthCurl({argv}).then();
     }
   )
 

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -3577,7 +3577,7 @@ yargs(hideBin(process.argv))
     (yargs) => {
       yargs
         .positional("email", {
-          describe: "the email to create the account for",
+          describe: "the email to create the account for, or @filename for list of emails",
           type: "string",
         })
         .positional("tenant", {

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -2440,7 +2440,7 @@ yargs(hideBin(process.argv))
 
   .command(
     "tenant_path_auth_curl <url_path> [post_body]",
-    "Generate a tenant token and use it to call an tenantPathAuth authd endpoint.",
+    "Generate a tenant token and use it to call a tenantPathAuth authd endpoint.",
     (yargs) => {
       yargs
         .positional("url_path", {


### PR DESCRIPTION

- add command for use against https://github.com/qluvio/elv-master/pull/1189
- fix tenant_auth_curl 
- add tenant_path_auth_curl


## USAGE

- create the accounts in bulk
```
./elv-live create_wallet_account @fileWithEmails iten4TXq2en3qtu3JREnE5tSLRf9zLod goats-media-property --only_create_account=true
```

- then, verify the accounts all exist; get all idents, sort, sort source list, compare

- finally, send emails to the already-created accounts

```
for i in `cat fileWithEmails` 
do
  ./elv-live create_wallet_account $email iten4TXq2en3qtu3JREnE5tSLRf9zLod goats-media-property --schedule_at 2024-11-13T09:00:00Z --only_send_email=true  | tee create.out
done
```

once again re-trying any w/ problems.  BUT, now, this is safe as we write metadata to the account on email success; it won't resend unless it didn't before


# 



new args:
```
  email          the email to create the account for, or @filename for list of emails                [string] [required]
  
      --only_create_account  only create the account, don't send email                                         [boolean]
      --only_send_email      only send account-creation email, do not create the account                       [boolean]
      --schedule_at          set future time for account-creation email (format is 2024-11-13T01:07:05Z)        [string]
```

usage:
```
$ time ./elv-live create_wallet_account todd+3@eluv.io $TENANT goats-media-property --schedule_at `date -v +5M -u +%Y-%m-%dT%H:%M:%SZ` --only_send_email=true --as_url=http://127.0.0.1:8080/as/
```