### PR TITLE
Add group decrypt oauth and oauth sync cmds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@eluvio/elv-client-js": "^4.2.15",
+        "axios": "^1.15.0",
         "big-number": "^2.0.0",
         "cbor-x": "^1.5.4",
         "csv-parse": "^5.3.0",
@@ -19,6 +20,7 @@
         "got": "^11.8.6",
         "js-yaml": "^3.14.1",
         "keccak256": "^1.0.6",
+        "p-limit": "^2.3.0",
         "postgres": "^3.3.5",
         "prompt-sync": "^4.2.0",
         "seedrandom": "^3.0.5",
@@ -76,7 +78,6 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.6.tgz",
       "integrity": "sha512-qAHSfAdVyFmIvl0VHELib8xar7ONuSHrE2hLnsaWkYNTI68dmi1x8GYDhJjMI/e7XWal9QBlZkwbOnkcw7Z8gQ==",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.6",
@@ -2078,6 +2079,7 @@
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
       "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
@@ -2264,6 +2266,7 @@
       "version": "8.56.10",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
       "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -2273,6 +2276,7 @@
       "version": "3.7.7",
       "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
       "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+      "peer": true,
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -2281,7 +2285,8 @@
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "peer": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
@@ -2381,6 +2386,7 @@
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
       "integrity": "sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.11.6",
         "@webassemblyjs/helper-wasm-bytecode": "1.11.6"
@@ -2389,22 +2395,26 @@
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
       "version": "1.11.6",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
-      "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw=="
+      "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.11.6",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
-      "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q=="
+      "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.12.1.tgz",
-      "integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw=="
+      "integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw==",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.11.6",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
       "integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.11.6",
         "@webassemblyjs/helper-api-error": "1.11.6",
@@ -2414,12 +2424,14 @@
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.11.6",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
-      "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA=="
+      "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.12.1.tgz",
       "integrity": "sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.12.1",
         "@webassemblyjs/helper-buffer": "1.12.1",
@@ -2431,6 +2443,7 @@
       "version": "1.11.6",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
       "integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
+      "peer": true,
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
@@ -2439,6 +2452,7 @@
       "version": "1.11.6",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
       "integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
