### PR TITLE
Update account_create cmd

### DIFF
--- a/src/ElvAccount.js
+++ b/src/ElvAccount.js
@@ -60,17 +60,25 @@ class ElvAccount {
    * @param {number} funds - The amount in ETH to fund the new account.
    * @param {string} accountName - The name of the account to set in it's wallet metadata (Optional)
    * @param {string} tenantId - The tenant ID (iten) (Optional)
+   * @param {object} groupToRoles - Map of group to roles [member|manager] (Optional)
    * @return {Promise<Object>} - An object containing the new account mnemonic, privateKey, address, accountName, balance
    */
-  async Create({ funds = 0.25, accountName, tenantId }) {
+  async Create({ funds = 0.25, accountName, tenantId, groupToRoles }) {
+
+    const abi = fs.readFileSync(
+      path.resolve(__dirname, "../contracts/v3/BaseTenantSpace.abi")
+    );
+
     if (!this.client) {
       throw Error("ElvAccount not intialized");
     }
 
+    let tenantUsersGroup;
     // We don't require the key is part of a tenant (for example when creating a tenant root key)
-    if (tenantId) {
+    if (tenantId){
       // Validate tenant ID (make sure it is not the tenant admins ID)
       const idType = await this.client.AccessType({ id: tenantId });
+
       if (idType !== this.client.authClient.ACCESS_TYPES.TENANT) {
         throw Error("Bad tenant ID");
       }
@@ -80,12 +88,38 @@ class ElvAccount {
       try {
         await this.client.CallContractMethod({
           contractAddress: tenantAddr,
+          abi: JSON.parse(abi),
           methodName: "groupsMapping",
           methodArgs: ["tenant_admin", 0],
           formatArguments: true,
         });
       } catch (e) {
         throw Error("Bad tenant - missing tenant admins group");
+      }
+
+      // require tenant admin key to create new users
+      let owner = await this.client.CallContractMethod({
+        contractAddress: tenantAddr,
+        abi: JSON.parse(abi),
+        methodName: "owner",
+        methodArgs: [],
+        formatArguments: true,
+      });
+      if (this.client.CurrentAccountAddress() !== owner.toLowerCase()) {
+        throw Error(`Not run by Tenant Admin - ${owner.toLowerCase()}`);
+      }
+
+      try {
+        tenantUsersGroup = await this.client.CallContractMethod({
+          contractAddress: tenantAddr,
+          abi: JSON.parse(abi),
+          methodName: "groupsMapping",
+          methodArgs: ["tenant_users", 0],
+          formatArguments: true,
+        });
+      } catch (e) {
+        tenantUsersGroup = null;
+        console.log("WARN: missing tenant users group");
       }
     }
 
@@ -129,6 +163,47 @@ class ElvAccount {
       }
 
       let balance = await wallet.GetAccountBalance({ signer });
+
+      // add new user to tenant_users group
+      if (tenantUsersGroup) {
+        await this.AddToAccessGroup({
+          groupAddress: tenantUsersGroup,
+          accountAddress: address,
+          isManager: false,
+        });
+        console.log("Added user to tenant users group:", tenantUsersGroup);
+      }
+
+      if (groupToRoles) {
+        for (const [group, role] of Object.entries(groupToRoles)) {
+
+          let isManager;
+          switch (role) {
+            case "manager": isManager = true; break;
+            default: isManager = false;
+          }
+
+          let groupAddress;
+          // convert to address format
+          if (group.startsWith("igrp") || group.startsWith("iten")) {
+            groupAddress = Utils.HashToAddress(group);
+          } else if (group.startsWith("0x")) {
+            groupAddress = group;
+          } else {
+            console.log(`WARN: User was NOT added to the group "${group}" because the provided format is invalid. 
+Accepted formats: igrp, iten, or address.`);
+            continue;
+          }
+
+          // add user to group provided
+          await this.AddToAccessGroup({
+            groupAddress: groupAddress,
+            accountAddress: address,
+            isManager,
+          });
+          console.log(`Added user to group: ${groupAddress} as ${role}`);
+        }
+      }
 
       return {
         accountName,

--- a/src/ElvAccount.js
+++ b/src/ElvAccount.js
@@ -61,9 +61,10 @@ class ElvAccount {
    * @param {string} accountName - The name of the account to set in it's wallet metadata (Optional)
    * @param {string} tenantId - The tenant ID (iten) (Optional)
    * @param {object} groupToRoles - Map of group to roles [member|manager] (Optional)
+   * @param {boolean} skipAddingToTenantUserGroup - skip adding to tenant user group (Optional)
    * @return {Promise<Object>} - An object containing the new account mnemonic, privateKey, address, accountName, balance
    */
-  async Create({ funds = 0.25, accountName, tenantId, groupToRoles }) {
+  async Create({ funds = 0.25, accountName, tenantId, groupToRoles, skipAddingToTenantUserGroup = false }) {
 
     const abi = fs.readFileSync(
       path.resolve(__dirname, "../contracts/v3/BaseTenantSpace.abi")
@@ -165,7 +166,7 @@ class ElvAccount {
       let balance = await wallet.GetAccountBalance({ signer });
 
       // add new user to tenant_users group
-      if (tenantUsersGroup) {
+      if (tenantUsersGroup && !skipAddingToTenantUserGroup) {
         await this.AddToAccessGroup({
           groupAddress: tenantUsersGroup,
           accountAddress: address,

--- a/src/Provision.js
+++ b/src/Provision.js
@@ -8,7 +8,6 @@ const {Config} = require("./Config");
 const { EluvioLive } = require("../src/EluvioLive.js");
 const { ElvFabric } = require("./ElvFabric");
 const { ElvTenant } = require("./ElvTenant");
-const { ElvClient } = require("@eluvio/elv-client-js");
 
 const TYPE_LIVE_DROP_EVENT_SITE = "Media Wallet Drop Event Site";
 const TYPE_LIVE_TENANT = "Media Wallet Tenant";
@@ -746,6 +745,10 @@ const createOpsKeyAndAddToGroup = async ({groupAddress, opsKeyType, t, debug})=>
       funds: OPS_AMOUNT,
       accountName: `${t.base.tenantName}-${opsKeyType}`,
       tenantId: t.base.tenantId,
+      skipAddingToTenantUserGroup: true,
+      groupToRoles: {
+        [groupAddress]: "manager",
+      },
     });
     console.log(`\n${t.base.tenantName}-${opsKeyType}:\n`);
     console.log(`address:${res.address}`);
@@ -759,23 +762,6 @@ const createOpsKeyAndAddToGroup = async ({groupAddress, opsKeyType, t, debug})=>
     }
     writeConfigToFile(t);
   }
-
-  // In order to address from private key
-  let client = await ElvClient.FromConfigurationUrl({
-    configUrl: Config.networks[Config.net],
-  });
-  let wallet = client.GenerateWallet();
-  const signer = wallet.AddAccount({
-    privateKey: opsKey
-  });
-  const opsKeyAddress = signer.address;
-
-  // add the user as manager to provided group address
-  await elvAccount.AddToAccessGroup({
-    groupAddress: groupAddress,
-    accountAddress: opsKeyAddress,
-    isManager: true,
-  });
   console.log(`${t.base.tenantName}-${opsKeyType} added as manager to ${groupAddress}`);
 };
 

--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -36,6 +36,7 @@ const CmdAccountCreate = async ({ argv }) => {
   console.log(`funds: ${argv.funds}`);
   console.log(`account_name: ${argv.account_name}`);
   console.log(`tenant: ${argv.tenant}`);
+  console.log(`group-roles: ${argv.group_roles}`);
 
   try {
     let elvAccount = new ElvAccount({
@@ -47,10 +48,13 @@ const CmdAccountCreate = async ({ argv }) => {
       privateKey: process.env.PRIVATE_KEY,
     });
 
+    const groupToRoles = argv.group_roles ? JSON.parse(argv.group_roles) : {};
+
     let res = await elvAccount.Create({
       funds: argv.funds,
       accountName: argv.account_name,
       tenantId: argv.tenant,
+      groupToRoles,
     });
     console.log(yaml.dump(res));
   } catch (e) {
@@ -1302,6 +1306,11 @@ yargs(hideBin(process.argv))
         })
         .positional("tenant", {
           describe: "Tenant ID (iten)",
+          type: "string",
+        })
+
+        .options("group_roles", {
+          describe: "group and role pairs in JSON format, Eg: {\"grp1\":\"member\"}",
           type: "string",
         });
     },


### PR DESCRIPTION
**Changes made:**
* only tenant admin can create new user
* new user are added to tenant users group
* flag `group_roles` can be used to provide groups and roles the users will be assigned in json format. 
`--group_roles {"0xdeedbeef|igrpXXX|itenXXX":"member|manager"}`.
* made changes to provision script to skip adding ops key as members in tenant users groups.

**Cmd:**

```
./elv-admin account_create --help
 account_create <funds> <account_name> <tenant>

Create a new account -> mnemonic, address, private key

Positionals:
  funds         How much to fund the new account from this private key (ELV).
                                                             [string] [required]
  account_name  Account Name                                 [string] [required]
  tenant        Tenant ID (iten)                             [string] [required]

Options:
      --version      Show version number                               [boolean]
  -v, --verbose      Verbose mode                                      [boolean]
      --help         Show help                                         [boolean]
      --group_roles  group and role pairs in JSON format, Eg: {"grp1":"member"}
                                                                        [string]
```

**Example:**
```
./elv-admin account_create 0.3 acc_1 itennqoQSehkEq3RhmQ7KzHcQVjNqnq \
--group_roles '{"0xe34c35c8afd0b5432bf85ca0d7485923638eee11":"member","igrpDxkti2RZJJeeWbQq6rtYZyiFWBh":"manager"}'
```

