### PR TITLE
Update to Ops Key and Faucet Funding Key Funds

### DIFF
--- a/src/ElvSpace.js
+++ b/src/ElvSpace.js
@@ -52,6 +52,11 @@ class ElvSpace {
         elvClient: this.client,
       });
 
+      let initialBalance = await elvAccount.GetBalance();
+      if (initialBalance < funds){
+        throw Error(`Signer ${elvAccount.client.signer.address.toString()} has insufficient balance: ${initialBalance} Elv, require ${funds} Elv`) ;
+      }
+
       const tenantSlug = tenantName.toLowerCase().replace(/ /g, "-");
       account = await elvAccount.Create({
         funds: funds,

--- a/src/ElvSpace.js
+++ b/src/ElvSpace.js
@@ -39,7 +39,7 @@ class ElvSpace {
     this.client = elvClient;
   }
 
-  async TenantCreate({ tenantName, funds = 20 }) {
+  async TenantCreate({ tenantName, funds = 51 }) {
     let account = null;
     let elvAccount = null;
     try {

--- a/src/ElvTenant.js
+++ b/src/ElvTenant.js
@@ -848,6 +848,7 @@ class ElvTenant {
         console.log(`Funds after transfer: Receiver=${fundingAddress}, Balance=${finalReceiverBalance}`);
       }
       res.amount_transferred = finalReceiverBalance-initialReceiverBalance;
+      res.current_balance = finalReceiverBalance;
     }
 
     return res;

--- a/src/ElvTenant.js
+++ b/src/ElvTenant.js
@@ -765,7 +765,7 @@ class ElvTenant {
     return res;
   }
 
-  async TenantCreateFaucetAndFund({ asUrl, tenantId, amount = 2, noFunds = false }) {
+  async TenantCreateFaucetAndFund({ asUrl, tenantId, amount = 20, noFunds = false }) {
     const config = {
       configUrl: Config.networks[Config.net],
       mainObjectId: Config.mainObjects[Config.net],

--- a/src/Provision.js
+++ b/src/Provision.js
@@ -383,6 +383,7 @@ const handleTenantFaucet = async ({tenantId, asUrl, t, debug}) => {
   t.base.faucet.funding_address = res.faucet.funding_address;
   if ( "amount_transferred" in res ) {
     t.base.faucet.amount_transferred = res.amount_transferred;
+    t.base.faucet.current_balance = res.current_balance;
   }
   writeConfigToFile(t);
 };

--- a/src/Provision.js
+++ b/src/Provision.js
@@ -44,10 +44,10 @@ const typeMetadata = {
 const TENANT_OPS_KEY="tenant-ops";
 const CONTENT_OPS_KEY="content-ops";
 
-const EXPECTED_SENDER_BALANCE=2.5;
-// This value must be greater than 0.1 Elv
+const EXPECTED_SENDER_BALANCE=10.5;
+// This value must be greater than 0.1 Elv for tx fee
 // (checked by elv-client-js when adding as an access group member)
-const OPS_AMOUNT=2;
+const OPS_AMOUNT=10;
 
 // ===================================================================
 
@@ -345,6 +345,13 @@ const handleTenantFaucet = async ({tenantId, asUrl, t, debug}) => {
   let amount;
   if (isEmptyParams(t.base.faucet.amount)) {
     amount = undefined;
+  } else {
+    amount = t.base.faucet.amount;
+  }
+
+  let noFunds = false;
+  if (!isEmptyParams(t.base.faucet.no_funds)){
+    noFunds = true;
   }
 
   let maxAttempts = 5;
@@ -356,7 +363,8 @@ const handleTenantFaucet = async ({tenantId, asUrl, t, debug}) => {
       res = await elvTenant.TenantCreateFaucetAndFund({
         asUrl,
         tenantId,
-        amount,
+        ...(amount != null && {amount: amount}),
+        noFunds
       });
       console.log(`Success creating faucet for ${tenantId} on attempt ${attempt+1}`);
       break;
@@ -638,11 +646,11 @@ const createTenantObjectId = async ({client, t}) => {
     if (isEmptyParams(t.mediaWallet.liveTypes[TYPE_LIVE_TENANT])){
       throw Error(`require t.mediaWallet.liveTypes.'${TYPE_LIVE_TENANT}' to be set`);
     }
-    if (isEmptyParams(t.base.tenantOpsKey)){
-      throw Error("require t.base.tenantOpsKey set");
+    if (isEmptyParams(t.base.opsKey.tenantOps.key)){
+      throw Error("require t.base.opsKey.tenantOps.key set");
     }
-    if (isEmptyParams(t.base.contentOpsKey)){
-      throw Error("require t.base.contentOpsKey set");
+    if (isEmptyParams(t.base.opsKey.contentOps.key)){
+      throw Error("require t.base.opsKey.contentOps.key set");
     }
 
     objectName = `${TYPE_LIVE_TENANT} - ${t.base.tenantName}`;
@@ -650,9 +658,9 @@ const createTenantObjectId = async ({client, t}) => {
 
     // get ops key address
     let wallet = client.GenerateWallet();
-    let tenantOpsSigner = wallet.AddAccount({privateKey: t.base.tenantOpsKey});
+    let tenantOpsSigner = wallet.AddAccount({privateKey: t.base.opsKey.tenantOps.key});
     let tenantOpsAddr = await tenantOpsSigner.getAddress();
-    let contentOpsSigner = wallet.AddAccount({privateKey: t.base.contentOpsKey});
+    let contentOpsSigner = wallet.AddAccount({privateKey: t.base.opsKey.contentOps.key});
     let contentOpsAddr = await contentOpsSigner.getAddress();
 
 
@@ -726,10 +734,17 @@ const createSiteId = async ({client, t}) => {
 
 const createOpsKeyAndAddToGroup = async ({groupToRoles, opsKeyType, t, debug})=>{
   let opsKey = "";
+  let opsFund = OPS_AMOUNT;
   if (opsKeyType === TENANT_OPS_KEY){
-    opsKey = t.base.tenantOpsKey;
+    opsKey = t.base.opsKey.tenantOps.key;
+    if (!isEmptyParams(t.base.opsKey.tenantOps.amount)){
+      opsFund = t.base.opsKey.tenantOps.amount;
+    }
   } else {
-    opsKey = t.base.contentOpsKey;
+    opsKey = t.base.opsKey.contentOps.key;
+    if (!isEmptyParams(t.base.opsKey.contentOps.amount)){
+      opsFund = t.base.opsKey.contentOps.amount;
+    }
   }
 
   if (opsKey === "none") {
@@ -755,7 +770,7 @@ const createOpsKeyAndAddToGroup = async ({groupToRoles, opsKeyType, t, debug})=>
     }
 
     let res = await elvAccount.Create({
-      funds: OPS_AMOUNT,
+      funds: opsFund,
       accountName: `${t.base.tenantName}-${opsKeyType}`,
       tenantId: t.base.tenantId,
       skipAddingToTenantUserGroup: true,
@@ -766,9 +781,11 @@ const createOpsKeyAndAddToGroup = async ({groupToRoles, opsKeyType, t, debug})=>
     console.log(`privateKey:${res.privateKey}`);
 
     if (opsKeyType === TENANT_OPS_KEY){
-      t.base.tenantOpsKey = res.privateKey;
+      t.base.opsKey.tenantOps.key = res.privateKey;
+      t.base.opsKey.tenantOps.amount_transferred = opsFund;
     } else {
-      t.base.contentOpsKey = res.privateKey;
+      t.base.opsKey.contentOps.key = res.privateKey;
+      t.base.opsKey.contentOps.amount_transferred = opsFund;
     }
     writeConfigToFile(t);
   }
@@ -790,8 +807,16 @@ const InitializeTenant = async ({client, kmsId, tenantId, asUrl, statusFile, ini
   if (!statusFile) {
     t = {
       base: {
-        tenantOpsKey: "",
-        contentOpsKey: "",
+        opsKey : {
+          tenantOps: {
+            key: "",
+            amount: null
+          },
+          contentOps: {
+            key: "",
+            amount: null
+          },
+        },
         groups : {
           "tenantAdminGroupAddress": "",
           "contentAdminGroupAddress": "",
@@ -815,6 +840,7 @@ const InitializeTenant = async ({client, kmsId, tenantId, asUrl, statusFile, ini
         },
         faucet: {
           "enable": true,
+          "no_funds": false,
           "funding_address": null,
           "amount": null,
         }
@@ -849,15 +875,32 @@ const InitializeTenant = async ({client, kmsId, tenantId, asUrl, statusFile, ini
     return t;
   }
 
-  let expectedSignerBalance = 1;
-  if (t.base.contentOpsKey === "") {
-    expectedSignerBalance+=2;
+  // minimum signer balance required
+  let expectedSignerBalance = 10;
+  // fund content ops key
+  if (t.base.opsKey.contentOps.key === "") {
+    if (!isEmptyParams(t.base.opsKey.contentOps.key)){
+      expectedSignerBalance += t.base.opsKey.contentOps.amount;
+    } else {
+      expectedSignerBalance += 10;
+    }
   }
-  if (t.base.tenantOpsKey === "") {
-    expectedSignerBalance+=2;
+  // fund tenant ops key
+  if (t.base.opsKey.tenantOps.key === "") {
+    if (!isEmptyParams(t.base.opsKey.tenantOps.key)){
+      expectedSignerBalance += t.base.opsKey.tenantOps.amount;
+    } else {
+      expectedSignerBalance += 10;
+    }
   }
+
+  // fund faucet if enabled
   if (t.base.faucet.enable) {
-    expectedSignerBalance+=2;
+    if (!isEmptyParams(t.base.faucet.amount)) {
+      expectedSignerBalance += t.base.faucet.amount;
+    } else {
+      expectedSignerBalance += 20;
+    }
   }
 
   let elvAccount = new ElvAccount({

--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -328,9 +328,8 @@ const CmdSpaceTenantCreate = async ({ argv }) => {
 
     res = await space.TenantCreate({
       tenantName: argv.tenant_name,
-      funds: argv.funds,
+      ...(argv.funds != null && {funds : argv.funds})
     });
-
     console.log(yaml.dump(res));
   } catch (e) {
     console.error("ERROR:", e);
@@ -2011,18 +2010,20 @@ yargs(hideBin(process.argv))
   )
 
   .command(
-    "space_tenant_create <tenant_name> <funds>",
-    "Creates a new tenant account including all supporting access groups and deployment of contracts. PRIVATE_KEY must be set for the space owner.",
+    "space_tenant_create <tenant_name>",
+    `Creates a new tenant account including all supporting access groups and deployment of contracts. 
+      PRIVATE_KEY must be set for the space owner.
+      By default, 51 Elv is transferred to tenant root key`,
     (yargs) => {
       yargs
         .positional("tenant_name", {
           describe: "Tenant Name",
           type: "string",
         })
-        .positional("funds", {
+        .option("funds", {
           describe:
-            "How much to fund the new tenant from this private key in ETH.",
-          type: "string",
+            "funds transferred to tenant-admin key",
+          type: "integer",
         });
     },
     (argv) => {

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -3066,11 +3066,15 @@ yargs(hideBin(process.argv))
 
   .command(
     "tenant_provision <tenant> [options]",
-    "Provision a new tenancy with standard media libraries and content types. " +
-    "Run as the tenant root key, as created by space_tenant_create. This is a multi-step operation, " +
-    "and intermediate status is saved in the local directory in the file tenant_status.json. " +
-    "The operation can be resumed by specifying a status file, which indicates the operations " +
-    "that have already been executed.",
+    `Provision a new tenancy with standard media libraries and content types.
+    Run as the tenant root key, as created by space_tenant_create. This is a multi-step operation,
+    and intermediate status is saved in the local directory in the file tenant_status.json using --status flag.
+    The operation can be resumed by specifying a status file, which indicates the operations
+    that have already been executed.
+      Funds transferred (default):
+      * tenant ops created: 10 elv
+      * content ops created: 10 elv
+      * faucet funding address: 20 elv`,
     (yargs) => {
       yargs.positional("tenant", {
         describe: "Tenant ID",
@@ -3083,6 +3087,7 @@ yargs(hideBin(process.argv))
       yargs.option("init_config",{
         describe: "Displays the initial provisioning config, which can be used to input existing objects",
         type: "boolean",
+        default: false
       });
     },
     (argv) => {


### PR DESCRIPTION
### Changes Made:

1. **Update to `./elv-admin space_tenant_create`**:
   - **Old**: 
     ```
     ./elv-admin space_tenant_create <tenant_name> <funds>
     ```
   - **New**: 
     ```
     ./elv-admin space_tenant_create <tenant_name> --funds 20
     ```
   - The default value for the tenant root key is **51 Elv**, which can be overridden using the `--funds` flag.
   - The `tenant_provision` command requires a maximum of **50 Elv** initially, and the `space_tenant_create` command performs certain blockchain transactions before the `tenant_provision` step, so made the default value to **51 Elv**.
   - Added a check to ensure that the `space_owner` balance >= to the specified funds.

2. **Update to `./elv-live tenant_provision <tenant_id>`**:
   - **Default values**:
     - Tenant ops and content ops keys are set to **10 Elv**.
     - Faucet funding is set to **20 Elv**.
   - These values can be modified by editing the `amount` field in the status JSON file:
     ```
     {
       "base": {
         "opsKey": {
           "tenantOps": {
             "key": "xxx",
             "amount": null,
             "amount_transferred": 10
           },
           "contentOps": {
             "key": "xxx",
             "amount": null,
             "amount_transferred": 10
           }
         },
         "faucet": {
           "enable": true,
           "no_funds": false,
           "funding_address": "xxx",
           "amount": null,
           "amount_transferred": 20
         }
       }
       ...
     }
     ```
 - **Re-run Provision Script Without Funding Faucet Keys:**
     - disable faucet field : `t.base.faucet.enable = false` or
     - make `no_funds` field = true, `t.base.faucet.no_funds=true`. 
     This will retrieve the faucet funding keys address without funding them.
   
3. **To create an empty status JSON file** to modify the default values:
   ```bash
   ./elv-live tenant_provision iten1C6PjcwpLoxQsFzmDCTShJ2gsnV --init-config
   ```
