### PR TITLE
fix tenant auth helper (again)

### DIFF
--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -112,7 +112,7 @@ const CmdTenantAuthCurl = async ({ argv }) => {
         host: argv.as_url,
       });
     } else {
-        res = await elvlv.PostServiceRequest({
+      res = await elvlv.PostServiceRequest({
         path: argv.url_path,
         host: argv.as_url,
         body: JSON.parse(argv.post_body),

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -120,7 +120,7 @@ const CmdTenantAuthCurl = async ({ argv }) => {
     }
     console.log(await res.json());
   } catch (e) {
-    console.error("ERROR:", e);
+    console.error("ERROR:", JSON.stringify(e, null, 2));
   }
 };
 

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -105,11 +105,19 @@ const CmdTenantAuthCurl = async ({ argv }) => {
   try {
     await Init({ debugLogging: argv.verbose, asUrl: argv.as_url });
 
-    let res = await elvlv.PostServiceRequest({
-      path: argv.url_path,
-      host: argv.as_url,
-      body: JSON.parse(argv.post_body === "" ? "{}" : argv.post_body),
-    });
+    let res = "";
+    if (argv.post_body === "") {
+      res = await elvlv.GetServiceRequest({
+        path: argv.url_path,
+        host: argv.as_url,
+      });
+    } else {
+        res = await elvlv.PostServiceRequest({
+        path: argv.url_path,
+        host: argv.as_url,
+        body: JSON.parse(argv.post_body),
+      });
+    }
     console.log(await res.json());
   } catch (e) {
     console.error("ERROR:", e);
@@ -2432,7 +2440,7 @@ yargs(hideBin(process.argv))
           type: "string",
         })
         .positional("post_body", {
-          describe: "body",
+          describe: "either json body for POST, or '' for GET",
           type: "string",
         });
     },
@@ -2451,7 +2459,7 @@ yargs(hideBin(process.argv))
           type: "string",
         })
         .positional("post_body", {
-          describe: "optional body; if set will POST, if not, will GET",
+          describe: "either json body for POST, or '' for GET",
           type: "string",
         });
     },


### PR DESCRIPTION
sorry i missed a commit


#

  POST vs GET

```
$ elv-live tenant_auth_curl /faucet/add_otp/iten4TXq2en3qtu3JREnE5tSLRf9zLod '{"eth_amount":0.0113651}'

{ status: 'success', otp_id: 'Za8hM48WZGLT', amount: 0.0113651 }
```

vs

```
$ elv-live tenant_auth_curl /faucet/get_tenant/iten4TXq2en3qtu3JREnE5tSLRf9zLod '' 

{
  status: 'success',
  tenant_record: {
    tenant_id: 'iten4TXq2en3qtu3JREnE5tSLRf9zLod',
    tenant_funding_address: '0xc524b45b4b297ab0bbf013a76d1abdd88c638689',
    monthly_limit: 10,
    per_top_up_limit: 0.2,
    user_max_allowed: 500
  }
}
```