### PR TITLE
Add nft proxy transfer batch command

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "elv-live": "elv-live",
     "elv-stream": "elv-stream",
     "elv-admin": "elv-admin"
-   },
+  },
   "scripts": {
     "bump-version": "npm --git-tag-version --no-commit-hooks version patch",
     "test": "jest",
@@ -53,6 +53,7 @@
     "got": "^11.8.6",
     "js-yaml": "^3.14.1",
     "keccak256": "^1.0.6",
+    "p-limit": "^2.3.0",
     "postgres": "^3.3.5",
     "prompt-sync": "^4.2.0",
     "seedrandom": "^3.0.5",

--- a/src/BatchNFTOperations.js
+++ b/src/BatchNFTOperations.js
@@ -41,7 +41,7 @@ class BatchNFTOperations {
   }
 
 
-  async BatchNftTransfer({inputFile, concurrency = 5}) {
+  async BatchNftTransfer({inputFile, concurrency = 5, batchSize = 20}) {
     // --- read data from csv file ---
     const inputData = [];
     await new Promise((resolve, reject) => {
@@ -50,7 +50,7 @@ class BatchNFTOperations {
         .on("data", (row)=>{
           inputData.push({
             addr: row.addr,
-            tokenId: ethers.BigNumber.from(row.tokenId),
+            tokenId: row.tokenId,
             fromAddr: row.fromAddr,
             toAddr: row.toAddr
           });
@@ -72,7 +72,7 @@ class BatchNFTOperations {
         tokenId: item.tokenId,
         nonce: getNonce(),
       });
-    }, { concurrency });
+    }, { concurrency, batchSize });
 
     const submittedTxs = [];
     const failed = [];
@@ -131,9 +131,10 @@ class BatchNFTOperations {
   async NftProxyTransferFrom({addr, tokenId, fromAddr, toAddr, nonce}){
 
     const nftContract = new ethers.Contract(addr, this.nftAbi, this.signer);
+    const tknId = ethers.BigNumber.from(tokenId);
 
     // check if owner of the tokenId matches 'from' address
-    const ownerOf = await nftContract.ownerOf(tokenId);
+    const ownerOf = await nftContract.ownerOf(tknId);
     if (ownerOf.toLowerCase() !==  fromAddr.toLowerCase()){
       if (this.debug) {
         console.log(`Not owner of token ${tokenId} (owner: ${ownerOf})`);
@@ -150,7 +151,7 @@ class BatchNFTOperations {
     const proxyContract = new ethers.Contract(proxyAddr, this.proxyAbi, this.signer);
     try {
       const tx = await proxyContract.proxyTransferFrom(
-        addr, fromAddr, toAddr, tokenId,
+        addr, fromAddr, toAddr, tknId,
         { nonce }
       );
       return { status: "submitted", tx, tokenId };

--- a/src/BatchNFTOperations.js
+++ b/src/BatchNFTOperations.js
@@ -2,14 +2,13 @@ const { ethers } = require("ethers");
 const fs = require("fs");
 const path = require("path");
 const { parse } = require("csv-parse");
-const { ElvClient } = require("@eluvio/elv-client-js");
 const pLimit = require("p-limit");
 
 
 class BatchNFTOperations {
 
   constructor({configUrl}) {
-    this.configUrl = configUrl || ElvClient.main;
+    this.configUrl = `${configUrl}/config`;
     this.nftAbi = JSON.parse(fs.readFileSync(
       path.resolve(__dirname, "../contracts/v3/ElvTradableLocal.abi")
     ));
@@ -37,7 +36,7 @@ class BatchNFTOperations {
 
     this.debug = debugLogging;
 
-    this.provider = new ethers.JsonRpcProvider(ethUrl);
+    this.provider = new ethers.providers.JsonRpcProvider(ethUrl);
     this.signer = new ethers.Wallet(this.privKey, this.provider);
   }
 

--- a/src/BatchNFTOperations.js
+++ b/src/BatchNFTOperations.js
@@ -1,0 +1,223 @@
+const { ethers } = require("ethers");
+const fs = require("fs");
+const path = require("path");
+const { parse } = require("csv-parse");
+const { ElvClient } = require("@eluvio/elv-client-js");
+const pLimit = require("p-limit");
+
+
+class BatchNFTOperations {
+
+  constructor({configUrl}) {
+    this.configUrl = configUrl || ElvClient.main;
+    this.nftAbi = JSON.parse(fs.readFileSync(
+      path.resolve(__dirname, "../contracts/v3/ElvTradableLocal.abi")
+    ));
+    this.proxyAbi = JSON.parse(fs.readFileSync(
+      path.resolve(__dirname, "../contracts/v3/TransferProxyRegistry.abi")
+    ));
+
+  }
+
+  async Init({debugLogging = false}={}){
+    const res = await fetch(this.configUrl);
+    if (!res.ok) throw new Error(`HTTP error ${res.status}`);
+    const cfgOut = await res.json();
+
+    const ethUrl = cfgOut?.network?.seed_nodes?.ethereum_api?.[0];
+    if (!ethUrl) {
+      throw new Error("No eth url found");
+    }
+    this.ethUrl = ethUrl;
+
+    if (!process.env.PRIVATE_KEY) {
+      throw new Error("require env PRIVATE_KEY to be set");
+    }
+    this.privKey = process.env.PRIVATE_KEY;
+
+    this.debug = debugLogging;
+
+    this.provider = new ethers.JsonRpcProvider(ethUrl);
+    this.signer = new ethers.Wallet(this.privKey, this.provider);
+  }
+
+
+  async BatchNftTransfer({inputFile, concurrency = 5}) {
+    // --- read data from csv file ---
+    const inputData = [];
+    await new Promise((resolve, reject) => {
+      fs.createReadStream(inputFile)
+        .pipe(parse({columns:true, trim: true}))
+        .on("data", (row)=>{
+          inputData.push({
+            addr: row.addr,
+            tokenId: ethers.BigNumber.from(row.tokenId),
+            fromAddr: row.fromAddr,
+            toAddr: row.toAddr
+          });
+        })
+        .on("end", () => resolve(inputData))
+        .on("error", reject);
+    });
+    console.log(`Loaded ${inputData.length} data from CSV file`);
+
+    let nonce = await this.provider.getTransactionCount(this.signer.address);
+    const getNonce = () => nonce++;
+
+    // perform nft proxy transfer in batch
+    const results = await this.batchProcessor(inputData, async (item) => {
+      return await this.NftProxyTransferFrom({
+        addr: item.addr,
+        toAddr: item.toAddr,
+        fromAddr: item.fromAddr,
+        tokenId: item.tokenId,
+        nonce: getNonce(),
+      });
+    }, { concurrency });
+
+    const submittedTxs = [];
+    const failed = [];
+    const ownerMismatch = [];
+
+    // Separate results
+    results.forEach(res => {
+      if (!res) return;
+      if (res.status === "submitted") submittedTxs.push(res);
+      else if (res.status === "failed") failed.push(res);
+      else if (res.status === "owner_mismatch") ownerMismatch.push(res);
+    });
+
+    // Wait for all submitted TXs to be mined
+    await Promise.all(submittedTxs.map(async ({ tx, tokenId }) => {
+      const receipt = await tx.wait();
+      console.log(`Token ${tokenId} mined!`);
+      if (this.debug) {
+        console.log("Receipt:", {
+          hash: receipt.transactionHash,
+          blockNumber: receipt.blockNumber,
+          gasUsed: receipt.gasUsed.toString(),
+          status: receipt.status,
+        });
+        console.log("=========================");
+      }
+    }));
+
+    console.log("All Txs processed!");
+    return { failed, ownerMismatch};
+  }
+
+  // Get nft proxy owner address
+  async NftProxyOwner({proxyAddr}) {
+    const proxyContract = new ethers.Contract(proxyAddr, this.proxyAbi, this.signer);
+    const owner = await proxyContract.owner();
+    return owner;
+  }
+
+  // Get nft proxy address
+  async CheckNftProxy({addr}) {
+    const nftInstance = new ethers.Contract(addr, this.nftAbi, this.signer);
+    const proxyAddr = await nftInstance.proxyRegistryAddress();
+    if (proxyAddr === "0x0000000000000000000000000000000000000000") {
+      throw new Error("NFT has no proxy");
+    }
+
+    const proxyOwner = await this.NftProxyOwner({proxyAddr});
+    if (proxyOwner.toLowerCase() !== this.signer.address.toLowerCase()) {
+      throw new Error(`Bad key - not proxy owner (should be: ${proxyOwner}`);
+    }
+    return proxyAddr;
+  }
+
+  // Transfer an NFT as a proxy owner
+  async NftProxyTransferFrom({addr, tokenId, fromAddr, toAddr, nonce}){
+
+    const nftContract = new ethers.Contract(addr, this.nftAbi, this.signer);
+
+    // check if owner of the tokenId matches 'from' address
+    const ownerOf = await nftContract.ownerOf(tokenId);
+    if (ownerOf.toLowerCase() !==  fromAddr.toLowerCase()){
+      if (this.debug) {
+        console.log(`Not owner of token ${tokenId} (owner: ${ownerOf})`);
+      }
+      return { status: "owner_mismatch", tokenId, addr, fromAddr, toAddr, actualOwner: ownerOf };
+    }
+
+    // get proxy addr
+    const proxyAddr = await this.CheckNftProxy({ addr });
+
+    if (this.debug) {
+      console.log("Executing proxyTransferFrom");
+    }
+    const proxyContract = new ethers.Contract(proxyAddr, this.proxyAbi, this.signer);
+    try {
+      const tx = await proxyContract.proxyTransferFrom(
+        addr, fromAddr, toAddr, tokenId,
+        { nonce }
+      );
+      return { status: "submitted", tx, tokenId };
+    } catch (e) {
+      return { status: "failed", tokenId, addr, fromAddr, toAddr, e };
+    }
+  }
+
+  // The batchProcessor expects each jobFn to return an object with a `status` field.
+  // Items with `status: "failed"` will be retried up to the retry limit using exponential backoff.
+  // Items are processed in batches based on the configured batchSize.
+  async batchProcessor(items, jobFn, {
+    batchSize = 20,
+    batchDelayMs = 2000,
+    concurrency = 5,
+    retries = 3,
+    retryDelayMs = 1000
+  } = {}) {
+    const limit = pLimit(concurrency);
+    const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+    const results = [];
+
+    for (let i = 0; i < items.length; i += batchSize) {
+      const batch = items.slice(i, i + batchSize);
+      console.log(`Processing batch ${Math.floor(i / batchSize) + 1} (${batch.length} items)...`);
+
+      // Map each item to a retried job
+      const batchResults = await Promise.all(batch.map(item => limit(async () => {
+        let attempt = 0;
+        while (attempt <= retries) {
+          const res = await jobFn(item);
+
+          if (res.status !== "failed") {
+            // Success or owner_mismatch - no retry
+            return res;
+          }
+
+          attempt++;
+          if (attempt > retries) {
+            if (this.debug) {
+              console.log(`Failed item after ${retries} retries: ${JSON.stringify(item)}`);
+            }
+            return res;
+          }
+
+          const wait = retryDelayMs * 2 ** (attempt - 1); // exponential backoff
+          if (this.debug) {
+            console.log(`Retry ${attempt} for failed item: ${JSON.stringify(item)}. Waiting ${wait}ms`);
+          }
+          await sleep(wait);
+        }
+      })));
+
+      results.push(...batchResults);
+
+      if (i + batchSize < items.length) {
+        if (this.debug) {
+          console.log(`Waiting ${batchDelayMs}ms before next batch...`);
+        }
+        await sleep(batchDelayMs);
+      }
+    }
+
+    return results;
+  }
+}
+
+exports.BatchNFTOperations = BatchNFTOperations;

--- a/src/BatchNFTOperations.js
+++ b/src/BatchNFTOperations.js
@@ -122,7 +122,7 @@ class BatchNFTOperations {
 
     const proxyOwner = await this.NftProxyOwner({proxyAddr});
     if (proxyOwner.toLowerCase() !== this.signer.address.toLowerCase()) {
-      throw new Error(`Bad key - not proxy owner (should be: ${proxyOwner}`);
+      throw new Error(`Bad key - not proxy owner (should be: ${proxyOwner})`);
     }
     return proxyAddr;
   }

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -339,9 +339,10 @@ const CmdNftPackSetDist = async ({ argv }) => {
 const CmdNftProxyTransferBatch = async ({ argv }) => {
   console.log(
     "NFT - transfer as proxy owner in batches",
-    argv.input_file,
-    argv.verbose,
-    argv.concurrency,
+    "input-file", argv.input_file,
+    "verbose", argv.verbose,
+    "concurrency", argv.concurrency,
+    "batch_size", argv.batch_size,
   );
   try {
     const configUrl = Config.networks[Config.net];
@@ -352,9 +353,36 @@ const CmdNftProxyTransferBatch = async ({ argv }) => {
     let res = await batchOps.BatchNftTransfer({
       inputFile: argv.input_file,
       concurrency: argv.concurrency,
+      batchSize: argv.batch_size,
     });
 
-    console.log(yaml.dump(res));
+    console.log("All NFT proxy transfers have been processed!");
+
+    if (res.failed && res.failed.length > 0) {
+      const file = "batchNftTransfer_failed.csv";
+      const header =  "status,tokenId,addr,fromAddr,toAddr,error\n";
+
+      const rows = res.failed.map(({ tokenId, addr, fromAddr, toAddr, e }) => {
+        const errorMsg = e?.message || e || "";
+        const safeError = `"${String(errorMsg).replace(/"/g, '""')}"`;
+        return `failed,${tokenId},${addr},${fromAddr},${toAddr},${safeError}`;
+      }).join("\n");
+
+      fs.writeFileSync(file, header + rows + "\n", "utf8");
+      console.log(`Written ${res.failed.length} failed records to ${file}`);
+    }
+
+    if (res.ownerMismatch && res.ownerMismatch.length > 0) {
+      const file = "batchNftTransfer_ownerMismatch.csv";
+      const header =  "status,tokenId,addr,fromAddr,toAddr,actualOwner\n";
+
+      const rows = res.ownerMismatch.map(({ tokenId, addr, fromAddr, toAddr, actualOwner }) => {
+        return `owner_mismatch,${tokenId},${addr},${fromAddr},${toAddr},${actualOwner}`;
+      }).join("\n");
+
+      fs.writeFileSync(file, header + rows + "\n", "utf8");
+      console.log(`Written ${res.ownerMismatch.length} owner_mismatch records to ${file}`);
+    }
   } catch(e) {
     console.error("ERROR:", e);
   }
@@ -2098,7 +2126,10 @@ yargs(hideBin(process.argv))
           type: "string",
         })
         .option("concurrency", {
-          describe: "number of concurrent operations",
+          describe: "number of concurrent operations (default: 5)",
+        })
+        .option("batch_size", {
+          describe: "size of each batch (default:20)",
         })
         .option("verbose", {
           describe: "enable debug",

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -14,6 +14,7 @@ const { hideBin } = require("yargs/helpers");
 const yaml = require("js-yaml");
 const fs = require("fs");
 const path = require("path");
+const { BatchNFTOperations } = require("../src/BatchNFTOperations");
 const prompt = require("prompt-sync")({ sigint: true });
 const exec = require("child_process").exec;
 
@@ -331,6 +332,30 @@ const CmdNftPackSetDist = async ({ argv }) => {
 
     console.log(yaml.dump(res));
   } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
+const CmdNftProxyTransferBatch = async ({ argv }) => {
+  console.log(
+    "NFT - transfer as proxy owner in batches",
+    argv.input_file,
+    argv.verbose,
+    argv.concurrency,
+  );
+  try {
+    const configUrl = Config.networks[Config.net];
+
+    batchOps = new BatchNFTOperations({configUrl});
+    await batchOps.Init({debugLogging:argv.debug});
+
+    let res = await batchOps.BatchNftTransfer({
+      inputFile: argv.input_file,
+      concurrency: argv.concurrency,
+    });
+
+    console.log(yaml.dump(res));
+  } catch(e) {
     console.error("ERROR:", e);
   }
 };
@@ -2064,6 +2089,28 @@ yargs(hideBin(process.argv))
   )
 
   .command(
+    "nft_proxy_transfer_batch <input_file>",
+    "Tranfer NFT as a proxy owner in batches",
+    (yargs) => {
+      yargs
+        .positional("input_file", {
+          describe: "CSV file with values: addr, tokenId, fromAddr, toAddr",
+          type: "string",
+        })
+        .option("concurrency", {
+          describe: "number of concurrent operations",
+        })
+        .option("verbose", {
+          describe: "enable debug",
+          type: "boolean",
+        });
+    },
+    (argv) => {
+      CmdNftProxyTransferBatch({ argv });
+    }
+  )
+
+  .command(
     "nft_build <library> <object> [options]",
     "Build the public/nft section based on asset metadata. If --nft_dir is specified, will build a generative nft based on *.json files inside the dir. See README.md for more details.",
     (yargs) => {
@@ -3133,7 +3180,7 @@ yargs(hideBin(process.argv))
       yargs.option("name", {
         describe: "Tenant name",
         type: "string"
-      })
+      });
       yargs.option("status",{
         describe: "Path to the JSON File for existing tenant provision config",
         type: "string",


### PR DESCRIPTION
# Command

```bash
./elv-live nft_proxy_transfer_batch --help
nft_proxy_transfer_batch <input_file>

Transfer NFTs as a proxy owner in batches.

Positionals:
  input_file  CSV file with columns: addr, tokenId, fromAddr, toAddr  [string] [required]

Options:
      --version       Show version number                                [boolean]
  -v, --verbose       Enable debug logging                               [boolean]
      --as_url        Alternate authority service URL (include '/as/' route if necessary) [string]
      --help          Show help                                           [boolean]
      --concurrency   Number of concurrent operations (default: 5)
      --batch_size    Number of items per batch (default: 20)
```

---

### Description

* Requires an input CSV file with the first row as headers: `addr,tokenId,fromAddr,toAddr`. Subsequent rows contain the data to process.
* Splits the input into batches of size 20 (or as specified with `--batch_size`).
* Processes items in each batch with a concurrency limit of 5 (configurable via `--concurrency`).
* Retries failed transactions up to 3 times with **exponential backoff**.
* Adds a wait time of 2 seconds between batches.
* Results are split into:
  * **Owner mismatch errors** → written to `batchNftTransfer_ownermismatch.csv`
  * **Other failures** → written to `batchNftTransfer_failed.csv`

---

### Example

input.csv
```
addr,tokenId,fromAddr,toAddr
0xe2cdae49604c4e77124f3273a41402354d8fd96e,2854006,0x02494d6c5e88664527921152aead7f29dd57c678,0x9ce2ad0c8cf040db3a7e1fdc0bc2ef58bca669da
0xe2cdae49604c4e77124f3273a41402354d8fd96e,4092064,0x0249dfa543991ded0a293adbd89bae973c6d6649,0x9ce2ad0c8cf040db3a7e1fdc0bc2ef58bca669da
0xe2cdae49604c4e77124f3273a41402354d8fd96e,8922082,0x024fc0ddc23eea5cd85ce7a362c8943fd09a682d,0x9ce2ad0c8cf040db3a7e1fdc0bc2ef58bca669da
```
Command:
```
./elv-live nft_proxy_transfer_batch input.csv 
```