+      "peer": true,
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
@@ -2446,12 +2460,14 @@
     "node_modules/@webassemblyjs/utf8": {
       "version": "1.11.6",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
-      "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA=="
+      "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==",
+      "peer": true
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz",
       "integrity": "sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.12.1",
         "@webassemblyjs/helper-buffer": "1.12.1",
@@ -2467,6 +2483,7 @@
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.12.1.tgz",
       "integrity": "sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.12.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
@@ -2479,6 +2496,7 @@
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.12.1.tgz",
       "integrity": "sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.12.1",
         "@webassemblyjs/helper-buffer": "1.12.1",
@@ -2490,6 +2508,7 @@
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz",
       "integrity": "sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.12.1",
         "@webassemblyjs/helper-api-error": "1.11.6",
@@ -2503,6 +2522,7 @@
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.12.1.tgz",
       "integrity": "sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.12.1",
         "@xtuc/long": "4.2.2"
@@ -2511,12 +2531,14 @@
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "peer": true
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "peer": true
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -2541,7 +2563,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2598,7 +2619,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2719,8 +2739,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -2735,6 +2754,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/babel-jest": {
@@ -3179,7 +3223,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001587",
         "electron-to-chromium": "^1.4.668",
@@ -3424,6 +3467,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
       "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+      "peer": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -3546,7 +3590,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3929,7 +3972,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4192,6 +4234,7 @@
       "version": "5.16.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.16.1.tgz",
       "integrity": "sha512-4U5pNsuDl0EhuZpq46M5xPslstkviJuhrdobaRDBk2Jy2KO37FDAJl4lb2KlNabxT0m4MTK2UHNrsAcphE8nyw==",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -4248,7 +4291,8 @@
     "node_modules/es-module-lexer": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.3.tgz",
-      "integrity": "sha512-i1gCgmR9dCl6Vil6UKPI/trA69s08g/syhiDK9TG0Nf1RJjjFI+AzoWW7sPufzkgYAn861skuCwJa0pIIHYxvg=="
+      "integrity": "sha512-i1gCgmR9dCl6Vil6UKPI/trA69s08g/syhiDK9TG0Nf1RJjjFI+AzoWW7sPufzkgYAn861skuCwJa0pIIHYxvg==",
+      "peer": true
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -4257,6 +4301,20 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4888,10 +4946,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
-      "dev": true,
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -5100,7 +5157,8 @@
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "peer": true
     },
     "node_modules/globals": {
       "version": "11.12.0",
@@ -7547,7 +7605,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -7731,6 +7788,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
       "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+      "peer": true,
       "engines": {
         "node": ">=6.11.5"
       }
@@ -8020,7 +8078,8 @@
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "peer": true
     },
     "node_modules/node-addon-api": {
       "version": "2.0.2",
@@ -8683,6 +8742,14 @@
         "node": ">= 6"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -9147,6 +9214,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
       "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "peer": true,
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -9566,6 +9634,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -9590,6 +9659,7 @@
       "version": "5.31.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.0.tgz",
       "integrity": "sha512-Q1JFAoUKE5IMfI4Z/lkE/E6+SwgzO+x4tq4v1AyBLRj8VSYvRO6A/rQrPg1yud4g0En9EKI1TvFRF2tQFcoUkg==",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -9607,6 +9677,7 @@
       "version": "5.3.10",
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz",
       "integrity": "sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==",
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.20",
         "jest-worker": "^27.4.5",
@@ -9640,6 +9711,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
       "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
@@ -9657,6 +9729,7 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9667,7 +9740,8 @@
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "peer": true
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -10028,6 +10102,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.1.tgz",
       "integrity": "sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==",
+      "peer": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -10057,6 +10132,7 @@
       "version": "5.91.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.91.0.tgz",
       "integrity": "sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.5",
@@ -10103,6 +10179,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
       "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       }
@@ -10123,6 +10200,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
       "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+      "peer": true,
       "peerDependencies": {
         "acorn": "^8"
       }
@@ -10131,6 +10209,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
       "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "homepage": "https://github.com/eluv-io/elv-live-js#readme",
   "dependencies": {
     "@eluvio/elv-client-js": "^4.2.15",
+    "axios": "^1.15.0",
     "big-number": "^2.0.0",
     "cbor-x": "^1.5.4",
     "csv-parse": "^5.3.0",

--- a/src/ElvFabric.js
+++ b/src/ElvFabric.js
@@ -497,7 +497,7 @@ class ElvFabric {
     }
 
     const contentSpaceLibraryId = ElvUtils.AddressToId({prefix: "ilib", address: spaceAddr});
-    const groupId = ElvUtils.AddressToId({prefix: "iq__", address: group})
+    const groupId = ElvUtils.AddressToId({prefix: "iq__", address: group});
     const userIdKey = "/eluv.jwtv." + ElvUtils.AddressToId({prefix: "iusr", address: this.client.signer.address});
     const kmsIdKey = "/eluv.jwtv." + ElvUtils.AddressToId({prefix: "ikms", address: this.client.signer.address});
     let cap = await this.client.ContentObjectMetadata({

--- a/src/ElvFabric.js
+++ b/src/ElvFabric.js
@@ -482,7 +482,7 @@ class ElvFabric {
   }
 
 
-  async GroupDecryptCap({group, spaceAddr}) {
+  async GroupDecryptOauth({group, spaceAddr}) {
     if (!group || !spaceAddr) {
       throw new Error("group and spaceAddr are required");
     }
@@ -518,6 +518,92 @@ class ElvFabric {
     }
 
     return await this.client.Crypto.DecryptCap(cap, this.client.signer._signingKey().privateKey);
+  }
+
+  async GroupEncryptOauth({group, spaceAddr, kmsAddr, oauthConfig}) {
+
+    if (this.debug) {
+      console.log("Group", group);
+      console.log("SpaceAddr", spaceAddr);
+      console.log("KmsAddr", kmsAddr);
+      console.log("OauthConfig", oauthConfig);
+    }
+
+
+    if (!group || !spaceAddr) {
+      throw new Error("group and spaceAddr are required");
+    }
+    if (!kmsAddr) {
+      throw new Error("kmsAddr is required");
+    }
+
+    if (!oauthConfig ) {
+      throw new Error(`
+        oauthConfig is required:
+        {
+          issuer: 'https://xxx/oauth2/default',
+          claims: {
+              aud: '0oaxxx',
+              groups: [ 'group-name' ]
+          }
+        }`);
+    }
+
+    let parsedOauthConfig;
+    try {
+      parsedOauthConfig =
+        typeof oauthConfig === "string"
+          ? JSON.parse(oauthConfig)
+          : oauthConfig;
+    } catch (e) {
+      throw new Error("oauthConfig must be valid JSON");
+    }
+
+    const {issuer, claims} = parsedOauthConfig;
+    if (!issuer || typeof issuer !== "string") {
+      throw new Error("oauthConfig.issuer must be set");
+    }
+    if (!claims || typeof claims !== "object") {
+      throw new Error("oauthConfig.claims must be an object");
+    }
+    if (!claims.aud || typeof claims.aud !== "string") {
+      throw new Error("oauthConfig.claims.aud must be set");
+    }
+    if (!claims.groups || !Array.isArray(claims.groups) || claims.groups.length === 0){
+      throw new Error("oauthConfig.claims.groups must be set with array of groups");
+    }
+
+    if (group.startsWith("igrp")){
+      group = this.client.utils.HashToAddress(group);
+    }
+
+    const kmsId = ElvUtils.AddressToId({prefix: "ikms", address: kmsAddr});
+
+
+    await this.client.LinkAccessGroupToOauth({
+      groupAddress: group,
+      kmsId,
+      oauthConfig: parsedOauthConfig
+    });
+
+    const contentSpaceLibraryId = ElvUtils.AddressToId({prefix: "ilib", address: spaceAddr});
+    const groupId = ElvUtils.AddressToId({prefix: "iq__", address: group});
+    const metadata = await this.client.ContentObjectMetadata({
+      libraryId: contentSpaceLibraryId,
+      objectId: groupId,
+    });
+
+    const kmsIdKey = "eluv.jwtv." + kmsId;
+    const userIdKey = "eluv.jwtv." + ElvUtils.AddressToId({prefix: "iusr", address: this.client.signer.address});
+    const hasKmsCap = metadata && metadata[kmsIdKey] !== undefined;
+    const hasUserCap = metadata && metadata[userIdKey] !== undefined;
+    if (!hasKmsCap) {
+      throw Error(`KMS ${kmsIdKey} not set in metadata`);
+    }
+    if (!hasUserCap) {
+      throw Error(`USER ${userIdKey} not set in metadata`);
+    }
+    return `Successfully set oauthConfig on ${group}.`;
   }
 }
 

--- a/src/ElvFabric.js
+++ b/src/ElvFabric.js
@@ -482,6 +482,43 @@ class ElvFabric {
   }
 
 
+  async GroupDecryptCap({group, spaceAddr}) {
+    if (!group || !spaceAddr) {
+      throw new Error("group and spaceAddr are required");
+    }
+
+    if (group.startsWith("igrp")){
+      group = this.client.utils.HashToAddress(group);
+    }
+
+    if (this.debug) {
+      console.log("Group", group);
+      console.log("SpaceAddr", spaceAddr);
+    }
+
+    const contentSpaceLibraryId = ElvUtils.AddressToId({prefix: "ilib", address: spaceAddr});
+    const groupId = ElvUtils.AddressToId({prefix: "iq__", address: group})
+    const userIdKey = "/eluv.jwtv." + ElvUtils.AddressToId({prefix: "iusr", address: this.client.signer.address});
+    const kmsIdKey = "/eluv.jwtv." + ElvUtils.AddressToId({prefix: "ikms", address: this.client.signer.address});
+    let cap = await this.client.ContentObjectMetadata({
+      libraryId: contentSpaceLibraryId,
+      objectId: groupId,
+      metadataSubtree: userIdKey,
+    });
+    if (!cap) {
+      cap = await this.client.ContentObjectMetadata({
+        libraryId: contentSpaceLibraryId,
+        objectId: groupId,
+        metadataSubtree: kmsIdKey,
+      });
+
+      if (!cap) {
+        throw new Error(`Cap not found for group ${group} for signer ${this.client.signer.address}`);
+      }
+    }
+
+    return await this.client.Crypto.DecryptCap(cap, this.client.signer._signingKey().privateKey);
+  }
 }
 
 

--- a/src/ElvIssuer.js
+++ b/src/ElvIssuer.js
@@ -132,7 +132,7 @@ class ElvIssuer {
       console.log("total groups:", groupCount);
 
       if (userCount === 0 || groupCount === 0) {
-        throw new Error("require users and groups to be set in user_group_list file");
+        throw new Error(`Invalid oauthInfo: users=${userCount}, groups=${groupCount}. Ensure user_group_list file is populated.`);
       }
     }
 

--- a/src/ElvIssuer.js
+++ b/src/ElvIssuer.js
@@ -1,0 +1,186 @@
+const axios = require("axios");
+const fs = require("fs");
+const path = require("path");
+const { ElvClient } = require("@eluvio/elv-client-js");
+
+class ElvIssuer {
+
+  constructor({configUrl, debugLogging = false}) {
+    this.configUrl = configUrl;
+    this.debug = debugLogging;
+  }
+
+  async Init() {
+    this.client = await ElvClient.FromConfigurationUrl({
+      configUrl: this.configUrl,
+    });
+    this.client.ToggleLogging(this.debug);
+  }
+
+  async fetchAllOktaUsersAndGroups({client, url}) {
+    let results = [];
+    let nextUrl = url;
+
+    while (nextUrl) {
+      console.log("Fetching:", nextUrl);
+
+      const res = await client.get(nextUrl);
+
+      results = results.concat(res.data);
+
+      // Parse Link header for pagination
+      const linkHeader = res.headers?.link;
+
+      if (linkHeader) {
+        const match = linkHeader.match(/<([^>]+)>;\s*rel="next"/);
+        nextUrl = match ? match[1] : null;
+      } else {
+        nextUrl = null;
+      }
+    }
+
+    return results;
+  }
+
+  formatUsers(users) {
+    const formatted = {};
+
+    users.forEach(user => {
+      formatted[user.id] = {
+        type: "oauthUser",
+        address: user.id,
+        name: `${user.profile.firstName || ""} ${user.profile.lastName || ""} (${user.profile.email || ""})`.trim()
+      };
+    });
+    return formatted;
+  }
+
+  formatGroups(groups) {
+    const formatted = {};
+
+    groups.forEach(group => {
+      formatted[group.id] = {
+        type: "oauthGroup",
+        address: group.id,
+        name: group.profile.name || group.id,
+        description: group.profile.description || ""
+      };
+    });
+    return formatted;
+  }
+
+  async GetOktaGroupsAndUsers({oktaDomain, adminToken, out}) {
+    if (!oktaDomain) {
+      throw new Error("require okta-domain to be set");
+    }
+    if (!adminToken) {
+      throw new Error("require env ADMIN_TOKEN to be set");
+    }
+
+    let filePath;
+    if (out) {
+      filePath = path.isAbsolute(out)? out : path.join(process.cwd(), out);
+    }
+
+    const client = axios.create({
+      baseURL: oktaDomain,
+      headers: {
+        Authorization: `SSWS ${adminToken}`,
+        Accept: "application/json"
+      }
+    });
+
+    const users = await this.fetchAllOktaUsersAndGroups({client, url:"/api/v1/users"});
+    const formattedUsers = this.formatUsers(users);
+
+    const groups = await this.fetchAllOktaUsersAndGroups({client, url:"/api/v1/groups"});
+    const formattedGroups = this.formatGroups(groups);
+
+    const res = {formattedUsers, formattedGroups};
+    if (filePath) {
+      fs.writeFileSync(filePath, JSON.stringify(res, null, 2), "utf-8");
+      return `JSON written to: ${filePath}`;
+    }
+    return res;
+  }
+
+
+  async SyncOktaIssuer({policyId, oktaDomain, adminToken, privateKey, keepExisting}) {
+
+    if (!privateKey) {
+      throw new Error("require env PRIVATE_KEY to be set");
+    }
+    if (!policyId) {
+      throw new Error("require policyId to be set");
+    }
+
+    let wallet = this.client.GenerateWallet();
+    let signer = wallet.AddAccount({privateKey: privateKey});
+    this.client.SetSigner({signer});
+
+    const oauthInfo = this.GetOktaGroupsAndUsers({oktaDomain, adminToken});
+
+    const libraryId = await this.client.ContentObjectLibraryId({objectId: policyId});
+
+    const editResponse = await this.client.EditContentObject({
+      libraryId,
+      objectId: policyId
+    });
+    const writeToken = editResponse.write_token;
+    console.log("write_token created:", writeToken);
+
+    const existingPart = await this.client.ContentObjectMetadata({
+      libraryId,
+      objectId: policyId,
+      metadataSubtree: "oauth_settings"
+    });
+    if (existingPart){
+      console.log("existing oauth_settings part:", existingPart);
+    }
+
+    const partInfo = await this.client.UploadPart({
+      libraryId,
+      objectId: policyId,
+      writeToken,
+      encryption: "cgck",
+      data: Buffer.from(JSON.stringify(oauthInfo))
+    });
+    const partHash = partInfo.part.hash;
+    console.log("new oauth_settings part:", partHash);
+
+    await this.client.ReplaceMetadata({
+      libraryId,
+      objectId: policyId,
+      writeToken,
+      metadataSubtree: "oauth_settings",
+      metadata: partHash
+    });
+
+    if (existingPart && !keepExisting) {
+      console.log("Deleting existing OAuth part hash...");
+      try {
+        await this.client.DeletePart({
+          libraryId,
+          objectId: policyId,
+          writeToken,
+          partHash: existingPart
+        });
+      } catch (e) {
+        console.log("Unable to delete existing part", e);
+      }
+    }
+
+    await this.client.FinalizeContentObject({
+      libraryId,
+      objectId: policyId,
+      writeToken: editResponse.write_token,
+      commitMessage: "OAuth sync"
+    });
+
+    return "Successfully synced with OAuth";
+
+  }
+
+}
+
+exports.ElvIssuer = ElvIssuer;

--- a/src/ElvIssuer.js
+++ b/src/ElvIssuer.js
@@ -90,13 +90,13 @@ class ElvIssuer {
       }
     });
 
-    const users = await this.fetchAllOktaUsersAndGroups({client, url:"/api/v1/users"});
-    const formattedUsers = this.formatUsers(users);
+    const oktaUsers = await this.fetchAllOktaUsersAndGroups({client, url:"/api/v1/users"});
+    const users = this.formatUsers(oktaUsers);
 
-    const groups = await this.fetchAllOktaUsersAndGroups({client, url:"/api/v1/groups"});
-    const formattedGroups = this.formatGroups(groups);
+    const oktaGroups = await this.fetchAllOktaUsersAndGroups({client, url:"/api/v1/groups"});
+    const groups = this.formatGroups(oktaGroups);
 
-    const res = {formattedUsers, formattedGroups};
+    const res = {users, groups};
     if (filePath) {
       fs.writeFileSync(filePath, JSON.stringify(res, null, 2), "utf-8");
       return `JSON written to: ${filePath}`;
@@ -105,7 +105,7 @@ class ElvIssuer {
   }
 
 
-  async SyncOktaIssuer({policyId, oktaDomain, adminToken, privateKey, keepExisting}) {
+  async SyncOktaIssuer({policyId, oktaDomain, adminToken, privateKey, keepExistingPart, userGroupList}) {
 
     if (!privateKey) {
       throw new Error("require env PRIVATE_KEY to be set");
@@ -118,7 +118,23 @@ class ElvIssuer {
     let signer = wallet.AddAccount({privateKey: privateKey});
     this.client.SetSigner({signer});
 
-    const oauthInfo = this.GetOktaGroupsAndUsers({oktaDomain, adminToken});
+    let oauthInfo;
+    if (!userGroupList) {
+      oauthInfo = this.GetOktaGroupsAndUsers({oktaDomain, adminToken});
+    } else {
+      const raw = fs.readFileSync(userGroupList, "utf-8");
+      oauthInfo = JSON.parse(raw);
+
+      const userCount = Object.keys(oauthInfo.users || {}).length;
+      const groupCount = Object.keys(oauthInfo.groups || {}).length;
+
+      console.log("total users:", userCount);
+      console.log("total groups:", groupCount);
+
+      if (userCount === 0 || groupCount === 0) {
+        throw new Error("require users and groups to be set in user_group_list file");
+      }
+    }
 
     const libraryId = await this.client.ContentObjectLibraryId({objectId: policyId});
 
@@ -156,7 +172,7 @@ class ElvIssuer {
       metadata: partHash
     });
 
-    if (existingPart && !keepExisting) {
+    if (existingPart && !keepExistingPart) {
       console.log("Deleting existing OAuth part hash...");
       try {
         await this.client.DeletePart({

--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -1780,7 +1780,7 @@ const CmdGroupDecryptCap = async ({argv}) => {
     await elvFabric.Init({privateKey: process.env.PRIVATE_KEY});
 
     const res = await elvFabric.GroupDecryptCap({
-      group: argv.group_id,
+      group: argv.group,
       spaceAddr: Config.consts[Config.net].spaceAddress,
     });
     console.log(yaml.dump(res));
@@ -2795,11 +2795,11 @@ yargs(hideBin(process.argv))
   )
 
   .command(
-    "group_decrypt_cap <group_id>",
+    "group_decrypt_cap <group>",
     "Decrypt the cap stored in eluv.jwt metadata",
     (yargs) => {
-      yargs.positional("group_id",{
-        describe: "group id",
+      yargs.positional("group",{
+        describe: "group id or address",
         type: "string"
       });
     },

--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -1770,6 +1770,25 @@ const CmdDeleteContentsBatch = async ({ argv }) => {
   }
 };
 
+const CmdGroupDecryptCap = async ({argv}) => {
+  try {
+    const elvFabric = new ElvFabric({
+      configUrl: Config.networks[Config.net],
+      debugLogging: argv.verbose,
+    });
+
+    await elvFabric.Init({privateKey: process.env.PRIVATE_KEY});
+
+    const res = await elvFabric.GroupDecryptCap({
+      group: argv.group_id,
+      spaceAddr: Config.consts[Config.net].spaceAddress,
+    });
+    console.log(yaml.dump(res));
+  } catch (e) {
+    console.error("ERROR:", argv.verbose? e: e.message);
+  }
+};
+
 yargs(hideBin(process.argv))
   .option("verbose", {
     describe: "Verbose mode",
@@ -2772,6 +2791,20 @@ yargs(hideBin(process.argv))
             CmdDeleteContentsBatch({ argv });
           }
         );
+    }
+  )
+
+  .command(
+    "group_decrypt_cap <group_id>",
+    "Decrypt the cap stored in eluv.jwt metadata",
+    (yargs) => {
+      yargs.positional("group_id",{
+        describe: "group id",
+        type: "string"
+      });
+    },
+    (argv) => {
+      CmdGroupDecryptCap({argv});
     }
   )
 

--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -7,6 +7,7 @@ const { BatchHelper } = require("../src/BatchHelper");
 const { Config } = require("../src/Config.js");
 const Ethers = require("ethers");
 const constants = require("../src/Constants");
+const { ElvIssuer } = require("../src/ElvIssuer");
 
 const yargs = require("yargs/yargs");
 const { hideBin } = require("yargs/helpers");
@@ -1810,6 +1811,49 @@ const CmdGroupEncryptOauth = async ({argv}) => {
   }
 };
 
+const CmdIssuerOktaGet = async ({argv}) => {
+  try {
+    const adminToken = process.env.ADMIN_TOKEN;
+    const elvIssuer = new ElvIssuer({
+      configUrl: Config.networks[Config.net],
+      debug: argv.verbose,
+    });
+
+    await elvIssuer.Init();
+    const res = await elvIssuer.GetOktaGroupsAndUsers({
+      oktaDomain: argv.okta_domain,
+      adminToken: adminToken,
+      out: argv.out
+    });
+    console.log(yaml.dump(res));
+  } catch (e) {
+    console.error("ERROR:", argv.verbose? e: e.message);
+  }
+};
+
+const CmdIssuerOktaSync = async ({argv}) => {
+  try {
+    const adminToken = process.env.ADMIN_TOKEN;
+    const privateKey = process.env.PRIVATE_KEY;
+    const elvIssuer = new ElvIssuer({
+      configUrl: Config.networks[Config.net],
+      debug: argv.verbose,
+    });
+
+    await elvIssuer.Init();
+    const res = await elvIssuer.SyncOktaIssuer({
+      policyId: argv.policy_id,
+      oktaDomain: argv.okta_domain,
+      adminToken,
+      privateKey,
+      keepExisting: argv.keep_existing
+    });
+    console.log(yaml.dump(res));
+  } catch (e) {
+    console.error("ERROR:", argv.verbose? e: e.message);
+  }
+};
+
 yargs(hideBin(process.argv))
   .option("verbose", {
     describe: "Verbose mode",
@@ -2845,6 +2889,49 @@ yargs(hideBin(process.argv))
     },
     (argv) => {
       CmdGroupEncryptOauth({argv});
+    }
+  )
+
+  .command(
+    "issuer_okta_get <okta_domain>",
+    "Retrieve all Okta users and groups for given issuer",
+    (yargs) => {
+      yargs
+        .positional("okta_domain", {
+          describe: "okta domain url",
+          type: "string"
+        })
+        .option("out", {
+          describe: "output-file path",
+          type: "string"
+        });
+    },
+    (argv) => {
+      CmdIssuerOktaGet({argv});
+    }
+  )
+
+  .command(
+    "issuer_okta_sync <policy_id> <okta_domain>",
+    "Retrieve all Okta users and groups for given issuer and update the policy object metadata",
+    (yargs) => {
+      yargs
+        .positional("policy_id", {
+          describe: "policy id",
+          type: "string"
+        })
+        .positional("okta_domain", {
+          describe: "okta domain url",
+          type: "string"
+        })
+        .option("keep_existing", {
+          describe: "do not delete oauth_settings part hash",
+          type: "boolean",
+          default: false,
+        });
+    },
+    (argv) => {
+      CmdIssuerOktaSync({argv});
     }
   )
 

--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -2817,7 +2817,7 @@ yargs(hideBin(process.argv))
 
   .command(
     "group_decrypt_oauth <group>",
-    "Decrypt the cap stored in eluv.jwt metadata",
+    "Decrypt the oauth info: issuer, claims.aud, claims.groups[] from group metadata",
     (yargs) => {
       yargs.positional("group",{
         describe: "group id or address",
@@ -2831,7 +2831,7 @@ yargs(hideBin(process.argv))
 
   .command(
     "group_encrypt_oauth <group> <oauth_config>",
-    "Decrypt the cap stored in eluv.jwt metadata",
+    "Encrypt oauth info: issuer, claims.aud, claims.groups[] and store in group metadata",
     (yargs) => {
       yargs
         .positional("group",{

--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -1846,7 +1846,8 @@ const CmdIssuerOktaSync = async ({argv}) => {
       oktaDomain: argv.okta_domain,
       adminToken,
       privateKey,
-      keepExisting: argv.keep_existing
+      keepExistingPart: argv.keep_existing_part,
+      userGroupList: argv.user_group_list
     });
     console.log(yaml.dump(res));
   } catch (e) {
@@ -2924,10 +2925,14 @@ yargs(hideBin(process.argv))
           describe: "okta domain url",
           type: "string"
         })
-        .option("keep_existing", {
-          describe: "do not delete oauth_settings part hash",
+        .option("keep_existing_part", {
+          describe: "do not delete existing oauth_settings part hash",
           type: "boolean",
           default: false,
+        })
+        .option("user_group_list", {
+          describe: "users and groups list to store in part",
+          type: "string",
         });
     },
     (argv) => {

--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -1770,7 +1770,7 @@ const CmdDeleteContentsBatch = async ({ argv }) => {
   }
 };
 
-const CmdGroupDecryptCap = async ({argv}) => {
+const CmdGroupDecryptOauth = async ({argv}) => {
   try {
     const elvFabric = new ElvFabric({
       configUrl: Config.networks[Config.net],
@@ -1779,9 +1779,30 @@ const CmdGroupDecryptCap = async ({argv}) => {
 
     await elvFabric.Init({privateKey: process.env.PRIVATE_KEY});
 
-    const res = await elvFabric.GroupDecryptCap({
+    const res = await elvFabric.GroupDecryptOauth({
       group: argv.group,
       spaceAddr: Config.consts[Config.net].spaceAddress,
+    });
+    console.log(yaml.dump(res));
+  } catch (e) {
+    console.error("ERROR:", argv.verbose? e: e.message);
+  }
+};
+
+const CmdGroupEncryptOauth = async ({argv}) => {
+  try {
+    const elvFabric = new ElvFabric({
+      configUrl: Config.networks[Config.net],
+      debugLogging: argv.verbose,
+    });
+
+    await elvFabric.Init({privateKey: process.env.PRIVATE_KEY});
+
+    const res = await elvFabric.GroupEncryptOauth({
+      group: argv.group,
+      spaceAddr: Config.consts[Config.net].spaceAddress,
+      kmsAddr: Config.consts[Config.net].kmsAddress,
+      oauthConfig: argv.oauth_config,
     });
     console.log(yaml.dump(res));
   } catch (e) {
@@ -2795,7 +2816,7 @@ yargs(hideBin(process.argv))
   )
 
   .command(
-    "group_decrypt_cap <group>",
+    "group_decrypt_oauth <group>",
     "Decrypt the cap stored in eluv.jwt metadata",
     (yargs) => {
       yargs.positional("group",{
@@ -2804,7 +2825,26 @@ yargs(hideBin(process.argv))
       });
     },
     (argv) => {
-      CmdGroupDecryptCap({argv});
+      CmdGroupDecryptOauth({argv});
+    }
+  )
+
+  .command(
+    "group_encrypt_oauth <group> <oauth_config>",
+    "Decrypt the cap stored in eluv.jwt metadata",
+    (yargs) => {
+      yargs
+        .positional("group",{
+          describe: "group id or address",
+          type: "string"
+        })
+        .positional("oauth_config",{
+          describe: "oauth config json",
+          type: "string"
+        });
+    },
+    (argv) => {
+      CmdGroupEncryptOauth({argv});
     }
   )
 

--- a/utilities/EluvioCli.js
+++ b/utilities/EluvioCli.js
@@ -2913,7 +2913,7 @@ yargs(hideBin(process.argv))
   )
 
   .command(
-    "issuer_okta_sync <policy_id> <okta_domain>",
+    "issuer_okta_sync <policy_id>",
     "Retrieve all Okta users and groups for given issuer and update the policy object metadata",
     (yargs) => {
       yargs
@@ -2921,7 +2921,7 @@ yargs(hideBin(process.argv))
           describe: "policy id",
           type: "string"
         })
-        .positional("okta_domain", {
+        .option("okta_domain", {
           describe: "okta domain url",
           type: "string"
         })


### PR DESCRIPTION
https://github.com/qluvio/elv-master/issues/1313

## Command:

```
./elv-admin group_decrypt_oauth --help                                    

 group_decrypt_oauth <group>

Decrypt the oauth info: issuer, claims.aud, claims.groups[] from group metadata

Positionals:
  group  group id or address                                 [string] [required]

```

```
./elv-admin group_encrypt_oauth --help

 group_encrypt_oauth <group> <oauth_config>

Encrypt oauth info: issuer, claims.aud, claims.groups[] and store in group
metadata

Positionals:
  group         group id or address                          [string] [required]
  oauth_config  oauth config json                            [string] [required]
```

## In dv3:

```
./elv-admin group_encrypt_oauth 0xdf79aa8b87bec4af0289cf1d6e65a3ebe73cee08 '{"issuer":"https://cognito-idp.us-west-1.amazonaws.com/us-west-1_8PGDyw7fe","claims
":{"aud":"6mb8fpsepk6ta1mb6ecb4n4ptr","groups":["editor"]}}'  

Successfully set oauthConfig on 0xdf79aa8b87bec4af0289cf1d6e65a3ebe73cee08.
```
```
./elv-admin group_decrypt_oauth 0xdf79aa8b87bec4af0289cf1d6e65a3ebe73cee08                                                                        

issuer: 'https://cognito-idp.us-west-1.amazonaws.com/us-west-1_8PGDyw7fe'
claims:
  aud: 6mb8fpsepk6ta1mb6ecb4n4ptr
  groups:
    - editor
```

## Example:
```
export PRIVATE_KEY="<mgm-elv-admin-key>"
./elv-admin group_decrypt_cap 0x6b6119dd30715cf99aeb9d45f63cbe16e675aacb

issuer: 'https://mgmdev.okta.com/oauth2/default'
claims:
  aud: 0oa1i977nwlyriDNX0h8
  groups:
    - ROAR-SERVICING-ALLTITLES

```
> For group `0x6b6119dd30715cf99aeb9d45f63cbe16e675aacb` , it has jwt metadata for mgm-elv-admin key

---

### **Export Okta Users and Groups**

Fetch users and groups from Okta and save them locally in the same JSON format used for the policy part.

```bash
export ADMIN_TOKEN=""   # Okta admin token

./elv-admin issuer_okta_get https://trial-4547718.okta.com --out ./out.json
```

### **Sync Okta Domain**

Fetch users and groups from Okta, format them into the expected JSON structure, upload the data as a part on the policy object, and update the `oauth_settings` metadata to reference the new part.

```bash
export PRIVATE_KEY="0xxx"   # Policy owner private key
export ADMIN_TOKEN=""       # Okta admin token

./elv-admin issuer_okta_sync iq__44HhFF5VDen3SmZhy2w2oyY4MFHk --okta_domain https://trial-4547718.okta.com
```

**Example output:**

```
Fetching: /api/v1/users
Fetching: /api/v1/groups
write_token created: tqw__HSYhpUpyW9SNucjKbceoTgdJDHSuPt5MoyoPTLxFEQT5eiWGdsV8fNWuQg9n92Bequ9rj3Xn52vxRAFgNJT
existing oauth_settings part: hqpe6nc5ALqtrFSCNehtthQoyoEP6gMbmmrcytuLB7DdDQ2ZwqW
new oauth_settings part: hqpe2sWzZoWKFd4JPJVijCxhmnLc4FwkpcTrfWjJNGWVAQG7EWY
Deleting existing OAuth part hash...
Successfully synced with OAuth
```

OR

with the okta user_group_list provided:

```bash
export PRIVATE_KEY="0xxx"   # Policy owner private key

./elv-admin issuer_okta_sync iq__44HhFF5VDen3SmZhy2w2oyY4MFHk  --user_group_list ./out.json
```



