### PR TITLE
add catch to CmdTenantAuthCurl

### DIFF
--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -102,15 +102,18 @@ const CmdTenantPathAuthCurl = async ({ argv }) => {
 };
 
 const CmdTenantAuthCurl = async ({ argv }) => {
-  await Init({ debugLogging: argv.verbose, asUrl: argv.as_url });
+  try {
+    await Init({ debugLogging: argv.verbose, asUrl: argv.as_url });
 
-  let res = await elvlv.PostServiceRequest({
-    path: argv.url_path,
-    host: argv.as_url,
-    body: {},
-  });
-
-  console.log(await res.json());
+    let res = await elvlv.PostServiceRequest({
+      path: argv.url_path,
+      host: argv.as_url,
+      body: {},
+    });
+    console.log(await res.json());
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
 };
 
 const CmfNftTemplateAddNftContract = async ({ argv }) => {


### PR DESCRIPTION
fix error path for https://github.com/eluv-io/elv-live-js/pull/191

from
```
elv-live tenant_auth_curl /faucet/add_otp/iten4TXq2en3qtu3JREnE5tSLRf9zLod {"eth_amount":0.0230102} --as_url http://localhost:6546
node:internal/process/promises:389
      new UnhandledPromiseRejection(reason);
      ^

UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "#<Object>".
    at throwUnhandledRejectionsMode (node:internal/process/promises:389:7)
    at processPromiseRejections (node:internal/process/promises:470:17)
    at process.processTicksAndRejections (node:internal/process/task_queues:96:32) {
  code: 'ERR_UNHANDLED_REJECTION'
}
```

to
```
elv-live tenant_auth_curl /faucet/add_otp/iten4TXq2en3qtu3JREnE5tSLRf9zLod {"eth_amount":0.0220553} --as_url http://localhost:6546
ERROR: {
  name: 'ElvHttpClientError',
  status: 400,
  statusText: 'Bad Request',
  message: 'Bad Request',
  url: 'http://localhost:6546/faucet/add_otp/iten4TXq2en3qtu3JREnE5tSLRf9zLod',
  body: {
    error: 'faucet AddOTP:[op [SecpPublicKey] kind [unclassified error] key [ikms3TiodRuV8CgkjB4M5P6cq3PgDepZ] sk [<nil>] cause:\n' +
      '\top [getSecpKeyFromVault] kind [unclassified error] cause:\n' +
      '\top [getKeyFromStore] kind [unclassified error] cause:\n' +
      '\top [getKeyFromVault] kind [unclassified error] cause [secret not found: at dv3/data/keys/ikms3TiodRuV8CgkjB4M5P6cq3PgDepZ]\n' +
      '\tgithub.com/qluvio/elv-master/auth/secretstore/vault_secretstore.go:272 (*vaultSecretStore).Get()\n' +
      '\tgithub.com/qluvio/elv-master/auth/keystore/keystore.go:153             (*KeyStore).getKeyFromStore()\n' +
      '\tgithub.com/qluvio/elv-master/auth/keystore/keystore.go:155             (*KeyStore).getKeyFromStore()\n' +
      '\tgithub.com/qluvio/elv-master/auth/keystore/keystore.go:45              (*KeyStore).GetSecpKey()\n' +
      '\tgithub.com/qluvio/elv-master/auth/keystore/keystore.go:47              (*KeyStore).GetSecpKey()\n' +
      '\tgithub.com/qluvio/elv-master/auth/keyman/keystore_keyman.go:100        (*KeystoreKeyman).SecpPublicKey()\n' +
      '\tgithub.com/qluvio/elv-master/auth/keyman/keystore_keyman.go:102        (*KeystoreKeyman).SecpPublicKey()\n' +
      '\tgithub.com/qluvio/elv-master/auth/secp_trust_provider.go:37            NewSecpTrustProvider()\n' +
      '\tgithub.com/qluvio/elv-master/auth/multi_key_man.go:128                 (*multiKeyManager).GetSecpTrustProvider()\n' +
      '\tgithub.com/qluvio/elv-master/authority/db/faucet_service.go:329        (*FaucetService).getFaucetBalance()\n' +
      '\tgithub.com/qluvio/elv-master/authority/db/faucet_service.go:97         (*FaucetService).AddOtp()\n' +
      '\tgithub.com/qluvio/elv-master/authority/faucet_api.go:149               addFaucetRoutes.(*Server).AddOTP.func3()\n' +
      '\tgithub.com/gin-gonic/gin@v1.7.7/context.go:168                         (*Context).Next()\n' +
      '\tgithub.com/qluvio/elv-master/sessions/sessions.go:65                   (*Server).setupOAuthTest.Session.Sessions.func2()\n' +
      '\tgithub.com/gin-gonic/gin@v1.7.7/context.go:168                         (*Context).Next()\n' +
      '\tgithub.com/qluvio/elv-master/authority/middleware/network.go:72        RouteRateFilter()\n' +
      '\tgithub.com/gin-gonic/gin@v1.7.7/context.go:168                         (*Context).Next()\n' +
      '\tgithub.com/qluvio/elv-master/authority/middleware/network.go:77        RouteLatencyFilter()\n' +
      '\tgithub.com/gin-gonic/gin@v1.7.7/context.go:168                         (*Context).Next()\n' +
      '\tgithub.com/qluvio/elv-master/authority/middleware/network.go:62        RequestLatencyFilter()\n' +
      '\tgithub.com/gin-gonic/gin@v1.7.7/context.go:168                         (*Context).Next()\n' +
      '\tgithub.com/qluvio/elv-master/authority/middleware/network.go:57        RequestRateFilter()\n' +
      '\tgithub.com/gin-gonic/gin@v1.7.7/context.go:168                         (*Context).Next()\n' +
      '\tgithub.com/qluvio/elv-master/authority/routing.go:104                  defaultCORS()\n' +
      '\tgithub.com/gin-gonic/gin@v1.7.7/context.go:168                         (*Context).Next()\n' +
      '\tgithub.com/qluvio/elv-master/middleware/error.go:21                    addRoutes.ErrorHandler.func1()\n' +
      '\tgithub.com/gin-gonic/gin@v1.7.7/context.go:168                         (*Context).Next()\n' +
      '\tgithub.com/qluvio/elv-master/middleware/recovery.go:43                 StartServer.Recovery.func4()\n' +
      '\tgithub.com/gin-gonic/gin@v1.7.7/context.go:168                         (*Context).Next()\n' +
      '\tgithub.com/gin-gonic/gin@v1.7.7/logger.go:241                          LoggerWithConfig.func1()\n' +
      '\tgithub.com/gin-gonic/gin@v1.7.7/context.go:168                         (*Context).Next()\n' +
      '\tgithub.com/gin-gonic/gin@v1.7.7/gin.go:555                             (*Engine).handleHTTPRequest()\n' +
      '\tgithub.com/gin-gonic/gin@v1.7.7/gin.go:511                             (*Engine).ServeHTTP()\n' +
      ']'
  },
  requestParams: {
    method: 'POST',
    headers: {
      Authorization: 'Bearer ES256K_K48HdY5JeJPpfkRHMqg5FaZhzzYgZKeMWrKhuY6bE6RmtwESDBbfiB9mAS5iaX3JKgDbVMJSBndfVE4mFfTRyfqwp',
      Accept: 'application/json',
      'Content-type': 'application/json'
    },
    body: '{"ts":1732576067891}'
  }
}
```