### PR TITLE
add tenant status cmds

### DIFF
--- a/src/Constants.js
+++ b/src/Constants.js
@@ -1,0 +1,15 @@
+// Define constant values
+const Constants = {
+  // tenant groups
+  TENANT_ADMIN: "tenant_admin",
+  CONTENT_ADMIN: "content_admin",
+  TENANT_USER_GROUP: "tenant_user_group",
+
+  // tenant status
+  TENANT_STATE:"_ELV_TENANT_STATUS",
+  TENANT_STATE_ACTIVE:"active",
+  TENANT_STATE_INACTIVE:"inactive"
+};
+
+// Export the constants object
+module.exports = Constants;

--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -5,6 +5,7 @@ const { ElvContracts } = require("../src/ElvContracts.js");
 const { EluvioLive } = require("../src/EluvioLive.js");
 const { Config } = require("../src/Config.js");
 const Ethers = require("ethers");
+const constants = require("../src/Constants")
 
 const yargs = require("yargs/yargs");
 const { hideBin } = require("yargs/helpers");
@@ -791,6 +792,45 @@ const CmdTenantRemoveTenantUsers = async ({ argv }) => {
       tenantUsersAddr: argv.tenant_users_address
     });
 
+    console.log(yaml.dump(res));
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
+const CmdTenantSetStatus = async ({argv}) => {
+  try {
+    const tenantContractId =  argv.tenant;
+    const tenantStatus =  argv.tenant_status;
+    let t = new ElvTenant({
+      configUrl: Config.networks[Config.net],
+      debugLogging: argv.verbose
+    });
+    await t.Init({ privateKey: process.env.PRIVATE_KEY });
+
+    let res = await t.TenantSetStatus({
+      tenantContractId: tenantContractId,
+      tenantStatus: tenantStatus,
+    });
+
+    console.log(yaml.dump(res));
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
+const CmdTenantStatus = async ({argv}) => {
+  try {
+    const tenantContractId = argv.tenant;
+    let t = new ElvTenant({
+      configUrl: Config.networks[Config.net],
+      debugLogging: argv.verbose
+    });
+    await t.Init({ privateKey: process.env.PRIVATE_KEY });
+
+    let res = await t.TenantStatus({
+      tenantContractId: tenantContractId,
+    });
     console.log(yaml.dump(res));
   } catch (e) {
     console.error("ERROR:", e);
@@ -1759,6 +1799,41 @@ yargs(hideBin(process.argv))
     },
     (argv) => {
       CmdTenantCreateFaucetAndFund({ argv });
+    }
+  )
+
+  .command(
+    "tenant_set_status <tenant> <tenant_status>",
+    "Set tenant status for given tenant",
+    (yargs) => {
+      yargs
+        .positional("tenant", {
+          describe: "Tenant ID",
+          type: "string",
+        })
+        .positional("tenant_status", {
+          describe: "Tenant Status",
+          choices: [constants.TENANT_STATE_ACTIVE, constants.TENANT_STATE_INACTIVE],
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdTenantSetStatus({argv});
+    }
+  )
+
+  .command(
+    "tenant_status <tenant>",
+    "Get tenant status for given tenant",
+    (yargs) => {
+      yargs
+        .positional("tenant", {
+          describe: "Tenant ID",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdTenantStatus({argv});
     }
   )
 

--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -819,24 +819,6 @@ const CmdTenantSetStatus = async ({argv}) => {
   }
 };
 
-const CmdTenantStatus = async ({argv}) => {
-  try {
-    const tenantContractId = argv.tenant;
-    let t = new ElvTenant({
-      configUrl: Config.networks[Config.net],
-      debugLogging: argv.verbose
-    });
-    await t.Init({ privateKey: process.env.PRIVATE_KEY });
-
-    let res = await t.TenantStatus({
-      tenantContractId: tenantContractId,
-    });
-    console.log(yaml.dump(res));
-  } catch (e) {
-    console.error("ERROR:", e);
-  }
-};
-
 const CmdSpaceTenantSetEluvioLiveId = async ({ argv }) => {
   console.log("Tenant set Eluvio Live ID");
   console.log(`Tenant: ${argv.tenant}`);
@@ -1819,21 +1801,6 @@ yargs(hideBin(process.argv))
     },
     (argv) => {
       CmdTenantSetStatus({argv});
-    }
-  )
-
-  .command(
-    "tenant_status <tenant>",
-    "Get tenant status for given tenant",
-    (yargs) => {
-      yargs
-        .positional("tenant", {
-          describe: "Tenant ID",
-          type: "string",
-        });
-    },
-    (argv) => {
-      CmdTenantStatus({argv});
     }
   )
 


### PR DESCRIPTION
**Changes made:**
* tenant status can be set and retrieved using below two commands:
```
./elv-admin tenant_set_status --help
 tenant_set_status <tenant> <tenant_status>

Set tenant status for given tenant

Positionals:
  tenant         Tenant ID                                   [string] [required]
  tenant_status  Tenant Status
                             [string] [required] [choices: "active", "inactive"]
```

```
./elv-admin tenant_show itenNZS3VF1RybdMURUCDUczWQtQsw7
Tenant - show itenNZS3VF1RybdMURUCDUczWQtQsw7
Network: demov3
tenant_admin_address: '0x734AfBe0D9E9fa783bCA6eD4492d32eFEd6D418A'
content_admin_address: '0x1d18Fe5807caf9D7d93C5395e7d78c4dB43Bf0fe'
tenant_users_address: '0xB2c6a4AE3A659708D91300d4d534a53fb925Cd6A'
tenant_root_key: '0x8EFD7184298fD2a38BC2bf30b1Fa883d1Eb12E68'
tenant_status: active
```
* tenant is set `active` when the tenant is created.