### PR TITLE
Add nft_set_policy_permissions_batch - uses async transaction submission

### DIFF
--- a/src/EluvioLive.js
+++ b/src/EluvioLive.js
@@ -1924,6 +1924,133 @@ class EluvioLive {
   }
 
   /**
+   * Batch version of NftSetPolicyAndPermissions.
+   *
+   * Sets the same policy and permissions to a list of objects.
+   * Objects are processed in batches: within a batch all transactions are submitted sequentially (noce safety)
+   *
+   * @namedParams
+   * @param {string[]} objectIds - The NFT object IDs (iq__... or hex address)
+   * @param {string} policyPath - Path to the policy file (eg. nft_owner_minter.yaml). Note that the policy must contain the minter address
+   * @param {string[]} addresses - Array of addresses to set the policy permissions
+   * @param {boolean} [clearAddresses=false] - Clear existing permissions by writing an empty address list before applying the new ones
+   * @returns {object} { succeeded: string[], failed: {objectId, error}[] }
+   */
+  async NftSetPolicyAndPermissionsBatch({ objectIds, policyPath, addresses=[], clearAddresses=false }) {
+
+    const BATCH_SIZE = 100;
+
+    let elvFabric = new ElvFabric({
+      configUrl: this.configUrl,
+      debugLogging: this.debug
+    });
+
+    await elvFabric.Init({
+      privateKey: process.env.PRIVATE_KEY
+    });
+
+    // Prepare the policy once (shared across all objects)
+    const policyString = fs.readFileSync(
+      policyPath
+    ).toString();
+
+    if (!policyString){
+      throw Error("Policy file contents is empty.");
+    }
+
+    if (this.debug){
+      console.log("Policy file contents: ", policyString);
+    }
+
+    let account = new ElvAccount({configUrl:this.configUrl, debugLogging: this.debug});
+    account.InitWithClient({elvClient: this.client});
+
+    let policyFormat = await ElvUtils.parseAndSignPolicy({policyString, configUrl:this.configUrl, elvAccount:account});
+
+    if (this.debug){
+      console.log("Policy Value To Set: ", policyFormat);
+    }
+
+    const policyValue = JSON.stringify(policyFormat);
+
+    // Prepare the permission addresses once (shared across all objects)
+    if (clearAddresses){
+      addresses = [];
+    }
+
+    for (const address of addresses){
+      if (!ethers.utils.isAddress(address)){
+        throw Error(`"${address}" is not a valid ethereum address.`);
+      }
+    }
+
+    // _NFT_ACCESS is only written when clearing or when addresses were provided,
+    const setAccess = clearAddresses || addresses.length > 0;
+    const addressesString = JSON.stringify(addresses);
+
+    const succeeded = [];
+    const failed = [];
+
+    for (let i = 0; i < objectIds.length; i += BATCH_SIZE) {
+      const batch = objectIds.slice(i, i + BATCH_SIZE);
+      console.log(`Processing batch ${Math.floor(i / BATCH_SIZE) + 1} (${batch.length} objects)...`);
+
+      // Submit every transaction for this batch sequentially (nonce safety)
+      const pending = [];
+      for (const objectId of batch) {
+        try {
+          // Policy can only be set by object owner
+          const objectOwner = await this.client.authClient.Owner({id: objectId});
+          if (objectOwner.toLowerCase() != this.client.signer.address.toLowerCase()) {
+            throw Error("Policy must be set by object owner " + objectOwner);
+          }
+
+          const txs = [];
+          txs.push(await elvFabric.SetContractMetaAsync({
+            address: objectId,
+            key: "_ELV",
+            value: policyValue
+          }));
+
+          if (setAccess) {
+            txs.push(await elvFabric.SetContractMetaAsync({
+              address: objectId,
+              key: "_NFT_ACCESS",
+              value: addressesString
+            }));
+          }
+
+          pending.push({ objectId, txs });
+        } catch (e) {
+          console.error(`Failed to submit transactions for ${objectId}:`, this.debug ? e : (e.message || e));
+          failed.push({ objectId, error: e.message || e });
+        }
+      }
+
+      // Wait for all transactions in this batch
+      await Promise.all(pending.map(async ({ objectId, txs }) => {
+        try {
+          const receipts = await Promise.all(txs.map(tx => tx.wait()));
+          for (const receipt of receipts) {
+            if (!ElvUtils.isTransactionSuccess(receipt)) {
+              throw receipt;
+            }
+          }
+          succeeded.push(objectId);
+          if (this.debug) {
+            console.log(`Object ${objectId} done.`);
+          }
+        } catch (e) {
+          console.error(`Failed to confirm transactions for ${objectId}:`, this.debug ? e : (e.message || e));
+          failed.push({ objectId, error: e.message || e });
+        }
+      }));
+    }
+
+    return { succeeded, failed };
+  }
+
+  /**
    * Gets the nft policy and permissions for a given contract
    *
    * @namedParams

--- a/src/ElvFabric.js
+++ b/src/ElvFabric.js
@@ -410,6 +410,38 @@ class ElvFabric {
   }
 
   /**
+   * SetContractMetaAsync - async version of client SetContractMeta()
+   * Submits the putMeta transaction WITHOUT waiting for completionand
+   * returns the ethers transaction response so the caller can wait on it
+   *
+   * @param {string} address  contract address
+   * @param {string} key  metadata key
+   * @param {string} value metadata value
+   * @returns {object} ethers transaction response - caller can call .wait()
+   */
+  async SetContractMetaAsync({address, key, value}) {
+    const abi = fs.readFileSync(
+      path.resolve(__dirname, "../contracts/v3/BaseContent.abi")
+    );
+
+    if (address.startsWith("iq")){
+      address = this.client.utils.HashToAddress(address);
+    }
+
+    if (this.debug){
+      console.log("Address", address);
+    }
+
+    return await this.client.CallContractMethod({
+      contractAddress: address,
+      abi: JSON.parse(abi),
+      methodName: "putMeta",
+      methodArgs: [key, value],
+      formatArguments: true,
+    });
+  }
+
+  /**
    * AccessGroupMemeber
    * Check if an address is a member of the access group
    * @param {string} group  Group ID (hex or igrp format)

--- a/utilities/EluvioLiveCli.js
+++ b/utilities/EluvioLiveCli.js
@@ -1511,6 +1511,42 @@ const CmdNFTSetPolicyPermissions = async ({ argv }) => {
   }
 };
 
+const CmdNFTSetPolicyPermissionsBatch = async ({ argv }) => {
+  console.log("NFT Set Policy and Permissions (batch)");
+  console.log(`Object list file: ${argv.object_list}`);
+  console.log(`Policy file path: ${argv.policy_path}`);
+  console.log(`Addresses: ${argv.addrs}`);
+  console.log(`verbose: ${argv.verbose}`);
+  console.log(`clear: ${argv.clear}`);
+
+  try {
+    await Init({ debugLogging: argv.verbose, asUrl: argv.as_url });
+
+    const objectIds = fs
+      .readFileSync(argv.object_list, "utf8")
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter(Boolean);
+
+    console.log(`Loaded ${objectIds.length} object IDs`);
+
+    const res = await elvlv.NftSetPolicyAndPermissionsBatch({
+      objectIds,
+      policyPath: argv.policy_path,
+      addresses: argv.addrs,
+      clearAddresses: argv.clear
+    });
+
+    console.log(`Done. Succeeded: ${res.succeeded.length}, Failed: ${res.failed.length}`);
+    if (res.failed.length > 0) {
+      console.log("Failed objects:");
+      res.failed.forEach((f) => console.log(`  ${f.objectId}: ${f.error}`));
+    }
+  } catch (e) {
+    console.error("ERROR:", argv.verbose ? e : e.message);
+  }
+};
+
 const CmdTenantGetMinter = async ({ argv }) => {
   console.log("Tenant Minter Get Config");
   console.log(`TenantId: ${argv.tenant}`);
@@ -2690,6 +2726,35 @@ yargs(hideBin(process.argv))
     },
     (argv) => {
       CmdNFTSetPolicyPermissions({ argv });
+    }
+  )
+
+  .command(
+    "nft_set_policy_permissions_batch <object_list> <policy_path> [addrs..]",
+    "Batch version of nft_set_policy_permissions. Reads content object IDs from file and sets the specified policy and permissions.",
+    (yargs) => {
+      yargs
+        .positional("object_list", {
+          describe: "Path to a file with one content object ID per line",
+          type: "string",
+        })
+        .positional("policy_path", {
+          describe: "Path of policy object file",
+          type: "string",
+        })
+        .positional("addrs", {
+          describe:
+            "List of space separated NFT contract addresses to set. Calling multiple times with a new list will replace the existing.",
+          type: "string",
+        })
+        .option("clear", {
+          describe: "clear the nft owners",
+          type: "boolean",
+          default: false
+        });
+    },
+    (argv) => {
+      CmdNFTSetPolicyPermissionsBatch({ argv });
     }
   )
 


### PR DESCRIPTION
Add `nft_set_policy_permissions_batch ` - a batch option for `nft_set_policy_permissions`

Optimized for larger object lists (1000+), it submits all transactions asynchronously in batches of 100 (currently).

Example usage:

```
./elv-live nft_set_policy_permissions_batch mylist ./common_policies/nft_owner.yaml 0xb39674b7673adddf82c7e7650f5484e8752d31d2 0xb40239af0daeab1338610db3dd477fb620573df8
```

Where file `mylist`:
```
iq__1E9mgPTpC1SDS9XZy37F9CWkGxr
iq__1FwZhdyeAaMG71yeGuo8QzSxBw6
...
```