### PR TITLE
Live to VOD - preserve offerings entry/exit points

### DIFF
--- a/src/ElvTenant.js
+++ b/src/ElvTenant.js
@@ -152,7 +152,7 @@ class ElvTenant {
 
     const groups = await this.client.ListAccessGroups();
     for (const g of groups) {
-      tenant.groups.push({id: g.id, name: g.meta.public.name});
+      tenant.groups.push({id: g.id, name: g.meta.public?.name});
     }
 
     tenant.libs = await this.client.ContentLibraries();

--- a/src/LiveStream.js
+++ b/src/LiveStream.js
@@ -467,6 +467,28 @@ class EluvioLiveStream {
       targetLibraryId = await this.client.ContentObjectLibraryId({objectId: object});
     }
 
+    // If updating an existing object, capture entry/exit rat from existing
+    // offerings so we can restore them after live-to-vod overwrites them.
+    let preservedOfferingPoints = {};
+    if (object && targetWriteToken == undefined) {
+      for (const offeringKey of ["default", "default_dash"]) {
+        const existing = await this.client.ContentObjectMetadata({
+          libraryId: targetLibraryId,
+          objectId: object,
+          metadataSubtree: `offerings/${offeringKey}`
+        });
+        if (existing && (existing.entry_point_rat || existing.exit_point_rat)) {
+          preservedOfferingPoints[offeringKey] = {
+            entry_point_rat: existing.entry_point_rat,
+            exit_point_rat: existing.exit_point_rat
+          };
+          console.log(
+            `Preserving offerings/${offeringKey} entry_point_rat=${existing.entry_point_rat} exit_point_rat=${existing.exit_point_rat}`
+          );
+        }
+      }
+    }
+
     console.log("Copying stream", stream, "object", object, "drm", drm);
 
     // Validation - require target object
@@ -599,6 +621,36 @@ class EluvioLiveStream {
         constant: false,
         format: "text"
       });
+
+      // Restore previously captured entry/exit rat values onto the offerings
+      for (const [offeringKey, points] of Object.entries(preservedOfferingPoints)) {
+        const offering = await this.client.ContentObjectMetadata({
+          libraryId: targetLibraryId,
+          objectId: object,
+          writeToken: targetWriteToken,
+          metadataSubtree: `offerings/${offeringKey}`
+        });
+        if (!offering) {
+          console.log(`Skipping restore for offerings/${offeringKey} (not present after copy)`);
+          continue;
+        }
+        if (points.entry_point_rat !== undefined) {
+          offering.entry_point_rat = points.entry_point_rat;
+        }
+        if (points.exit_point_rat !== undefined) {
+          offering.exit_point_rat = points.exit_point_rat;
+        }
+        await this.client.ReplaceMetadata({
+          libraryId: targetLibraryId,
+          objectId: object,
+          writeToken: targetWriteToken,
+          metadataSubtree: `offerings/${offeringKey}`,
+          metadata: offering
+        });
+        console.log(
+          `Restored offerings/${offeringKey} entry_point_rat=${points.entry_point_rat} exit_point_rat=${points.exit_point_rat}`
+        );
+      }
 
       let finalize = true;
       if (finalize) {


### PR DESCRIPTION
When updating an existing live to VOD object, preserve entry/exit points for 'default' and optionally 'default_dash' offerings