### PR TITLE
Faucet Fund Cmd

### DIFF
--- a/src/ElvTenant.js
+++ b/src/ElvTenant.js
@@ -720,7 +720,7 @@ class ElvTenant {
     return res;
   }
 
-  async TenantCreateFaucetAndFund({ asUrl, tenantId, amount }) {
+  async TenantCreateFaucetAndFund({ asUrl, tenantId, amount = 2 }) {
     // Initialize configuration
     const config = {
       configUrl: Config.networks[Config.net],

--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -351,6 +351,28 @@ const CmdTenantCreateFaucetAndFund = async ({ argv }) => {
   }
 };
 
+const CmdTenantFundUser = async ({ argv }) => {
+  try {
+    const { as_url: asUrl, tenant_id: tenantId, user_address: userAddress, amount: amount } = argv;
+
+    let t = new ElvTenant({
+      configUrl: Config.networks[Config.net],
+      debugLogging: argv.verbose
+    });
+    await t.Init({ privateKey: process.env.PRIVATE_KEY });
+
+    const res = await t.TenantFundUser({
+      asUrl,
+      tenantId,
+      userAddress,
+      amount,
+    });
+    console.log(yaml.dump(res));
+  } catch (e) {
+    console.error("ERROR:", e.message);
+  }
+};
+
 
 const CmdSpaceTenantDeploy = async ({ argv }) => {
   console.log("Tenant Deploy");
@@ -1759,6 +1781,33 @@ yargs(hideBin(process.argv))
     },
     (argv) => {
       CmdTenantCreateFaucetAndFund({ argv });
+    }
+  )
+
+  .command(
+    "tenant_fund_user <tenant_id> <user_address>",
+    "fund the user for given tenant_id",
+    (yargs) => {
+      yargs
+        .positional("tenant_id", {
+          describe: "tenant id",
+          type: "string",
+        })
+        .positional("user_address", {
+          describe: "user address",
+          type: "string",
+        })
+        .option("amount", {
+          describe: "The amount to fund the user address, specified in Elv's",
+          type: "number",
+        })
+        .option("as_url", {
+          describe: "Alternate authority service URL (include '/as/' route if necessary)",
+          type: "string",
+        });
+    },
+    (argv) => {
+      CmdTenantFundUser({ argv });
     }
   )
 


### PR DESCRIPTION
Cmd to fund users in the tenant by tenant admins:

```
./elv-admin tenant_fund_user --help
 tenant_fund_user <tenant_id> <user_address>

fund the user for given tenant_id

Positionals:
  tenant_id     tenant id                                    [string] [required]
  user_address  user address                                 [string] [required]

Options:
      --version  Show version number                                   [boolean]
  -v, --verbose  Verbose mode                                          [boolean]
      --help     Show help                                             [boolean]
      --amount   The amount to fund the user address, specified in Elv's[number]
      --as_url   Alternate authority service URL (include '/as/' route if
                 necessary)                                             [string]

```

**Example:**
```
export PRIVATE_KEY="<tenant_admin_key>"
./elv-admin tenant_fund_user itenNZS3VF1RybdMURUCDUczWQtQsw7 0x4aaec20ecc5b78f9b0edd24bf7b9c9b52b08fdef
TenantFundUser
as_url: undefined
tenant_id: itenNZS3VF1RybdMURUCDUczWQtQsw7
user_address: 0x4aaec20ecc5b78f9b0edd24bf7b9c9b52b08fdef
amount: 0.2

amount_transferred: 0.2
claimed:
  otp_id: oxxNPu99I7Dy
  tenant_id: itenNZS3VF1RybdMURUCDUczWQtQsw7
  eth_amount: 0.2
status: success
user_balance: 0.2999686922
```

**Process:**
1. Can be run by only the tenant admin
2. Checks if the user balance < tenant faucet per_top_up_limit
3. Sends a request to the API endpoint `<authd_url>/faucet/fund/:tid/:userAddress`.