### PR TITLE
mv cmds to elv-admin

### DIFF
--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -12,6 +12,8 @@ const yaml = require("js-yaml");
 
 const postgres = require('postgres');
 const { ElvFabric } = require("../src/ElvFabric");
+const Utils = require("@eluvio/elv-client-js/src/Utils");
+const { ElvUtils } = require("../src/Utils");
 const sql = postgres({
   host : 'rep1.elv',
   port: 5432,
@@ -1280,6 +1282,83 @@ const CmdNodes = async ({ argv }) => {
   }
 };
 
+const CmdSetObjectGroupPermission = async ({ argv }) => {
+  console.log("Set Group Permission");
+  console.log(`Object ID: ${argv.object}`);
+  console.log(`verbose: ${argv.verbose}`);
+  console.log(`group: ${argv.group}`);
+  console.log(`permission: ${argv.permission}`);
+
+  let object = argv.object;
+  let group = argv.group;
+  let permission = argv.permission;
+  try {
+
+    if (group.startsWith("igrp")){
+      group = Utils.HashToAddress(group);
+    }
+    if (object.startsWith("0x")){
+      object = ElvUtils.AddressToId({prefix:"iq__", address:object});
+    }
+
+    let elvContract = new ElvContracts({
+      configUrl: Config.networks[Config.net],
+      debugLogging: argv.verbose
+    });
+
+    await elvContract.Init({
+      privateKey: process.env.PRIVATE_KEY,
+    });
+
+    await elvContract.SetObjectGroupPermission({
+      objectId: object,
+      groupAddress: group,
+      permission,
+    });
+    console.log(`The group ${group} has been granted '${permission}' permission for the object ${object}`)
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
+const CmdCleanupObject = async ({ argv }) => {
+  console.log("Parameters:");
+  console.log("object", argv.object);
+  console.log("object_type", argv.object_type);
+
+  try {
+
+    const object = argv.object;
+    const objectType = argv.object_type;
+
+    let objectAddr;
+    if (object.startsWith("iq")) {
+      objectAddr =  Utils.HashToAddress(object);
+    } else if (object.startsWith("0x")) {
+      objectAddr = object;
+    } else {
+      throw new Error(`Invalid object provided: ${object}, require address or id`);
+    }
+
+    let elvContract = new ElvContracts({
+      configUrl: Config.networks[Config.net],
+      debugLogging: argv.verbose
+    });
+
+    await elvContract.Init({
+      privateKey: process.env.PRIVATE_KEY,
+    });
+
+    const res = await elvContract.CleanupObjects({
+      objectAddr,
+      objectType
+    });
+    console.log("objects cleaned:", res);
+  } catch (e) {
+    console.error("ERROR:", argv.verbose ? e : e.message);
+  }
+};
+
 yargs(hideBin(process.argv))
   .option("verbose", {
     describe: "Verbose mode",
@@ -2063,6 +2142,47 @@ yargs(hideBin(process.argv))
     },
     (argv) => {
       CmdNodes({ argv });
+    }
+  )
+
+  .command(
+    "set_object_group_permission <object> <group> <permission> [options]",
+    "Add a permission on the specified group for the specified object",
+    (yargs) => {
+      yargs.positional("object", {
+        describe: "object ID or address",
+        type: "string",
+      });
+      yargs.positional("group",{
+        describe: "group ID or address",
+        type: "string",
+      });
+      yargs.positional("permission",{
+        describe: "type of permission to add (see, access, manage)",
+        type: "string",
+      });
+    },
+    (argv) => {
+      CmdSetObjectGroupPermission({ argv });
+    }
+  )
+
+  .command(
+    "object_cleanup <object> <object_type>",
+    "cleanup given object access to dead objects like libraries, groups",
+    (yargs) => {
+      yargs
+        .positional("object", {
+          describe: "object to be cleaned",
+          type: "string",
+        })
+        .positional("object_type", {
+          describe: "object type: library | content_object | group | content_type",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdCleanupObject({ argv });
     }
   )
 

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -1370,46 +1370,6 @@ const CmdTenantProvision = async ({ argv }) => {
   }
 };
 
-const CmdSetObjectGroupPermission = async ({ argv }) => {
-  console.log("Set Group Permission");
-  console.log(`Object ID: ${argv.object}`);
-  console.log(`verbose: ${argv.verbose}`);
-  console.log(`group: ${argv.group}`);
-  console.log(`permission: ${argv.permission}`);
-
-  let object = argv.object;
-  let group = argv.group;
-  let permission = argv.permission;
-  try {
-
-    if (group.startsWith("igrp")){
-      group = Utils.HashToAddress(group);
-    }
-    if (object.startsWith("0x")){
-      object = ElvUtils.AddressToId({prefix:"iq__", address:object});
-    }
-
-    let elvContract = new ElvContracts({
-      configUrl: Config.networks[Config.net],
-      debugLogging: argv.verbose
-    });
-
-    await elvContract.Init({
-      privateKey: process.env.PRIVATE_KEY,
-    });
-
-    await elvContract.SetObjectGroupPermission({
-      objectId: object,
-      groupAddress: group,
-      permission,
-    });
-    console.log(`The group ${group} has been granted '${permission}' permission for the object ${object}`)
-  } catch (e) {
-    console.error("ERROR:", e);
-  }
-};
-
-
 const CmdTenantAddConsumerGroup = async ({ argv }) => {
   console.log("Tenant Add Consumer Group");
   console.log(`TenantId: ${argv.tenant}`);
@@ -1920,44 +1880,6 @@ const CmdContentClearPolicy = async ({ argv }) => {
     }
   } catch (e) {
     console.error("ERROR:", e);
-  }
-};
-
-const CmdCleanupObject = async ({ argv }) => {
-  console.log("Parameters:");
-  console.log("object", argv.object);
-  console.log("object_type", argv.object_type);
-
-  try {
-
-    const object = argv.object;
-    const objectType = argv.object_type;
-
-    let objectAddr;
-    if (object.startsWith("iq")) {
-      objectAddr =  Utils.HashToAddress(object);
-    } else if (object.startsWith("0x")) {
-      objectAddr = object;
-    } else {
-      throw new Error(`Invalid object provided: ${object}, require address or id`);
-    }
-
-    let elvContract = new ElvContracts({
-      configUrl: Config.networks[Config.net],
-      debugLogging: argv.verbose
-    });
-
-    await elvContract.Init({
-      privateKey: process.env.PRIVATE_KEY,
-    });
-
-    const res = await elvContract.CleanupObjects({
-      objectAddr,
-      objectType
-    });
-    console.log("objects cleaned:", res);
-  } catch (e) {
-    console.error("ERROR:", argv.verbose ? e : e.message);
   }
 };
 
@@ -3159,28 +3081,6 @@ yargs(hideBin(process.argv))
   )
 
   .command(
-    "set_object_group_permission <object> <group> <permission> [options]",
-    "Add a permission on the specified group for the specified object",
-    (yargs) => {
-      yargs.positional("object", {
-        describe: "object ID or address",
-        type: "string",
-      });
-      yargs.positional("group",{
-        describe: "group ID or address",
-        type: "string",
-      });
-      yargs.positional("permission",{
-        describe: "type of permission to add (see, access, manage)",
-        type: "string",
-      });
-    },
-    (argv) => {
-      CmdSetObjectGroupPermission({ argv });
-    }
-  )
-
-  .command(
     "tenant_add_consumer_group <tenant>",
     "Deploys a BaseTenantConsumerGroup and adds it to this tenant's contract.",
     (yargs) => {
@@ -3781,27 +3681,6 @@ yargs(hideBin(process.argv))
     },
     (argv) => {
       CmdAdminHealth({ argv });
-    }
-
-
-  )
-
-  .command(
-    "object_cleanup <object> <object_type>",
-    "cleanup given object access to dead objects like libraries, groups",
-    (yargs) => {
-      yargs
-        .positional("object", {
-          describe: "object to be cleaned",
-          type: "string",
-        })
-        .positional("object_type", {
-          describe: "object type: library | content_object | group | content_type",
-          type: "string",
-        });
-    },
-    (argv) => {
-      CmdCleanupObject({ argv });
     }
   )
 


### PR DESCRIPTION
### Changes made:

The `object_cleanup` and `set_object_group_permission` commands have been relocated from the `elv-live` CLI to the `elv-admin` CLI.

```
./elv-admin object_cleanup iq__3Sis7zDmtjwzH441BJnrvBN3MF8J
 object_cleanup <object> <object_type>

cleanup given object access to dead objects like libraries, groups

Positionals:
  object       object to be cleaned                          [string] [required]
  object_type  object type: library | content_object | group | content_type
                                                             [string] [required]

Options:
      --version  Show version number                                   [boolean]
  -v, --verbose  Verbose mode                                          [boolean]
      --help     Show help                                             [boolean]
```

```
./elv-admin set_object_group_permission --help
 set_object_group_permission <object> <group> <permission> [options]

Add a permission on the specified group for the specified object

Positionals:
  object      object ID or address                           [string] [required]
  group       group ID or address                            [string] [required]
  permission  type of permission to add (see, access, manage)[string] [required]

Options:
      --version  Show version number                                   [boolean]
  -v, --verbose  Verbose mode                                          [boolean]
      --help     Show help                                             [boolean]
```