### PR TITLE
Update NFT batch transfer cmd

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@eluvio/elv-client-js": "^4.2.15",
+        "async-mutex": "^0.5.0",
         "big-number": "^2.0.0",
         "cbor-x": "^1.5.4",
         "csv-parse": "^5.3.0",
@@ -19,6 +20,7 @@
         "got": "^11.8.6",
         "js-yaml": "^3.14.1",
         "keccak256": "^1.0.6",
+        "p-limit": "^2.3.0",
         "postgres": "^3.3.5",
         "prompt-sync": "^4.2.0",
         "seedrandom": "^3.0.5",
@@ -76,7 +78,6 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.6.tgz",
       "integrity": "sha512-qAHSfAdVyFmIvl0VHELib8xar7ONuSHrE2hLnsaWkYNTI68dmi1x8GYDhJjMI/e7XWal9QBlZkwbOnkcw7Z8gQ==",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.6",
@@ -2078,6 +2079,7 @@
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
       "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
@@ -2264,6 +2266,7 @@
       "version": "8.56.10",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
       "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -2273,6 +2276,7 @@
       "version": "3.7.7",
       "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
       "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+      "peer": true,
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -2281,7 +2285,8 @@
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "peer": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
@@ -2381,6 +2386,7 @@
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
       "integrity": "sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.11.6",
         "@webassemblyjs/helper-wasm-bytecode": "1.11.6"
@@ -2389,22 +2395,26 @@
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
       "version": "1.11.6",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
-      "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw=="
+      "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.11.6",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
-      "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q=="
+      "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.12.1.tgz",
-      "integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw=="
+      "integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw==",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.11.6",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
       "integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.11.6",
         "@webassemblyjs/helper-api-error": "1.11.6",
@@ -2414,12 +2424,14 @@
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.11.6",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
-      "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA=="
+      "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.12.1.tgz",
       "integrity": "sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.12.1",
         "@webassemblyjs/helper-buffer": "1.12.1",
@@ -2431,6 +2443,7 @@
       "version": "1.11.6",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
       "integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
+      "peer": true,
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
@@ -2439,6 +2452,7 @@
       "version": "1.11.6",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
       "integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
