### PR TITLE
Update group_xxx_oauth cmds to allow array of issuers and claims

### DIFF
--- a/src/ElvFabric.js
+++ b/src/ElvFabric.js
@@ -546,7 +546,7 @@ class ElvFabric {
               aud: '0oaxxx',
               groups: [ 'group-name' ]
           }
-        }`);
+        } or [{issuer,claims}, {issuer,claims}]`);
     }
 
     let parsedOauthConfig;
@@ -559,19 +559,25 @@ class ElvFabric {
       throw new Error("oauthConfig must be valid JSON");
     }
 
-    const {issuer, claims} = parsedOauthConfig;
-    if (!issuer || typeof issuer !== "string") {
-      throw new Error("oauthConfig.issuer must be set");
-    }
-    if (!claims || typeof claims !== "object") {
-      throw new Error("oauthConfig.claims must be an object");
-    }
-    if (!claims.aud || typeof claims.aud !== "string") {
-      throw new Error("oauthConfig.claims.aud must be set");
-    }
-    if (!claims.groups || !Array.isArray(claims.groups) || claims.groups.length === 0){
-      throw new Error("oauthConfig.claims.groups must be set with array of groups");
-    }
+    let configs = Array.isArray(parsedOauthConfig)? parsedOauthConfig:[parsedOauthConfig];
+
+    configs.forEach((config, index) => {
+      const {issuer, claims} = config;
+      if (!issuer || typeof issuer !== "string") {
+        throw new Error(`oauthConfig[${index}].issuer must be set`);
+      }
+      if (!claims || typeof claims !== "object") {
+        throw new Error(`oauthConfig[${index}].claims must be an object`);
+      }
+      if (!claims.aud || typeof claims.aud !== "string") {
+        throw new Error(`oauthConfig[${index}].claims.aud must be set`);
+      }
+      if (!claims.groups || !Array.isArray(claims.groups) || claims.groups.length === 0){
+        throw new Error(`oauthConfig[${index}].claims.groups must be set with array of groups`);
+      }
+
+    });
+
 
     if (group.startsWith("igrp")){
       group = this.client.utils.HashToAddress(group);


### PR DESCRIPTION
### To encrypt:
```
./elv-admin group_encrypt_oauth 0x78cf8a8673d28eecbedd71b5a03454d2ad29719e '[{"issuer":"https://trial-4547718.okta.com/oauth2/default","claims":{"aud":"0oa11yn318qTrZ8KF698","groups":["editor access"]}},{"issuer":"https://cognito-idp.us-west-1.amazonaws.com/us-west-1_8PGDyw7fe","claims":{"aud":"6mb8fpsepk6ta1mb6ecb4n4ptr","groups":["editor_access"]}}]'

Successfully set oauthConfig on 0x78cf8a8673d28eecbedd71b5a03454d2ad29719e
```


### To decrypt:
```
./elv-admin group_decrypt_oauth 0x78cf8a8673d28eecbedd71b5a03454d2ad29719e
- issuer: 'https://trial-4547718.okta.com/oauth2/default'
  claims:
    aud: 0oa11yn318qTrZ8KF698
    groups:
      - editor access
- issuer: 'https://cognito-idp.us-west-1.amazonaws.com/us-west-1_8PGDyw7fe'
  claims:
    aud: 6mb8fpsepk6ta1mb6ecb4n4ptr
    groups:
      - editor_access

```