### PR TITLE
fix `elv-stream status` command

### DIFF
--- a/src/LiveStream.js
+++ b/src/LiveStream.js
@@ -88,15 +88,15 @@ class EluvioLiveStream {
    * running         - stream is running and producing output
    * stalled         - LRO running but no source data (so not producing output)
    */
-  async Status({name, stopLro = false, showParams = false, saveMeta = true}) {
-
+  async Status({ name, stopLro = false, showParams = false, saveMeta = true }) {
     let status = await this.client.StreamStatus({name, stopLro, showParams});
+
 
     if (saveMeta) {
       let edgeMeta = await this.client.ContentObjectMetadata({
-        libraryId: status.library_id,
-        objectId: status.object_id,
-        writeToken: status.edge_write_token
+        libraryId: status.libraryId,
+        objectId: status.objectId,
+        writeToken: status.edgeWriteToken
       });
       fs.writeFileSync("meta-" + status.name + ".json", JSON.stringify(edgeMeta, null, 2));
     }

--- a/src/LiveStream.js
+++ b/src/LiveStream.js
@@ -91,7 +91,6 @@ class EluvioLiveStream {
   async Status({ name, stopLro = false, showParams = false, saveMeta = true }) {
     let status = await this.client.StreamStatus({name, stopLro, showParams});
 
-
     if (saveMeta) {
       let edgeMeta = await this.client.ContentObjectMetadata({
         libraryId: status.libraryId,


### PR DESCRIPTION
The latest API uses camel case for livestream status results. Because of this change `elv-stream status` would fail because it was looking for values in snake case. Most of the other commands depended on the function of status as well so they failed. Tested that the following commands are working now

 - stats
 - copy_as_vod
 - download 
 - reset
 - stop
 - start
 - terminate
 - start_recording
 - config