+      "peer": true,
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
@@ -2446,12 +2460,14 @@
     "node_modules/@webassemblyjs/utf8": {
       "version": "1.11.6",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
-      "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA=="
+      "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==",
+      "peer": true
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz",
       "integrity": "sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.12.1",
         "@webassemblyjs/helper-buffer": "1.12.1",
@@ -2467,6 +2483,7 @@
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.12.1.tgz",
       "integrity": "sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.12.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
@@ -2479,6 +2496,7 @@
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.12.1.tgz",
       "integrity": "sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.12.1",
         "@webassemblyjs/helper-buffer": "1.12.1",
@@ -2490,6 +2508,7 @@
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz",
       "integrity": "sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.12.1",
         "@webassemblyjs/helper-api-error": "1.11.6",
@@ -2503,6 +2522,7 @@
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.12.1.tgz",
       "integrity": "sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.12.1",
         "@xtuc/long": "4.2.2"
@@ -2511,12 +2531,14 @@
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "peer": true
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "peer": true
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -2541,7 +2563,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2598,7 +2619,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2714,6 +2734,14 @@
       "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dependencies": {
         "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/asynckit": {
@@ -3179,7 +3207,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001587",
         "electron-to-chromium": "^1.4.668",
@@ -3424,6 +3451,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
       "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+      "peer": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -4192,6 +4220,7 @@
       "version": "5.16.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.16.1.tgz",
       "integrity": "sha512-4U5pNsuDl0EhuZpq46M5xPslstkviJuhrdobaRDBk2Jy2KO37FDAJl4lb2KlNabxT0m4MTK2UHNrsAcphE8nyw==",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -4248,7 +4277,8 @@
     "node_modules/es-module-lexer": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.3.tgz",
-      "integrity": "sha512-i1gCgmR9dCl6Vil6UKPI/trA69s08g/syhiDK9TG0Nf1RJjjFI+AzoWW7sPufzkgYAn861skuCwJa0pIIHYxvg=="
+      "integrity": "sha512-i1gCgmR9dCl6Vil6UKPI/trA69s08g/syhiDK9TG0Nf1RJjjFI+AzoWW7sPufzkgYAn861skuCwJa0pIIHYxvg==",
+      "peer": true
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -5100,7 +5130,8 @@
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "peer": true
     },
     "node_modules/globals": {
       "version": "11.12.0",
@@ -7547,7 +7578,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -7731,6 +7761,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
       "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+      "peer": true,
       "engines": {
         "node": ">=6.11.5"
       }
@@ -8020,7 +8051,8 @@
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "peer": true
     },
     "node_modules/node-addon-api": {
       "version": "2.0.2",
@@ -9147,6 +9179,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
       "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "peer": true,
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -9566,6 +9599,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -9590,6 +9624,7 @@
       "version": "5.31.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.0.tgz",
       "integrity": "sha512-Q1JFAoUKE5IMfI4Z/lkE/E6+SwgzO+x4tq4v1AyBLRj8VSYvRO6A/rQrPg1yud4g0En9EKI1TvFRF2tQFcoUkg==",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -9607,6 +9642,7 @@
       "version": "5.3.10",
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz",
       "integrity": "sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==",
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.20",
         "jest-worker": "^27.4.5",
@@ -9640,6 +9676,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
       "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
@@ -9657,6 +9694,7 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9667,7 +9705,8 @@
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "peer": true
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -9782,6 +9821,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -10028,6 +10072,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.1.tgz",
       "integrity": "sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==",
+      "peer": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -10057,6 +10102,7 @@
       "version": "5.91.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.91.0.tgz",
       "integrity": "sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.5",
@@ -10103,6 +10149,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
       "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       }
@@ -10123,6 +10170,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
       "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+      "peer": true,
       "peerDependencies": {
         "acorn": "^8"
       }
@@ -10131,6 +10179,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
       "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "homepage": "https://github.com/eluv-io/elv-live-js#readme",
   "dependencies": {
     "@eluvio/elv-client-js": "^4.2.15",
+    "async-mutex": "^0.5.0",
     "big-number": "^2.0.0",
     "cbor-x": "^1.5.4",
     "csv-parse": "^5.3.0",

--- a/src/BatchNFTOperations.js
+++ b/src/BatchNFTOperations.js
@@ -29,6 +29,7 @@ class BatchNFTOperations {
     if (!ethUrl) {
       throw new Error("No eth url found");
     }
+    console.log("ETH URL", ethUrl);
 
     if (!process.env.PRIVATE_KEY) {
       throw new Error("require env PRIVATE_KEY to be set");
@@ -226,13 +227,30 @@ class BatchNFTOperations {
 
     const executeTx = async() => {
       const nonce = await this.getNextNonce();
-      const tx = await proxyContract.proxyTransferFrom(addr, fromAddr, toAddr, tknId, nonce);
-      const receipt = await Promise.race([
-        tx.wait(),
-        new Promise((_, reject) =>
-          setTimeout(() => reject(new Error("tx.wait() timed out")), 60000)
-        )
-      ]);
+      const tx = await proxyContract.proxyTransferFrom(
+        addr,
+        fromAddr,
+        toAddr,
+        tknId,
+        {
+          nonce,
+          gasLimit: 200000,
+          maxFeePerGas: ethers.utils.parseUnits("80", "gwei"),
+          maxPriorityFeePerGas: ethers.utils.parseUnits("5", "gwei"),
+        }
+      );
+
+      let cancel;
+      const timeout = new Promise((_, reject) => {
+        const id = setTimeout(() => {
+          reject(new Error("tx.wait() timed out"));
+        }, 60000);
+
+        cancel = () => clearTimeout(id);
+      });
+
+      const receipt = await Promise.race([tx.wait(), timeout])
+        .finally(() => cancel && cancel());
       return receipt.transactionHash;
     };
 

--- a/src/BatchNFTOperations.js
+++ b/src/BatchNFTOperations.js
@@ -142,7 +142,7 @@ class BatchNFTOperations {
 
       const rows = failed.map(({ tokenId, addr, fromAddr, toAddr, e }) => {
         const errorMsg = e?.message || e || "";
-        const safeError = `"${String(errorMsg).replace(/"/g, '""')}"`;
+        const safeError = `"${String(errorMsg).replace(/"/g, "\"\"")}"`;
 
         return `failed,${tokenId},${addr},${fromAddr},${toAddr},${safeError}`;
       }).join("\n");

--- a/src/BatchNFTOperations.js
+++ b/src/BatchNFTOperations.js
@@ -3,6 +3,7 @@ const fs = require("fs");
 const path = require("path");
 const { parse } = require("csv-parse");
 const pLimit = require("p-limit");
+const { Mutex } = require("async-mutex");
 
 
 class BatchNFTOperations {
@@ -15,10 +16,11 @@ class BatchNFTOperations {
     this.proxyAbi = JSON.parse(fs.readFileSync(
       path.resolve(__dirname, "../contracts/v3/TransferProxyRegistry.abi")
     ));
-
+    this.nonce = null;
+    this.nonceMutex = new Mutex();
   }
 
-  async Init({debugLogging = false}={}){
+  async Init({debugLogging = false}={}) {
     const res = await fetch(this.configUrl);
     if (!res.ok) throw new Error(`HTTP error ${res.status}`);
     const cfgOut = await res.json();
@@ -27,7 +29,6 @@ class BatchNFTOperations {
     if (!ethUrl) {
       throw new Error("No eth url found");
     }
-    this.ethUrl = ethUrl;
 
     if (!process.env.PRIVATE_KEY) {
       throw new Error("require env PRIVATE_KEY to be set");
@@ -38,10 +39,40 @@ class BatchNFTOperations {
 
     this.provider = new ethers.providers.JsonRpcProvider(ethUrl);
     this.signer = new ethers.Wallet(this.privKey, this.provider);
+
+    this.nonce = await this.provider.getTransactionCount(
+      this.signer.address,
+      "pending"
+    );
+  }
+
+  async getNextNonce() {
+    return this.nonceMutex.runExclusive(() => {
+      const n = this.nonce;
+      this.nonce++;
+      return n;
+    });
+  }
+
+  async SyncNonce() {
+    const newNonce = await this.provider.getTransactionCount(
+      this.signer.address,
+      "pending"
+    );
+
+    await this.nonceMutex.runExclusive(() => {
+      if (this.debug) {
+        console.log(`Resyncing nonce: local=${this.nonce}, chain=${newNonce}`);
+      }
+
+      if (newNonce > this.nonce) {
+        this.nonce = newNonce;
+      }
+    });
   }
 
 
-  async BatchNftTransfer({inputFile, concurrency = 5, batchSize = 20}) {
+  async BatchNftTransfer({inputFile, concurrency = 5, batchSize = 20, outputFolder = ""}) {
     // --- read data from csv file ---
     const inputData = [];
     await new Promise((resolve, reject) => {
@@ -60,9 +91,6 @@ class BatchNFTOperations {
     });
     console.log(`Loaded ${inputData.length} data from CSV file`);
 
-    let nonce = await this.provider.getTransactionCount(this.signer.address);
-    const getNonce = () => nonce++;
-
     // perform nft proxy transfer in batch
     const results = await this.batchProcessor(inputData, async (item) => {
       return await this.NftProxyTransferFrom({
@@ -70,39 +98,85 @@ class BatchNFTOperations {
         toAddr: item.toAddr,
         fromAddr: item.fromAddr,
         tokenId: item.tokenId,
-        nonce: getNonce(),
       });
     }, { concurrency, batchSize });
 
-    const submittedTxs = [];
+    const successTxs = [];
     const failed = [];
     const ownerMismatch = [];
 
     // Separate results
     results.forEach(res => {
       if (!res) return;
-      if (res.status === "submitted") submittedTxs.push(res);
+      if (res.status === "success") successTxs.push(res);
       else if (res.status === "failed") failed.push(res);
       else if (res.status === "owner_mismatch") ownerMismatch.push(res);
     });
 
-    // Wait for all submitted TXs to be mined
-    await Promise.all(submittedTxs.map(async ({ tx, tokenId }) => {
-      const receipt = await tx.wait();
-      console.log(`Token ${tokenId} mined!`);
-      if (this.debug) {
-        console.log("Receipt:", {
-          hash: receipt.transactionHash,
-          blockNumber: receipt.blockNumber,
-          gasUsed: receipt.gasUsed.toString(),
-          status: receipt.status,
-        });
-        console.log("=========================");
-      }
-    }));
+
+    // --- output files ---
+
+    const outputDir = path.resolve(outputFolder || process.cwd());
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true });
+    }
+    const successFilePath = path.join(outputDir, "output_success_list.csv");
+    const failedFilePath = path.join(outputDir, "output_failed_list.csv");
+    const ownerMismatchFilePath = path.join(outputDir, "output_owner_mismatch_list.csv");
+
+    if (successTxs.length > 0) {
+      const header = "status,tokenId,addr,fromAddr,toAddr,tx\n";
+
+      const rows = successTxs.map(({ tokenId, addr, fromAddr, toAddr, tx }) => {
+        return `success,${tokenId},${addr},${fromAddr},${toAddr},${tx}`;
+      }).join("\n");
+
+      fs.writeFileSync(successFilePath, header + rows + "\n", "utf8");
+      console.log(`Written ${successTxs.length} records to ${successFilePath}`);
+
+    }
+
+
+    if (failed.length > 0) {
+      const header = "status,tokenId,addr,fromAddr,toAddr,error\n";
+
+      const rows = failed.map(({ tokenId, addr, fromAddr, toAddr, e }) => {
+        const errorMsg = e?.message || e || "";
+        const safeError = `"${String(errorMsg).replace(/"/g, '""')}"`;
+
+        return `failed,${tokenId},${addr},${fromAddr},${toAddr},${safeError}`;
+      }).join("\n");
+
+      fs.writeFileSync(failedFilePath, header + rows + "\n", "utf8");
+      console.log(`Written ${failed.length} failed records to ${failedFilePath}`);
+    }
+
+    if (ownerMismatch.length > 0) {
+      const header = "status,tokenId,addr,fromAddr,toAddr,actualOwner\n";
+
+      const rows = ownerMismatch.map(({ tokenId, addr, fromAddr, toAddr, actualOwner }) => {
+        return `owner_mismatch,${tokenId},${addr},${fromAddr},${toAddr},${actualOwner}`;
+      }).join("\n");
+
+      fs.writeFileSync(ownerMismatchFilePath, header + rows + "\n", "utf8");
+      console.log(`Written ${ownerMismatch.length}  records to ${ownerMismatchFilePath}`);
+    }
 
     console.log("All Txs processed!");
-    return { failed, ownerMismatch};
+    return {
+      success: {
+        count: successTxs.length,
+        filepath: successTxs.length>0? successFilePath: "",
+      },
+      failed: {
+        count: failed.length,
+        filepath: failed.length>0? failedFilePath: "",
+      },
+      owner_mismatch: {
+        count: ownerMismatch.length,
+        filepath: ownerMismatch.length>0? ownerMismatchFilePath: "",
+      },
+    };
   }
 
   // Get nft proxy owner address
@@ -128,7 +202,7 @@ class BatchNFTOperations {
   }
 
   // Transfer an NFT as a proxy owner
-  async NftProxyTransferFrom({addr, tokenId, fromAddr, toAddr, nonce}){
+  async NftProxyTransferFrom({addr, tokenId, fromAddr, toAddr}){
 
     const nftContract = new ethers.Contract(addr, this.nftAbi, this.signer);
     const tknId = ethers.BigNumber.from(tokenId);
@@ -144,31 +218,55 @@ class BatchNFTOperations {
 
     // get proxy addr
     const proxyAddr = await this.CheckNftProxy({ addr });
+    const proxyContract = new ethers.Contract(proxyAddr, this.proxyAbi, this.signer);
 
     if (this.debug) {
       console.log("Executing proxyTransferFrom");
     }
-    const proxyContract = new ethers.Contract(proxyAddr, this.proxyAbi, this.signer);
-    try {
-      const tx = await proxyContract.proxyTransferFrom(
-        addr, fromAddr, toAddr, tknId,
-        { nonce }
-      );
-      return { status: "submitted", tx, tokenId };
-    } catch (e) {
-      return { status: "failed", tokenId, addr, fromAddr, toAddr, e };
+
+    const executeTx = async() => {
+      const nonce = await this.getNextNonce();
+      const tx = await proxyContract.proxyTransferFrom(addr, fromAddr, toAddr, tknId, nonce);
+      const receipt = await Promise.race([
+        tx.wait(),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("tx.wait() timed out")), 60000)
+        )
+      ]);
+      return receipt.transactionHash;
+    };
+
+    for (let attempt = 1; attempt <= 2; attempt++) {
+      try {
+        if (this.debug) {
+          console.log(`Attempt ${attempt}: Sending tx for token ${tokenId}`);
+        }
+        const txHash = await executeTx();
+        return { status: "success", tx: txHash, tokenId, addr, fromAddr, toAddr };
+      } catch (e) {
+        if (["NONCE_EXPIRED", "REPLACEMENT_UNDERPRICED", "TRANSACTION_REPLACED"].includes(e.code)) {
+          if (attempt === 1) {
+            if (this.debug) {
+              console.log("Nonce collision detected, resyncing nonce...");
+            }
+            await this.SyncNonce();
+            // Short delay before retrying
+            await new Promise(resolve => setTimeout(resolve, 200));
+            continue; // Retry once
+          }
+        }
+        // Any other error or second failure
+        return { status: "failed", tokenId, addr, fromAddr, toAddr, e };
+      }
     }
   }
 
   // The batchProcessor expects each jobFn to return an object with a `status` field.
-  // Items with `status: "failed"` will be retried up to the retry limit using exponential backoff.
   // Items are processed in batches based on the configured batchSize.
   async batchProcessor(items, jobFn, {
     batchSize = 20,
     batchDelayMs = 2000,
     concurrency = 5,
-    retries = 3,
-    retryDelayMs = 1000
   } = {}) {
     const limit = pLimit(concurrency);
     const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
@@ -180,35 +278,27 @@ class BatchNFTOperations {
       console.log(`Processing batch ${Math.floor(i / batchSize) + 1} (${batch.length} items)...`);
 
       // Map each item to a retried job
-      const batchResults = await Promise.all(batch.map(item => limit(async () => {
-        let attempt = 0;
-        while (attempt <= retries) {
-          const res = await jobFn(item);
-
-          if (res.status !== "failed") {
-            // Success or owner_mismatch - no retry
-            return res;
-          }
-
-          attempt++;
-          if (attempt > retries) {
-            if (this.debug) {
-              console.log(`Failed item after ${retries} retries: ${JSON.stringify(item)}`);
+      const batchResults = await Promise.all(
+        batch.map(item =>
+          limit(async () => {
+            try {
+              return await jobFn(item);
+            } catch (e) {
+              return {
+                status: "failed",
+                tokenId: item.tokenId,
+                addr: item.addr,
+                fromAddr: item.fromAddr,
+                toAddr: item.toAddr,
+                e
+              };
             }
-            return res;
-          }
-
-          const wait = retryDelayMs * 2 ** (attempt - 1); // exponential backoff
-          if (this.debug) {
-            console.log(`Retry ${attempt} for failed item: ${JSON.stringify(item)}. Waiting ${wait}ms`);
-          }
-          await sleep(wait);
-        }
-      })));
-
+          })
+        )
+      );
       results.push(...batchResults);
 
-      if (i + batchSize < items.length) {
+      if (i + batchSize < items.length && batchDelayMs > 0) {
         if (this.debug) {
           console.log(`Waiting ${batchDelayMs}ms before next batch...`);
         }

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -343,49 +343,27 @@ const CmdNftProxyTransferBatch = async ({ argv }) => {
     "verbose", argv.verbose,
     "concurrency", argv.concurrency,
     "batch_size", argv.batch_size,
+    "output_folder", argv.output_folder,
   );
   try {
     const configUrl = Config.networks[Config.net];
 
-    batchOps = new BatchNFTOperations({configUrl});
-    await batchOps.Init({debugLogging:argv.debug});
+    batchOps = new BatchNFTOperations({ configUrl });
+    await batchOps.Init({ debugLogging: argv.debug });
 
     let res = await batchOps.BatchNftTransfer({
       inputFile: argv.input_file,
       concurrency: argv.concurrency,
       batchSize: argv.batch_size,
+      outputFolder: argv.output_folder
     });
 
     console.log("All NFT proxy transfers have been processed!");
-
-    if (res.failed && res.failed.length > 0) {
-      const file = "batchNftTransfer_failed.csv";
-      const header =  "status,tokenId,addr,fromAddr,toAddr,error\n";
-
-      const rows = res.failed.map(({ tokenId, addr, fromAddr, toAddr, e }) => {
-        const errorMsg = e?.message || e || "";
-        const safeError = `"${String(errorMsg).replace(/"/g, '""')}"`;
-        return `failed,${tokenId},${addr},${fromAddr},${toAddr},${safeError}`;
-      }).join("\n");
-
-      fs.writeFileSync(file, header + rows + "\n", "utf8");
-      console.log(`Written ${res.failed.length} failed records to ${file}`);
-    }
-
-    if (res.ownerMismatch && res.ownerMismatch.length > 0) {
-      const file = "batchNftTransfer_ownerMismatch.csv";
-      const header =  "status,tokenId,addr,fromAddr,toAddr,actualOwner\n";
-
-      const rows = res.ownerMismatch.map(({ tokenId, addr, fromAddr, toAddr, actualOwner }) => {
-        return `owner_mismatch,${tokenId},${addr},${fromAddr},${toAddr},${actualOwner}`;
-      }).join("\n");
-
-      fs.writeFileSync(file, header + rows + "\n", "utf8");
-      console.log(`Written ${res.ownerMismatch.length} owner_mismatch records to ${file}`);
-    }
+    console.log(yaml.dump(res));
   } catch(e) {
     console.error("ERROR:", e);
   }
+
 };
 
 const CmdNftProxyTransfer = async ({ argv }) => {
@@ -2134,6 +2112,10 @@ yargs(hideBin(process.argv))
         .option("verbose", {
           describe: "enable debug",
           type: "boolean",
+        })
+        .option("output_folder", {
+          describe: "output folder",
+          type: "string"
         });
     },
     (argv) => {


### PR DESCRIPTION
### Summary of Changes

* **Improved nonce handling & batching strategy**
  Previously, all batches were created upfront and transactions were awaited later. This caused issues when an external process / parallel process used the same key, leading to `nonce replacement` errors and potential hangs.
  Updated the flow to process transactions **batch-by-batch**, waiting for each batch to be mined before proceeding.

  * Default behavior: **5 concurrent transactions per batch of 20**

* **Simplified retry logic**
  Earlier, failed transactions were retried up to 3 times. However, nonce replacement errors could cascade across subsequent transactions due to incremented nonces, causing further failures and hangs.
  Now:

  * Each failed transaction is **retried once**
  * If it still fails, it is recorded in the **failed set**

* **nonce sync**
  Nonce are synced from blockchain after each batch. Also, when nonce_replacement occurs.

* **Added transaction timeout**
  Introduced a **1-minute timeout** for transaction confirmation.
  * If a transaction is not mined within this period, it is marked as **failed**

*  Results are now written to output files:
     * Successful transactions
     * Failed transactions
     * Owner mismatch cases

  This allows easy re-running of the **failed subset** batch.

### Example:

```
/elv-live nft_proxy_transfer_batch ./input.csv --output_folder ./outputs

Loaded 44 data from CSV file
Processing batch 1 (20 items)...
Processing batch 2 (20 items)...
Processing batch 3 (4 items)...
Written 44 records to ./outputs/output_success_list.csv
All Txs processed!
All NFT proxy transfers have been processed!
success:
  count: 44
  filepath: ./outputs/output_success_list.csv
failed:
  count: 0
  filepath: ''
owner_mismatch:
  count: 0
  filepath: ''
```