### PR TITLE
add cmd to fix stuck transactions in txpool

### DIFF
--- a/src/ElvBlockchain.js
+++ b/src/ElvBlockchain.js
@@ -1,0 +1,65 @@
+const {ethers} = require("ethers");
+
+class ElvBlockchain {
+  constructor({ethUrl, privateKey}){
+    if (!ethUrl || !privateKey) {
+      throw new Error("require eth_url and PRIVATE_KEY to be set");
+    }
+
+    this.provider = new ethers.providers.JsonRpcProvider(ethUrl);
+    this.wallet = new ethers.Wallet(privateKey, this.provider);
+  }
+
+  async Init() {
+    this.userAddr = await this.wallet.getAddress();
+    console.log("Using address:", this.userAddr);
+  }
+
+  async getNonces() {
+    const latest = await this.provider.getTransactionCount(this.userAddr, "latest");
+    const pending = await this.provider.getTransactionCount(this.userAddr, "pending");
+
+    return { latest, pending };
+  }
+
+  async sendSelfTx(nonce) {
+    const tx = await this.wallet.sendTransaction({
+      to: this.userAddr,
+      value: 0,
+      nonce: nonce,
+      gasLimit: 21000,
+      maxFeePerGas: ethers.utils.parseUnits("80", "gwei"),
+      maxPriorityFeePerGas: ethers.utils.parseUnits("5", "gwei"),
+    });
+
+    console.log("Sent tx:", tx.hash, "nonce:", nonce);
+    return tx;
+  }
+
+  async waitForTx(tx) {
+    const receipt = await tx.wait();
+    console.log("Mined tx:", receipt.transactionHash);
+    return receipt;
+  }
+
+  async fixEthNonceGap({targetNonce}) {
+    console.log("Starting nonce fix...");
+
+    let { latest, pending } = await this.getNonces();
+    console.log(`Initial state, latest: ${latest}, pending: ${pending}`);
+
+    const endNonce = targetNonce>0? targetNonce: pending;
+    for (let i = latest; i <= endNonce; i++) {
+      latest = await this.provider.getTransactionCount(this.userAddr, "latest");
+
+      console.log("Current latest nonce:", latest);
+
+      const tx = await this.sendSelfTx(latest);
+      await this.waitForTx(tx);
+    }
+
+    console.log("Nonce gap fix completed.");
+  }
+}
+
+exports.ElvBlockchain = ElvBlockchain;

--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -2,11 +2,10 @@ const { ElvSpace } = require("../src/ElvSpace.js");
 const { ElvTenant } = require("../src/ElvTenant.js");
 const { ElvAccount } = require("../src/ElvAccount.js");
 const { ElvContracts } = require("../src/ElvContracts.js");
-const { EluvioLive } = require("../src/EluvioLive.js");
 const { BatchHelper } = require("../src/BatchHelper");
 const { Config } = require("../src/Config.js");
-const Ethers = require("ethers");
 const constants = require("../src/Constants");
+const { ElvBlockchain } = require("../src/ElvBlockchain");
 
 const yargs = require("yargs/yargs");
 const { hideBin } = require("yargs/helpers");
@@ -1770,6 +1769,21 @@ const CmdDeleteContentsBatch = async ({ argv }) => {
   }
 };
 
+const CmdFixEthNonceStuck = async ({ argv }) => {
+  try {
+    const elvBlkChain = new ElvBlockchain({
+      ethUrl: argv.eth_url,
+      privateKey: process.env.PRIVATE_KEY,
+    });
+    await elvBlkChain.Init();
+    const targetNonce = argv.target_nonce? argv.target_nonce : 0;
+
+    await elvBlkChain.fixEthNonceGap({ targetNonce });
+  } catch (e) {
+    console.error("ERROR:", e);
+  }
+};
+
 yargs(hideBin(process.argv))
   .option("verbose", {
     describe: "Verbose mode",
@@ -2772,6 +2786,25 @@ yargs(hideBin(process.argv))
             CmdDeleteContentsBatch({ argv });
           }
         );
+    }
+
+  )
+  .command(
+    "fix_nonce_stuck",
+    "Resolve stuck transactions by clearing pending/queued entries in the txpool for a given address",
+    (yargs) => {
+      yargs
+        .option("eth_url", {
+          describe: "Ethererum URL to connect to",
+          type: "string",
+        })
+        .option("target_nonce", {
+          describe: "Target nonce up to which transactions should be processed (defaults to current pending nonce)",
+          type: "number",
+        });
+    },
+    (argv) => {
+      CmdFixEthNonceStuck({ argv });
     }
   )
 


### PR DESCRIPTION
Command:

```
./elv-admin fix_nonce_stuck --help
 fix_nonce_stuck

Resolve stuck transactions by clearing pending/queued entries in the txpool for
a given address

Options:
      --version       Show version number                              [boolean]
  -v, --verbose       Verbose mode                                     [boolean]
      --help          Show help                                        [boolean]
      --eth_url       Ethererum URL to connect to                       [string]
      --target_nonce  Target nonce up to which transactions should be processed
                      (defaults to current pending nonce)               [number]

```


Example:
```
export PRIVATE_KEY="xxx"
./elv-admin fix_nonce_stuck --eth_url https://host-76-74-28-230.contentfabric.io/eth/
Using address: 0x6D2e648b40C693a8A76F01D214bCe660cEA940FC
Starting nonce fix...
Initial state, latest: 7767, pending: 7767
Current latest nonce: 7767
Sent tx: 0xc62b349147e90e0e193da17a0b65428ee330c4b9bf51f8f490b1c7bbf57142f1 nonce: 7767
Mined tx: 0xc62b349147e90e0e193da17a0b65428ee330c4b9bf51f8f490b1c7bbf57142f1
Nonce gap fix completed.

```